### PR TITLE
test: add comprehensive tests for Services landing page

### DIFF
--- a/src/app/[locale]/services/__tests__/ServicesSubmenu.test.tsx
+++ b/src/app/[locale]/services/__tests__/ServicesSubmenu.test.tsx
@@ -1,0 +1,180 @@
+import ServicesSubmenu from "@/app/[locale]/services/services-submenu"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+// Mock next-intl to provide specific translation values for services
+vi.mock("next-intl", () => ({
+    useTranslations: (namespace: string) => {
+        const translations: Record<string, Record<string, string>> = {
+            services: {
+                "landing.channelManagementTitle": "ViraTrend",
+                "landing.channelManagementDescription":
+                    "Social media management and content strategy",
+                "landing.pcOptimizationTitle": "PC Optimization",
+                "landing.pcOptimizationDescription":
+                    "Performance tuning and system optimization",
+                "landing.affiliateTitle": "Amazon Affiliate",
+                "landing.affiliateDescription":
+                    "Affiliate marketing strategies",
+                "landing.iqTestTitle": "IQ Test",
+                "landing.iqTestDescription":
+                    "Cognitive assessment platform",
+                "landing.personalityTestTitle": "Personality Test",
+                "landing.personalityTestDescription":
+                    "Psychological profiling tools",
+            },
+        }
+
+        const nsTranslations = translations[namespace] ?? {}
+
+        return (key: string) => {
+            return nsTranslations[key] ?? key
+        }
+    },
+    useLocale: () => "en",
+    useMessages: () => ({}),
+    useFormatter: () => ({
+        dateTime: (date: Date) => date.toISOString(),
+        number: (num: number) => num.toString(),
+    }),
+    NextIntlClientProvider: ({ children }: { children: React.ReactNode }) =>
+        children,
+}))
+
+describe("ServicesSubmenu", () => {
+    const categories = [
+        { key: "channel-management", title: "ViraTrend" },
+        { key: "pc-optimization", title: "PC Optimization" },
+        { key: "amazon-affiliate", title: "Amazon Affiliate" },
+        { key: "iq-test", title: "IQ Test" },
+        { key: "personality-test", title: "Personality Test" },
+    ] as const
+
+    const locales = ["en", "pt-BR", "es", "de"] as const
+
+    it.each(locales)(
+        "renders all 5 service categories for locale '%s'",
+        locale => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            // Check that all category labels are rendered
+            for (const category of categories) {
+                expect(
+                    screen.getByText(category.title)
+                ).toBeInTheDocument()
+            }
+        }
+    )
+
+    it.each(locales)(
+        "renders 5 links for locale '%s'",
+        locale => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            expect(links).toHaveLength(5)
+        }
+    )
+
+    it.each([
+        { locale: "en" as const, expected: "/en/channel-management" },
+        { locale: "pt-BR" as const, expected: "/pt-BR/gerenciamento-de-canais" },
+        { locale: "es" as const, expected: "/es/gestion-de-canales" },
+        { locale: "de" as const, expected: "/de/kanalverwaltung" },
+    ])(
+        "localizes channel-management link for '$locale'",
+        ({ locale, expected }) => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            const channelLink = links.find(
+                link =>
+                    link.getAttribute("href") === expected
+            )
+            expect(channelLink).toBeTruthy()
+            expect(channelLink).toHaveAttribute("href", expected)
+        }
+    )
+
+    it.each([
+        { locale: "en" as const, expected: "/en/pc-optimization" },
+        { locale: "pt-BR" as const, expected: "/pt-BR/otimizacao-de-pc" },
+        { locale: "es" as const, expected: "/es/optimizacion-de-pc" },
+        { locale: "de" as const, expected: "/de/pc-optimierung" },
+    ])(
+        "localizes pc-optimization link for '$locale'",
+        ({ locale, expected }) => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            const link = links.find(
+                l => l.getAttribute("href") === expected
+            )
+            expect(link).toBeTruthy()
+            expect(link).toHaveAttribute("href", expected)
+        }
+    )
+
+    it.each([
+        { locale: "en" as const, expected: "/en/amazon-affiliate" },
+        { locale: "pt-BR" as const, expected: "/pt-BR/afiliados-amazon" },
+        { locale: "es" as const, expected: "/es/afiliados-amazon" },
+        { locale: "de" as const, expected: "/de/amazon-partner" },
+    ])(
+        "localizes amazon-affiliate link for '$locale'",
+        ({ locale, expected }) => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            const link = links.find(
+                l => l.getAttribute("href") === expected
+            )
+            expect(link).toBeTruthy()
+            expect(link).toHaveAttribute("href", expected)
+        }
+    )
+
+    it.each([
+        { locale: "en" as const, expected: "/en/iq-test" },
+        { locale: "pt-BR" as const, expected: "/pt-BR/teste-de-qi" },
+        { locale: "es" as const, expected: "/es/prueba-de-ci" },
+        { locale: "de" as const, expected: "/de/iq-test" },
+    ])(
+        "localizes iq-test link for '$locale'",
+        ({ locale, expected }) => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            const link = links.find(
+                l => l.getAttribute("href") === expected
+            )
+            expect(link).toBeTruthy()
+            expect(link).toHaveAttribute("href", expected)
+        }
+    )
+
+    it.each([
+        { locale: "en" as const, expected: "/en/personality-test" },
+        {
+            locale: "pt-BR" as const,
+            expected: "/pt-BR/teste-de-personalidade",
+        },
+        {
+            locale: "es" as const,
+            expected: "/es/prueba-de-personalidad",
+        },
+        { locale: "de" as const, expected: "/de/personlichkeitstest" },
+    ])(
+        "localizes personality-test link for '$locale'",
+        ({ locale, expected }) => {
+            render(<ServicesSubmenu locale={locale} />)
+
+            const links = screen.getAllByRole("link")
+            const link = links.find(
+                l => l.getAttribute("href") === expected
+            )
+            expect(link).toBeTruthy()
+            expect(link).toHaveAttribute("href", expected)
+        }
+    )
+})

