### PR TITLE
fix: YouTube publish endpoint 404 + video upload integration

### DIFF
--- a/src/app/api/platform/youtube/publish/route.ts
+++ b/src/app/api/platform/youtube/publish/route.ts
@@ -1,0 +1,250 @@
+/**
+ * POST /api/platform/youtube/publish
+ * Publish content to YouTube.
+ *
+ * YouTube's Data API v3 only supports video uploads (not text-only posts).
+ * This endpoint requires a video file uploaded as multipart/form-data.
+ *
+ * Accepts multipart/form-data:
+ *   - video: File (required) - the video file to upload
+ *   - description: string (required) - text description/title of the video
+ *   - privacyStatus: "public" | "unlisted" | "private" (default: "unlisted")
+ *   - tags?: string (comma-separated)
+ *
+ * For JSON-only requests (text without video), returns a 400 error
+ * explaining that YouTube requires a video file.
+ *
+ * Response (201):
+ *   { success: true, videoId: string, url: string }
+ *
+ * Error codes:
+ *   MISSING_USER_ID        - Not authenticated
+ *   YOUTUBE_NOT_LINKED     - YouTube account not linked
+ *   VIDEO_REQUIRED         - JSON-only request without video file
+ *   VALIDATION_ERROR       - Missing/invalid fields
+ *   PUBLISH_FAILED         - YouTube API error
+ */
+
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { createLogger } from "@/lib/logger"
+import { uploadVideo } from "@/lib/posting/adapters/youtube"
+import { NextRequest, NextResponse } from "next/server"
+
+const logger = createLogger("YouTubePublishEndpoint")
+
+const VALID_PRIVACY_STATUSES = new Set([
+    "public",
+    "unlisted",
+    "private",
+] as const)
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        const userId = session?.user?.id
+
+        if (!userId) {
+            logger.warn("Missing user ID in YouTube publish request")
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "MISSING_USER_ID",
+                    message: "User ID is required",
+                },
+                { status: 400 }
+            )
+        }
+
+        // Detect if the request is JSON (text-only) or multipart (with video)
+        const contentType = request.headers.get("content-type") || ""
+
+        if (contentType.includes("application/json")) {
+            // JSON request - text-only, no video
+            let body: Record<string, unknown>
+            try {
+                body = await request.json()
+            } catch {
+                return NextResponse.json(
+                    {
+                        success: false,
+                        error: "VALIDATION_ERROR",
+                        message: "Invalid JSON body",
+                    },
+                    { status: 400 }
+                )
+            }
+
+            const message = body.message || body.description || ""
+
+            logger.warn("Text-only publish attempted to YouTube", {
+                userId,
+                messageLength: typeof message === "string" ? message.length : 0,
+            })
+
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VIDEO_REQUIRED",
+                    message:
+                        "YouTube não aceita postagens de texto puro. Para publicar no YouTube, você precisa enviar um arquivo de vídeo. Use a opção de upload de vídeo na interface de publicação.",
+                    youtubeUploadHint:
+                        "Select a video file in the upload area when publishing to YouTube.",
+                },
+                { status: 400 }
+            )
+        }
+
+        // ── Multipart/form-data with video file ──
+        let formData: FormData
+        try {
+            formData = await request.formData()
+        } catch {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VALIDATION_ERROR",
+                    message: "Invalid form data",
+                },
+                { status: 400 }
+            )
+        }
+
+        // Extract video file
+        const videoFile = formData.get("video")
+        if (!(videoFile instanceof File)) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VIDEO_REQUIRED",
+                    message:
+                        "YouTube requires a video file to publish. Please select a video file.",
+                },
+                { status: 400 }
+            )
+        }
+
+        if (videoFile.size === 0) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VALIDATION_ERROR",
+                    message: "Uploaded video file is empty",
+                },
+                { status: 400 }
+            )
+        }
+
+        // Validate mime type
+        const mime = videoFile.type?.toLowerCase() || ""
+        if (mime && !mime.startsWith("video/")) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VALIDATION_ERROR",
+                    message: "File must be a video",
+                },
+                { status: 400 }
+            )
+        }
+
+        // Validate file size (max 500MB)
+        const MAX_SIZE = 500 * 1024 * 1024
+        if (videoFile.size > MAX_SIZE) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "VALIDATION_ERROR",
+                    message: "Video file exceeds maximum size of 500MB",
+                },
+                { status: 400 }
+            )
+        }
+
+        // Extract description/text content
+        const description = formData.get("description")?.toString().trim() || ""
+
+        // Extract privacy status
+        const privacyRaw =
+            formData.get("privacyStatus")?.toString() || "unlisted"
+        const privacyStatus = VALID_PRIVACY_STATUSES.has(
+            privacyRaw as "public" | "unlisted" | "private"
+        )
+            ? (privacyRaw as "public" | "unlisted" | "private")
+            : "unlisted"
+
+        // Extract tags
+        const tagsRaw = formData.get("tags")?.toString().trim() || ""
+        const tags = tagsRaw
+            ? tagsRaw
+                  .split(",")
+                  .map(t => t.trim())
+                  .filter(Boolean)
+            : undefined
+
+        // Generate title from description (first line, max 100 chars)
+        let title = description.split("\n")[0].trim().slice(0, 100)
+        if (!title) {
+            title = "Video upload"
+        }
+
+        logger.info("YouTube publish requested (video upload)", {
+            userId,
+            title,
+            fileSize: videoFile.size,
+            mimeType: mime,
+        })
+
+        // Upload video
+        const buffer = Buffer.from(await videoFile.arrayBuffer())
+        const result = await uploadVideo(userId, buffer, {
+            title,
+            description,
+            tags,
+            privacyStatus,
+        })
+
+        if (!result.success) {
+            const status = result.error?.toLowerCase().includes("token")
+                ? 401
+                : 500
+            logger.error("YouTube publish failed", {
+                userId,
+                error: result.error,
+            })
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "PUBLISH_FAILED",
+                    message: result.error || "Failed to publish to YouTube",
+                },
+                { status }
+            )
+        }
+
+        logger.info("YouTube publish succeeded", {
+            userId,
+            videoId: result.videoId,
+        })
+
+        return NextResponse.json(
+            {
+                success: true,
+                videoId: result.videoId,
+                url: result.url,
+            },
+            { status: 201 }
+        )
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("Failed to publish to YouTube", err)
+
+        return NextResponse.json(
+            {
+                success: false,
+                error: "PUBLISH_FAILED",
+                message: err.message,
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/src/components/publish/PostingInterface.tsx
+++ b/src/components/publish/PostingInterface.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react"
 import ContentCreator from "./ContentCreator"
 import NetworkSelector from "./NetworkSelector"
 import PostingScheduler from "./PostingScheduler"
+import VideoUploader from "./VideoUploader"
 
 interface PostingInterfaceProps {
     onClose: () => void
@@ -45,6 +46,9 @@ interface Schedule {
     timezone?: string
 }
 
+/** Platforms that require video content instead of text */
+const VIDEO_REQUIRED_PLATFORMS = new Set(["youtube"])
+
 export default function PostingInterface({
     onClose,
     defaultDate,
@@ -58,6 +62,7 @@ export default function PostingInterface({
         images: [],
         urls: [],
     })
+    const [videoFile, setVideoFile] = useState<File | null>(null)
     const [schedule, setSchedule] = useState<Schedule>({
         type: defaultDate ? "scheduled" : "immediate",
     })
@@ -110,12 +115,24 @@ export default function PostingInterface({
         { id: "5", platform: "linkedin", status: "disconnected" },
     ]
 
+    /** Get the set of selected platform names */
+    const selectedPlatforms = selectedNetworkIds
+        .map(id => networks.find(n => n.id === id)?.platform)
+        .filter(Boolean) as string[]
+
+    /** Whether YouTube is among the selected platforms */
+    const hasYouTubeSelected = selectedPlatforms.some(p =>
+        VIDEO_REQUIRED_PLATFORMS.has(p)
+    )
+
     const handleNetworkToggle = useCallback((networkId: string) => {
         setSelectedNetworkIds(prev =>
             prev.includes(networkId)
                 ? prev.filter(id => id !== networkId)
                 : [...prev, networkId]
         )
+        // Clear previous error on network change
+        setError("")
     }, [])
 
     const handleGroupToggle = useCallback((_groupId: string) => {}, [])
@@ -134,12 +151,13 @@ export default function PostingInterface({
         setError("")
         setSuccess(false)
 
+        // ── Validation ──
         if (selectedNetworkIds.length === 0) {
             setError(t("networkRequired"))
             return
         }
 
-        if (!content.text.trim() && content.images.length === 0) {
+        if (!content.text.trim() && content.images.length === 0 && !videoFile) {
             setError(t("contentRequired"))
             return
         }
@@ -154,19 +172,36 @@ export default function PostingInterface({
             return
         }
 
+        // Validate video requirement for YouTube
+        if (hasYouTubeSelected && !videoFile) {
+            setError(
+                "YouTube requer um arquivo de vídeo para publicar. Selecione um vídeo na área de upload abaixo."
+            )
+            return
+        }
+
+        // Validate scheduled + YouTube (not supported yet)
+        if (
+            schedule.type === "scheduled" &&
+            schedule.scheduledTime &&
+            hasYouTubeSelected
+        ) {
+            setError(
+                "Publicação agendada para o YouTube não é suportada no momento. Publique imediatamente ou remova o YouTube das plataformas selecionadas."
+            )
+            return
+        }
+
         setIsSubmitting(true)
 
         try {
-            const selectedPlatforms = selectedNetworkIds
-                .map(id => networks.find(n => n.id === id)?.platform)
-                .filter(Boolean) as string[]
-
             let scheduledTime: number | undefined
             if (schedule.type === "scheduled" && schedule.scheduledTime) {
                 scheduledTime = schedule.scheduledTime.getTime()
             }
 
             if (schedule.type === "scheduled" && scheduledTime) {
+                // Scheduled post - YouTube not allowed here (validated above)
                 const res = await fetch("/api/posts", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -183,9 +218,37 @@ export default function PostingInterface({
                     throw new Error(data.error || t("failedToSchedule"))
                 }
             } else {
-                // Immediate publish - send to each platform's publish endpoint
-                await Promise.all(
-                    selectedPlatforms.map(async platform => {
+                // Immediate publish - send to each platform
+                const errors: string[] = []
+
+                for (const platform of selectedPlatforms) {
+                    if (VIDEO_REQUIRED_PLATFORMS.has(platform) && videoFile) {
+                        // ── YouTube: send multipart with video + description ──
+                        const formData = new FormData()
+                        formData.append("video", videoFile)
+                        formData.append("description", content.text)
+                        formData.append("privacyStatus", "unlisted")
+
+                        const res = await fetch(
+                            `/api/platform/${platform}/publish`,
+                            {
+                                method: "POST",
+                                body: formData,
+                            }
+                        )
+
+                        if (!res.ok) {
+                            const data = await res.json()
+                            const errorMsg =
+                                data.message || data.error || "Unknown error"
+                            errors.push(`${platform}: ${errorMsg}`)
+                            console.error(
+                                `Failed to publish to ${platform}:`,
+                                data
+                            )
+                        }
+                    } else {
+                        // ── Other platforms: send JSON ──
                         const res = await fetch(
                             `/api/platform/${platform}/publish`,
                             {
@@ -200,13 +263,23 @@ export default function PostingInterface({
                         )
                         if (!res.ok) {
                             const data = await res.json()
+                            const errorMsg =
+                                data.message || data.error || "Unknown error"
+                            errors.push(`${platform}: ${errorMsg}`)
                             console.error(
                                 `Failed to publish to ${platform}:`,
                                 data
                             )
                         }
-                    })
-                )
+                    }
+                }
+
+                if (errors.length > 0) {
+                    throw new Error(
+                        "Falha ao publicar em algumas plataformas:\n" +
+                            errors.join("\n")
+                    )
+                }
             }
 
             setSuccess(true)
@@ -245,9 +318,11 @@ export default function PostingInterface({
 
                 <div className="space-y-4">
                     {error && (
-                        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-red-800 dark:bg-red-950/30 dark:text-red-400">
-                            <AlertCircle className="h-5 w-5 flex-shrink-0" />
-                            <p className="text-sm">{error}</p>
+                        <div className="flex items-start gap-2 rounded-lg bg-red-50 p-3 text-red-800 dark:bg-red-950/30 dark:text-red-400">
+                            <AlertCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
+                            <div className="text-sm whitespace-pre-line">
+                                {error}
+                            </div>
                         </div>
                     )}
 
@@ -279,6 +354,17 @@ export default function PostingInterface({
                     )}
 
                     <ContentCreator onContentChange={setContent} />
+
+                    {/* Show VideoUploader when YouTube is selected */}
+                    {hasYouTubeSelected && (
+                        <VideoUploader
+                            onFileSelect={setVideoFile}
+                            selectedPlatforms={selectedPlatforms.filter(p =>
+                                VIDEO_REQUIRED_PLATFORMS.has(p)
+                            )}
+                            disabled={isSubmitting}
+                        />
+                    )}
 
                     <PostingScheduler
                         onScheduleChange={setSchedule}

--- a/src/lib/posting/adapters/youtube.ts
+++ b/src/lib/posting/adapters/youtube.ts
@@ -101,4 +101,21 @@ export async function postToYouTube(
     }
 }
 
-export default { postToYouTube, uploadVideo }
+/**
+ * Queue-compatible publish method.
+ * Matches the interface expected by PublicationQueue.
+ * YouTube only supports video uploads - use uploadVideo for actual publishing.
+ */
+export async function publish(config: {
+    content: string
+    images?: string[]
+    metadata?: Record<string, unknown>
+    token?: string
+}): Promise<{ id?: string; url?: string; success: boolean; error?: string }> {
+    return {
+        success: false,
+        error: "YouTube scheduled publishing is not supported. YouTube requires a video file for publishing, which cannot be provided via scheduled posts.",
+    }
+}
+
+export default { postToYouTube, uploadVideo, publish }


### PR DESCRIPTION
## Descricao

Corrige o erro 404 ao tentar publicar no YouTube e integra o upload de video no fluxo de publicacao.

### Problemas resolvidos

1. 404 no endpoint /api/platform/youtube/publish/ - rota nao existia
2. Erros invisiveis ao usuario - apareciam so no console
3. YouTube nao aceita texto puro - API nao suporta Community Posts
4. VideoUploader nao integrado - nao dava pra selecionar video no publish

### O que foi feito

- Nova rota POST /api/platform/youtube/publish/ (multipart com video)
- PostingInterface reformulado: erros visiveis, VideoUploader integrado
- YouTube tratado separadamente: multipart para YouTube, JSON para outras plataformas
- Validacoes: video obrigatorio para YouTube, agendamento bloqueado para YouTube
- Adapter YouTube: metodo publish() adicionado para queue

### Arquivos modificados

- src/app/api/platform/youtube/publish/route.ts (novo)
- src/components/publish/PostingInterface.tsx (modificado)
- src/lib/posting/adapters/youtube.ts (modificado)

Closes #122
