### PR TITLE
[PR #69] Update resend from ^6.12.0 to ^6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "react-dom": "^19.2.5",
                 "react-icons": "^5.6.0",
                 "react-international-phone": "^4.8.0",
-                "resend": "^6.12.0",
+                "resend": "^6.16.0",
                 "tailwind-merge": "^3.5.0",
                 "web-vitals": "^5.2.0"
             },
@@ -21666,9 +21666,9 @@
             "license": "ISC"
         },
         "node_modules/resend": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
-            "integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/resend/-/resend-6.16.0.tgz",
+            "integrity": "sha512-SaKISwHtxvAxneF84Njgnzg+zdngUu1vOT/paRU1De9QF+zXQR3GnwJHSh+mpJPjUhsGD4WxYi5CfKkXMkDqwg==",
             "license": "MIT",
             "dependencies": {
                 "postal-mime": "2.7.4",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
         "react-dom": "^19.2.5",
         "react-icons": "^5.6.0",
         "react-international-phone": "^4.8.0",
-        "resend": "^6.12.0",
+        "resend": "^6.16.0",
         "tailwind-merge": "^3.5.0",
         "web-vitals": "^5.2.0"
     },


### PR DESCRIPTION
Closes #69

Updates the resend package to the latest compatible version within the ^6.12.0 range.

## Changes
- Updated package.json: resend ^6.12.0 → ^6.16.0
- Updated package-lock.json to reflect the change

## Verification
✅ Type-check passes
✅ Build completes successfully
✅ No code changes required (additive type changes only)