### PR TITLE
fix: migration para tabela oauth_tokens no Supabase production

### DIFF
--- a/supabase/migrations/20260704_create_oauth_tokens_table.sql
+++ b/supabase/migrations/20260704_create_oauth_tokens_table.sql
@@ -1,0 +1,32 @@
+-- Migration: Create oauth_tokens table
+-- Description: Stores encrypted OAuth tokens for social media API access
+-- This migration is needed because the oauth_tokens table exists in schema.sql
+-- but was never deployed to production Supabase via a migration.
+
+-- Create the table
+CREATE TABLE IF NOT EXISTS public.oauth_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  platform TEXT NOT NULL,
+  encrypted_token TEXT NOT NULL,
+  refresh_token TEXT,
+  expires_at TIMESTAMPTZ,
+  linked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, platform)
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_oauth_tokens_user_id ON public.oauth_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_tokens_platform ON public.oauth_tokens(platform);
+CREATE INDEX IF NOT EXISTS idx_oauth_tokens_expires_at ON public.oauth_tokens(expires_at);
+
+-- Enable Row Level Security
+ALTER TABLE public.oauth_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Create RLS policy
+CREATE POLICY IF NOT EXISTS "Users can manage own oauth tokens"
+  ON public.oauth_tokens FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Mudanças
- Criada migration 20260704_create_oauth_tokens_table.sql com a tabela oauth_tokens
- Colunas: id (uuid), user_id, platform, encrypted_token, refresh_token, expires_at
- RLS ativado com política 'Users can manage own oauth tokens'

Closes #113