### PR TITLE
fix: Google OAuth - cookie sessão 30 dias + 'Manter login' via state

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -32,7 +32,7 @@ const SESSION_COOKIE = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
-    maxAge: 60 * 60, // 1 hour
+    maxAge: 30 * 24 * 60 * 60, // 30 days
     path: "/",
 }
 
@@ -236,11 +236,22 @@ async function handleGoogleCallback(
 }
 
 /**
+ * Parse rememberMe flag from the OAuth state parameter
+ * State format: optionally prefixed with 'r_' for rememberMe=true
+ * Example: "r_abc123" → rememberMe=true, "abc123" → rememberMe=false
+ */
+function parseRememberMeFromState(stateParam: string | null): boolean {
+    if (!stateParam) return false
+    return stateParam.startsWith("r_")
+}
+
+/**
  * GET handler for Google OAuth callback
  * Google redirects here with authorization code in query parameters
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
     const clientIp = getClientIp(request)
+    const userAgent = request.headers.get("user-agent") || undefined
 
     try {
         const code = request.nextUrl.searchParams.get("code")
@@ -264,6 +275,35 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             new URL("/dashboard", request.url)
         )
         setSessionCookie(redirectResponse, result.sessionId)
+
+        // Create remember_me_token if user opted for "Manter login"
+        const stateParam = request.nextUrl.searchParams.get("state")
+        const rememberMe = parseRememberMeFromState(stateParam)
+        if (rememberMe) {
+            try {
+                const rememberMeToken = await createRememberMeToken(
+                    result.userId,
+                    clientIp,
+                    userAgent
+                )
+                redirectResponse.cookies.set(
+                    "remember_me_token",
+                    rememberMeToken.token_hash,
+                    REMEMBER_ME_COOKIE
+                )
+            } catch (error) {
+                logger.warn(
+                    "Failed to create Remember Me token for Google OAuth (GET)",
+                    {
+                        context: "Auth",
+                        error: error as Error,
+                        data: { userId: result.userId },
+                    }
+                )
+                // Don't fail the login if remember me fails
+            }
+        }
+
         return redirectResponse
     } catch (err) {
         logger.error("Google callback GET error", {
@@ -325,11 +365,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
                     REMEMBER_ME_COOKIE
                 )
             } catch (error) {
-                logger.warn("Failed to create Remember Me token for Google OAuth", {
-                    context: "Auth",
-                    error: error as Error,
-                    data: { userId: result.userId },
-                })
+                logger.warn(
+                    "Failed to create Remember Me token for Google OAuth",
+                    {
+                        context: "Auth",
+                        error: error as Error,
+                        data: { userId: result.userId },
+                    }
+                )
                 // Don't fail the login if remember me fails
             }
         }

--- a/src/components/auth/google-login-button.tsx
+++ b/src/components/auth/google-login-button.tsx
@@ -64,7 +64,12 @@ export function GoogleLoginButton({
             }
 
             // Generate state parameter for CSRF protection
-            const state = Math.random().toString(36).substring(7)
+            // Prefix with 'r_' if user opted for "Manter login"
+            const rememberMe =
+                sessionStorage.getItem("oauth_remember_me") === "true"
+            const state =
+                (rememberMe ? "r_" : "") +
+                Math.random().toString(36).substring(7)
             sessionStorage.setItem("oauth_state", state)
 
             // Build Google OAuth authorization URL

--- a/src/components/auth/unified-signin-form.tsx
+++ b/src/components/auth/unified-signin-form.tsx
@@ -163,8 +163,15 @@ export default function UnifiedSignInForm({
                 throw new Error("Google redirect URI not configured")
             }
 
+            // Save rememberMe preference to sessionStorage so it survives
+            // the Google OAuth redirect and is available on callback
+            sessionStorage.setItem("oauth_remember_me", String(rememberMe))
+
             // Generate state parameter for CSRF protection
-            const state = Math.random().toString(36).substring(7)
+            // Prefix with 'r_' if user opted for "Manter login"
+            const state =
+                (rememberMe ? "r_" : "") +
+                Math.random().toString(36).substring(7)
             sessionStorage.setItem("oauth_state", state)
 
             // Build Google OAuth authorization URL
@@ -237,6 +244,20 @@ export default function UnifiedSignInForm({
                             ? t("signin.emailButton")
                             : t("signin.emailSignUpButton")}
                     </button>
+
+                    {/* Remember Me Checkbox */}
+                    <label className="flex items-center gap-2 cursor-pointer justify-center">
+                        <input
+                            type="checkbox"
+                            checked={rememberMe}
+                            onChange={e => setRememberMe(e.target.checked)}
+                            className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                            disabled={isLoading}
+                        />
+                        <span className="text-sm text-gray-600 dark:text-gray-400">
+                            {t("login.rememberMe")}
+                        </span>
+                    </label>
 
                     {/* Create Account Link */}
                     <div className="mt-6 pt-6 border-t border-gray-300 dark:border-gray-600 text-center">


### PR DESCRIPTION
## Mudanças
### Cookie de sessão
- SESSION_COOKIE.maxAge no callback do Google OAuth alterado de 1 hora para 30 dias (alinhado com session.ts)

### Remember Me no Google OAuth
- Adicionado parseRememberMeFromState() que lê o prefixo 'r_' do parâmetro state
- GET handler agora cria remember_me_token quando state começa com 'r_'
- unified-signin-form: checkbox 'Manter login' adicionado no step inicial de botões
- google-login-button: lê rememberMe do sessionStorage e codifica no state

## Arquivos alterados
- src/app/api/auth/google/callback/route.ts
- src/components/auth/unified-signin-form.tsx
- src/components/auth/google-login-button.tsx

Closes #112