### PR TITLE
[DRAFT] fix(oauth): replace x-user-id header with server session cookie in authorize routes

### DIFF
--- a/src/__tests__/security/facebook-authorize.security.test.ts
+++ b/src/__tests__/security/facebook-authorize.security.test.ts
@@ -27,6 +27,7 @@
  *   21 (timing side-channel) — all paths return JSON errors
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { POST } from "@/app/api/oauth/authorize/facebook/route"
 import { NextRequest } from "next/server"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -81,6 +82,10 @@ vi.mock("@/lib/logger", () => ({
     }),
 }))
 
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: vi.fn(),
+}))
+
 function makePostRequest(
     url: string,
     body: unknown,
@@ -100,6 +105,7 @@ function makePostRequest(
 describe("POST /api/oauth/authorize/facebook — Attack Matrix", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(getServerSession).mockResolvedValue({ user: { id: "test-user-123" } })
     })
 
     afterEach(() => {
@@ -107,7 +113,8 @@ describe("POST /api/oauth/authorize/facebook — Attack Matrix", () => {
     })
 
     describe("Row 1 — Auth bypass", () => {
-        it("should reject request without x-user-id header", async () => {
+        it("should reject request without session cookie", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/facebook",
                 {
@@ -117,24 +124,26 @@ describe("POST /api/oauth/authorize/facebook — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
-        it("should reject request with empty x-user-id", async () => {
+        it("should reject request with invalid session", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = makePostRequest(
                 "http://localhost/api/oauth/authorize/facebook",
                 {},
                 { "x-user-id": "" }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
         it("should reject request without any auth headers", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/facebook",
                 {
@@ -144,7 +153,7 @@ describe("POST /api/oauth/authorize/facebook — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
         })
     })
 
@@ -319,17 +328,21 @@ describe("POST /api/oauth/authorize/facebook — Attack Matrix", () => {
 
     describe("Row 15 — Info disclosure", () => {
         it("should not leak internal paths in error response", async () => {
-            const request = makePostRequest(
+            vi.mocked(getServerSession).mockResolvedValue(null)
+            const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/facebook",
-                {},
-                { "x-user-id": "" }
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({}),
+                }
             )
             const response = await POST(request)
             const body = await response.json()
-            expect(body.message).not.toContain(":\\")
-            expect(body.message).not.toContain("/src/")
-            expect(body.message).not.toContain("at ")
-            expect(body.message).not.toContain("stack")
+            expect(body.error).not.toContain(":\\")
+            expect(body.error).not.toContain("/src/")
+            expect(body.error).not.toContain("at ")
+            expect(body.error).not.toContain("stack")
         })
     })
 

--- a/src/__tests__/security/instagram-authorize.security.test.ts
+++ b/src/__tests__/security/instagram-authorize.security.test.ts
@@ -27,6 +27,7 @@
  *   21 (timing side-channel) — all paths return JSON errors
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { POST } from "@/app/api/oauth/authorize/instagram/route"
 import { NextRequest } from "next/server"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -77,6 +78,10 @@ vi.mock("@/lib/logger", () => ({
     }),
 }))
 
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: vi.fn(),
+}))
+
 function makePostRequest(
     url: string,
     body: unknown,
@@ -96,6 +101,7 @@ function makePostRequest(
 describe("POST /api/oauth/authorize/instagram — Attack Matrix", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(getServerSession).mockResolvedValue({ user: { id: "test-user-123" } })
     })
 
     afterEach(() => {
@@ -104,7 +110,8 @@ describe("POST /api/oauth/authorize/instagram — Attack Matrix", () => {
 
     // ── Row 1: Auth bypass ──
     describe("Row 1 — Auth bypass", () => {
-        it("should reject request without x-user-id header", async () => {
+        it("should reject request without session cookie", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/instagram",
                 {
@@ -114,24 +121,26 @@ describe("POST /api/oauth/authorize/instagram — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
-        it("should reject request with empty x-user-id", async () => {
+        it("should reject request with invalid session", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = makePostRequest(
                 "http://localhost/api/oauth/authorize/instagram",
                 {},
                 { "x-user-id": "" }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
         it("should reject request without any auth headers", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/instagram",
                 {
@@ -141,7 +150,7 @@ describe("POST /api/oauth/authorize/instagram — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
         })
     })
 
@@ -323,17 +332,21 @@ describe("POST /api/oauth/authorize/instagram — Attack Matrix", () => {
     // ── Row 15: Info disclosure ──
     describe("Row 15 — Info disclosure", () => {
         it("should not leak internal paths in error response", async () => {
-            const request = makePostRequest(
+            vi.mocked(getServerSession).mockResolvedValue(null)
+            const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/instagram",
-                {},
-                { "x-user-id": "" }
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({}),
+                }
             )
             const response = await POST(request)
             const body = await response.json()
-            expect(body.message).not.toContain(":\\")
-            expect(body.message).not.toContain("/src/")
-            expect(body.message).not.toContain("at ")
-            expect(body.message).not.toContain("stack")
+            expect(body.error).not.toContain(":\\")
+            expect(body.error).not.toContain("/src/")
+            expect(body.error).not.toContain("at ")
+            expect(body.error).not.toContain("stack")
         })
     })
 

--- a/src/__tests__/security/kick-authorize.security.test.ts
+++ b/src/__tests__/security/kick-authorize.security.test.ts
@@ -27,6 +27,7 @@
  *   21 (timing side-channel) — all paths return JSON errors
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { POST } from "@/app/api/oauth/authorize/kick/route"
 import { NextRequest } from "next/server"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -74,6 +75,10 @@ vi.mock("@/lib/logger", () => ({
     }),
 }))
 
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: vi.fn(),
+}))
+
 function makePostRequest(
     url: string,
     body: unknown,
@@ -93,6 +98,7 @@ function makePostRequest(
 describe("POST /api/oauth/authorize/kick — Attack Matrix", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(getServerSession).mockResolvedValue({ user: { id: "test-user-123" } })
     })
 
     afterEach(() => {
@@ -101,7 +107,8 @@ describe("POST /api/oauth/authorize/kick — Attack Matrix", () => {
 
     // ── Row 1: Auth bypass ──
     describe("Row 1 — Auth bypass", () => {
-        it("should reject request without x-user-id header", async () => {
+        it("should reject request without session cookie", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/kick",
                 {
@@ -111,24 +118,26 @@ describe("POST /api/oauth/authorize/kick — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
-        it("should reject request with empty x-user-id", async () => {
+        it("should reject request with invalid session", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = makePostRequest(
                 "http://localhost/api/oauth/authorize/kick",
                 {},
                 { "x-user-id": "" }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
         it("should reject request without any auth headers", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/kick",
                 {
@@ -138,7 +147,7 @@ describe("POST /api/oauth/authorize/kick — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
         })
     })
 
@@ -314,17 +323,21 @@ describe("POST /api/oauth/authorize/kick — Attack Matrix", () => {
     // ── Row 15: Info disclosure ──
     describe("Row 15 — Info disclosure", () => {
         it("should not leak internal paths in error response", async () => {
-            const request = makePostRequest(
+            vi.mocked(getServerSession).mockResolvedValue(null)
+            const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/kick",
-                {},
-                { "x-user-id": "" }
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({}),
+                }
             )
             const response = await POST(request)
             const body = await response.json()
-            expect(body.message).not.toContain(":\\")
-            expect(body.message).not.toContain("/src/")
-            expect(body.message).not.toContain("at ")
-            expect(body.message).not.toContain("stack")
+            expect(body.error).not.toContain(":\\")
+            expect(body.error).not.toContain("/src/")
+            expect(body.error).not.toContain("at ")
+            expect(body.error).not.toContain("stack")
         })
     })
 

--- a/src/__tests__/security/tiktok-authorize.security.test.ts
+++ b/src/__tests__/security/tiktok-authorize.security.test.ts
@@ -27,6 +27,7 @@
  *   21 (timing side-channel) — all paths return JSON errors
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { POST } from "@/app/api/oauth/authorize/tiktok/route"
 import { NextRequest } from "next/server"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -88,6 +89,10 @@ vi.mock("@/lib/logger", () => ({
     }),
 }))
 
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: vi.fn(),
+}))
+
 function makePostRequest(
     url: string,
     body: unknown,
@@ -107,6 +112,7 @@ function makePostRequest(
 describe("POST /api/oauth/authorize/tiktok — Attack Matrix", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(getServerSession).mockResolvedValue({ user: { id: "test-user-123" } })
     })
 
     afterEach(() => {
@@ -114,7 +120,8 @@ describe("POST /api/oauth/authorize/tiktok — Attack Matrix", () => {
     })
 
     describe("Row 1 — Auth bypass", () => {
-        it("should reject request without x-user-id header", async () => {
+        it("should reject request without session cookie", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/tiktok",
                 {
@@ -124,24 +131,26 @@ describe("POST /api/oauth/authorize/tiktok — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
-        it("should reject request with empty x-user-id", async () => {
+        it("should reject request with invalid session", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = makePostRequest(
                 "http://localhost/api/oauth/authorize/tiktok",
                 {},
                 { "x-user-id": "" }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
 
         it("should reject request without any auth headers", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
             const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/tiktok",
                 {
@@ -151,9 +160,9 @@ describe("POST /api/oauth/authorize/tiktok — Attack Matrix", () => {
                 }
             )
             const response = await POST(request)
-            expect(response.status).toBe(400)
+            expect(response.status).toBe(401)
             const body = await response.json()
-            expect(body.error).toBe("MISSING_USER_ID")
+            expect(body.error).toBe("UNAUTHORIZED")
         })
     })
 
@@ -317,17 +326,21 @@ describe("POST /api/oauth/authorize/tiktok — Attack Matrix", () => {
 
     describe("Row 15 — Info disclosure", () => {
         it("should not leak internal paths in error response", async () => {
-            const request = makePostRequest(
+            vi.mocked(getServerSession).mockResolvedValue(null)
+            const request = new NextRequest(
                 "http://localhost/api/oauth/authorize/tiktok",
-                {},
-                { "x-user-id": "" }
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({}),
+                }
             )
             const response = await POST(request)
             const body = await response.json()
-            expect(body.message).not.toContain(":\\")
-            expect(body.message).not.toContain("/src/")
-            expect(body.message).not.toContain("at ")
-            expect(body.message).not.toContain("stack")
+            expect(body.error).not.toContain(":\\")
+            expect(body.error).not.toContain("/src/")
+            expect(body.error).not.toContain("at ")
+            expect(body.error).not.toContain("stack")
         })
     })
 

--- a/src/app/api/oauth/authorize/[platform]/route.ts
+++ b/src/app/api/oauth/authorize/[platform]/route.ts
@@ -5,6 +5,7 @@
  * Requirements: 10.1, 10.2, 10.3, 10.5, 10.6, 10.7
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { createLogger } from "@/lib/logger"
 import { getOAuthManager } from "@/lib/oauth"
 import { rateLimitByKey } from "@/lib/rate-limit"
@@ -45,13 +46,14 @@ export async function POST(
         }
 
         // Get user ID from session
-        const userId = request.headers.get("x-user-id")
-        if (!userId) {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
             logger.warn("Unauthorized OAuth authorization attempt", {
                 platform: platform,
             })
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
         }
+        const userId = session.user.id
 
         // Validate platform
         const oauthManager = getOAuthManager()

--- a/src/app/api/oauth/authorize/facebook/route.ts
+++ b/src/app/api/oauth/authorize/facebook/route.ts
@@ -1,3 +1,4 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { createLogger } from "@/lib/logger"
 import { getFacebookConfig } from "@/lib/facebook/config"
 import { getFacebookOAuthService } from "@/lib/facebook/oauth-service"
@@ -8,19 +9,20 @@ const logger = createLogger("FacebookAuthorizeEndpoint")
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
-        const userId = request.headers.get("x-user-id")
+        const session = await getServerSession(request)
 
-        if (!userId) {
-            logger.warn("Missing user ID in request")
+        if (!session?.user?.id) {
+            logger.warn("Unauthorized OAuth authorization attempt", { platform: "facebook" })
             return NextResponse.json(
                 {
                     success: false,
-                    error: "MISSING_USER_ID",
-                    message: "User ID is required",
+                    error: "UNAUTHORIZED",
+                    message: "Authentication required",
                 },
-                { status: 400 }
+                { status: 401 }
             )
         }
+        const userId = session.user.id
 
         logger.info("Facebook linking initiation requested", { userId })
 

--- a/src/app/api/oauth/authorize/instagram/route.ts
+++ b/src/app/api/oauth/authorize/instagram/route.ts
@@ -13,6 +13,7 @@
  * }
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { createLogger } from "@/lib/logger"
 import { getInstagramConfig } from "@/lib/instagram/config"
 import { getInstagramOAuthService } from "@/lib/instagram/oauth-service"
@@ -23,19 +24,20 @@ const logger = createLogger("InstagramAuthorizeEndpoint")
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
-        const userId = request.headers.get("x-user-id")
+        const session = await getServerSession(request)
 
-        if (!userId) {
-            logger.warn("Missing user ID in request")
+        if (!session?.user?.id) {
+            logger.warn("Unauthorized OAuth authorization attempt", { platform: "instagram" })
             return NextResponse.json(
                 {
                     success: false,
-                    error: "MISSING_USER_ID",
-                    message: "User ID is required",
+                    error: "UNAUTHORIZED",
+                    message: "Authentication required",
                 },
-                { status: 400 }
+                { status: 401 }
             )
         }
+        const userId = session.user.id
 
         logger.info("Instagram linking initiation requested", { userId })
 

--- a/src/app/api/oauth/authorize/kick/route.ts
+++ b/src/app/api/oauth/authorize/kick/route.ts
@@ -13,6 +13,7 @@
  * }
  */
 
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { createLogger } from "@/lib/logger"
 import { getKickConfig } from "@/lib/kick/config"
 import { getKickOAuthService } from "@/lib/kick/oauth-service"
@@ -23,19 +24,20 @@ const logger = createLogger("KickAuthorizeEndpoint")
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
-        const userId = request.headers.get("x-user-id")
+        const session = await getServerSession(request)
 
-        if (!userId) {
-            logger.warn("Missing user ID in request")
+        if (!session?.user?.id) {
+            logger.warn("Unauthorized OAuth authorization attempt", { platform: "kick" })
             return NextResponse.json(
                 {
                     success: false,
-                    error: "MISSING_USER_ID",
-                    message: "User ID is required",
+                    error: "UNAUTHORIZED",
+                    message: "Authentication required",
                 },
-                { status: 400 }
+                { status: 401 }
             )
         }
+        const userId = session.user.id
 
         logger.info("Kick linking initiation requested", { userId })
 

--- a/src/app/api/oauth/authorize/tiktok/route.ts
+++ b/src/app/api/oauth/authorize/tiktok/route.ts
@@ -1,3 +1,4 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
 import { createLogger } from "@/lib/logger"
 import { getTikTokConfig } from "@/lib/tiktok/config"
 import { getTikTokOAuthService } from "@/lib/tiktok/oauth-service"
@@ -8,19 +9,20 @@ const logger = createLogger("TikTokAuthorizeEndpoint")
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
-        const userId = request.headers.get("x-user-id")
+        const session = await getServerSession(request)
 
-        if (!userId) {
-            logger.warn("Missing user ID in request")
+        if (!session?.user?.id) {
+            logger.warn("Unauthorized OAuth authorization attempt", { platform: "tiktok" })
             return NextResponse.json(
                 {
                     success: false,
-                    error: "MISSING_USER_ID",
-                    message: "User ID is required",
+                    error: "UNAUTHORIZED",
+                    message: "Authentication required",
                 },
-                { status: 400 }
+                { status: 401 }
             )
         }
+        const userId = session.user.id
 
         logger.info("TikTok linking initiation requested", { userId })
 

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const [connectingChannel, setConnectingChannel] = useState<string | null>(
         null
     )
+    const [connectionError, setConnectionError] = useState<string | null>(null)
 
     const handleChannelConnect = async (channelId: string) => {
         if (connectingChannel) return
@@ -72,8 +73,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 throw new Error("No authorization URL returned")
             }
         } catch (err) {
+            const message = err instanceof Error ? err.message : `Failed to connect ${channelId}`
             logger.error(`Failed to connect ${channelId}`, { error: err })
+            setConnectionError(message)
             setConnectingChannel(null)
+            // Auto-clear error after 5 seconds
+            setTimeout(() => setConnectionError(null), 5000)
         }
     }
 
@@ -141,6 +146,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
                         {t("connectChannels")}
                     </h3>
+                    {connectionError && (
+                        <div className="mb-3 rounded-md bg-red-50 p-2 text-xs text-red-600 dark:bg-red-950 dark:text-red-400">
+                            {connectionError}
+                        </div>
+                    )}
                     <div className="grid grid-cols-3 gap-2">
                         {channels.map(channel => (
                             <button
@@ -260,6 +270,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
                         {t("connectChannels")}
                     </h3>
+                    {connectionError && (
+                        <div className="mb-3 rounded-md bg-red-50 p-2 text-xs text-red-600 dark:bg-red-950 dark:text-red-400">
+                            {connectionError}
+                        </div>
+                    )}
                     <div className="grid grid-cols-3 gap-2">
                         {channels.map(channel => (
                             <button


### PR DESCRIPTION
﻿## Summary
Fix OAuth authorize routes that were failing because the frontend doesn't send the `x-user-id` header. Replaced header-based auth with `getServerSession()` which reads the session cookie — matching how the frontend actually works.

Fixes authentication mismatch where the backend expected `x-user-id` header but the frontend never sent it.

## Risk Assessment
**Risk Level:** CRITICAL (auth-related routes)
**Cost:** ✅ Free (all changes local)

## Changes
- **5 route files** (`[platform]/route.ts`, `facebook/route.ts`, `instagram/route.ts`, `tiktok/route.ts`, `kick/route.ts`): Replaced `request.headers.get("x-user-id")` with `getServerSession(request)` for session-based authentication
- **`Sidebar.tsx`**: Added `connectionError` state with auto-clearing error display for failed OAuth connection attempts (both desktop and mobile views)
- **4 security test files**: Updated mocks to use `getServerSession` and expect 401/UNAUTHORIZED responses instead of 400/MISSING_USER_ID

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (all security tests updated and passing)
- [x] Build passes

Closes #100

_Generated by engineering-loop | Cost-free: ✅_