--- a/src/app/[locale]/services/__tests__/metadata.test.ts
+++ b/src/app/[locale]/services/__tests__/metadata.test.ts
@@ -1,0 +1,116 @@
+import { generateMetadata } from "@/app/[locale]/services/page"
+import { describe, expect, it, vi } from "vitest"
+
+// Mock next-intl/server for generateMetadata
+vi.mock("next-intl/server", () => ({
+    getTranslations: async ({
+        locale,
+        namespace,
+    }: {
+        locale: string
+        namespace: string
+    }) => {
+        const translations: Record<
+            string,
+            Record<string, string>
+        > = {
+            en: {
+                "landing.title": "Services",
+                "landing.description":
+                    "From channel management to custom development, I offer a range of services to help you grow your online presence and achieve your goals.",
+            },
+            "pt-BR": {
+                "landing.title": "Serviços",
+                "landing.description":
+                    "Do gerenciamento de canais ao desenvolvimento personalizado, ofereço uma gama de serviços para ajudar você a crescer sua presença online e alcançar seus objetivos.",
+            },
+            es: {
+                "landing.title": "Servicios",
+                "landing.description":
+                    "Desde la gestión de canales hasta el desarrollo personalizado, ofrezco una gama de servicios para ayudarte a crecer tu presencia online y alcanzar tus objetivos.",
+            },
+            de: {
+                "landing.title": "Dienstleistungen",
+                "landing.description":
+                    "Von der Kanalverwaltung bis zur individuellen Entwicklung biete ich eine Reihe von Dienstleistungen an, die Ihnen helfen, Ihre Online-Präsenz auszubauen und Ihre Ziele zu erreichen.",
+            },
+        }
+
+        const nsTranslations = translations[locale] ?? {}
+
+        return (key: string) => {
+            const fullKey = `${namespace}.${key}`
+            // Strip the "services." prefix since the returned function
+            // already scopes to the namespace
+            return nsTranslations[key] ?? fullKey
+        }
+    },
+}))
+
+describe("generateMetadata", () => {
+    it.each([
+        {
+            locale: "en" as const,
+            expectedTitle: "Services - Gabriel Toth",
+            expectedDescription:
+                "From channel management to custom development, I offer a range of services to help you grow your online presence and achieve your goals.",
+        },
+        {
+            locale: "pt-BR" as const,
+            expectedTitle: "Serviços - Gabriel Toth",
+            expectedDescription:
+                "Do gerenciamento de canais ao desenvolvimento personalizado, ofereço uma gama de serviços para ajudar você a crescer sua presença online e alcançar seus objetivos.",
+        },
+        {
+            locale: "es" as const,
+            expectedTitle: "Servicios - Gabriel Toth",
+            expectedDescription:
+                "Desde la gestión de canales hasta el desarrollo personalizado, ofrezco una gama de servicios para ayudarte a crecer tu presencia online y alcanzar tus objetivos.",
+        },
+        {
+            locale: "de" as const,
+            expectedTitle: "Dienstleistungen - Gabriel Toth",
+            expectedDescription:
+                "Von der Kanalverwaltung bis zur individuellen Entwicklung biete ich eine Reihe von Dienstleistungen an, die Ihnen helfen, Ihre Online-Präsenz auszubauen und Ihre Ziele zu erreichen.",
+        },
+    ])(
+        "returns correct title and description for locale '$locale'",
+        async ({ locale, expectedTitle, expectedDescription }) => {
+            const params = Promise.resolve({ locale })
+            const metadata = await generateMetadata({ params })
+
+            expect(metadata.title).toBe(expectedTitle)
+            expect(metadata.description).toBe(expectedDescription)
+        }
+    )
+
+    it("includes keywords", async () => {
+        const params = Promise.resolve({ locale: "en" as const })
+        const metadata = await generateMetadata({ params })
+
+        expect(metadata.keywords).toBeDefined()
+        expect(Array.isArray(metadata.keywords)).toBe(true)
+        expect(metadata.keywords).toContain("services")
+        expect(metadata.keywords).toContain("channel management")
+        expect(metadata.keywords).toContain("pc optimization")
+    })
+
+    it("includes openGraph data", async () => {
+        const params = Promise.resolve({ locale: "en" as const })
+        const metadata = await generateMetadata({ params })
+
+        expect(metadata.openGraph).toBeDefined()
+        expect(metadata.openGraph?.title).toBe("Services")
+        expect(metadata.openGraph?.description).toBe(
+            "From channel management to custom development, I offer a range of services to help you grow your online presence and achieve your goals."
+        )
+        expect(metadata.openGraph?.type).toBe("website")
+    })
+
+    it("sets locale-specific openGraph locale", async () => {
+        const params = Promise.resolve({ locale: "pt-BR" as const })
+        const metadata = await generateMetadata({ params })
+
+        expect(metadata.openGraph?.locale).toBe("pt-BR")
+    })
+})


### PR DESCRIPTION
Closes #70

## Summary
Add comprehensive unit and metadata tests for the Services landing page. Covers the ServicesSubmenu component (5 categories x 4 locales) and the generateMetadata function.

## Risk Assessment
**Risk Level:** LOW
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- \ServicesSubmenu.test.tsx\ — 28 test cases covering all 5 service categories for all 4 locales (en, pt-BR, es, de)
- \metadata.test.ts\ — 7 test cases for generateMetadata (title, description, keywords, openGraph)

## Testing
- [x] 35 tests pass (28 submenu + 7 metadata)
- [x] TypeScript compiles

Closes #70

_Generated by engineering-loop | Cost-free: ✅_