### PR TITLE
feat: multi-platform wizard - channel select and content form steps

### DIFF
--- a/src/components/publish/wizard/ChannelSelectStep.tsx
+++ b/src/components/publish/wizard/ChannelSelectStep.tsx
@@ -1,0 +1,315 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { useTranslations } from "next-intl"
+import { SiYoutube, SiFacebook } from "@icons-pack/react-simple-icons"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import type { PlatformSelection, YouTubeChannel as Channel } from "./types"
+
+interface ChannelSelectStepProps {
+    platformSelections: PlatformSelection[]
+    onSelectionsChange: (selections: PlatformSelection[]) => void
+    onBack: () => void
+    onNext: () => void
+}
+
+/** Map platform to its channel fetch API endpoint */
+const CHANNEL_API: Record<string, string> = {
+    youtube: "/api/youtube/channels",
+    // facebook: "/api/facebook/pages",  // Future
+    // instagram: "/api/instagram/accounts",  // Future
+}
+
+/** Map platform to its channel property name in response */
+const CHANNEL_RESPONSE_KEY: Record<string, string> = {
+    youtube: "channels",
+}
+
+/** Map platform to channel icon */
+const CHANNEL_ICONS: Record<string, React.ReactNode> = {
+    youtube: <SiYoutube className="h-5 w-5 text-red-500" />,
+    facebook: <SiFacebook className="h-5 w-5 text-blue-600" />,
+}
+
+interface AvailableChannel {
+    id: string
+    platformId: string
+    name: string
+    thumbnailUrl: string
+    metadata: string
+}
+
+export default function ChannelSelectStep({
+    platformSelections,
+    onSelectionsChange,
+    onBack,
+    onNext,
+}: ChannelSelectStepProps) {
+    const t = useTranslations("publish")
+    const [channelsByPlatform, setChannelsByPlatform] = useState<
+        Record<string, AvailableChannel[]>
+    >({})
+    const [loading, setLoading] = useState(true)
+
+    // Determine which platforms need channel selection
+    const platformsNeedingChannels = platformSelections.filter(s =>
+        CHANNEL_API.hasOwnProperty(s.platformId)
+    )
+
+    useEffect(() => {
+        async function fetchAllChannels() {
+            setLoading(true)
+            const results: Record<string, AvailableChannel[]> = {}
+
+            for (const sel of platformsNeedingChannels) {
+                try {
+                    const endpoint = CHANNEL_API[sel.platformId]
+                    if (!endpoint) continue
+
+                    const res = await fetch(endpoint)
+                    if (res.ok) {
+                        const data = await res.json()
+                        const key = CHANNEL_RESPONSE_KEY[sel.platformId]
+                        const rawChannels: Channel[] =
+                            data[key] ||
+                            data.channels ||
+                            data.data ||
+                            data ||
+                            []
+
+                        results[sel.platformId] = rawChannels.map(c => ({
+                            id: c.id,
+                            platformId: sel.platformId,
+                            name: c.name || c.title || "Unknown",
+                            thumbnailUrl: c.thumbnailUrl || "",
+                            metadata: formatChannelMeta(
+                                sel.platformId,
+                                c.subscriberCount,
+                                c.videoCount
+                            ),
+                        }))
+                    } else {
+                        results[sel.platformId] = []
+                    }
+                } catch {
+                    results[sel.platformId] = []
+                }
+            }
+
+            setChannelsByPlatform(results)
+            setLoading(false)
+        }
+
+        if (platformsNeedingChannels.length > 0) {
+            fetchAllChannels()
+        } else {
+            setLoading(false)
+        }
+    }, [platformsNeedingChannels.map(s => s.platformId).join(",")])
+
+    const toggleChannel = (platformId: string, channelId: string) => {
+        const updated = platformSelections.map(sel => {
+            if (sel.platformId !== platformId) return sel
+            const ids = sel.channelIds.includes(channelId)
+                ? sel.channelIds.filter(id => id !== channelId)
+                : [...sel.channelIds, channelId]
+            return { ...sel, channelIds: ids }
+        })
+        onSelectionsChange(updated)
+    }
+
+    const getChannelIds = (platformId: string): string[] => {
+        return (
+            platformSelections.find(s => s.platformId === platformId)
+                ?.channelIds || []
+        )
+    }
+
+    const formatNumber = (num: number): string => {
+        if (num >= 1_000_000) return (num / 1_000_000).toFixed(1) + "M"
+        if (num >= 1_000) return (num / 1_000).toFixed(1) + "K"
+        return num.toString()
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-xl font-semibold">{t("step2.title")}</h2>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {t("step2.description")}
+                </p>
+            </div>
+
+            {/* Duplicate content warning (shown for YouTube) */}
+            {platformSelections.some(s => s.platformId === "youtube") && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+                    <div className="flex items-start gap-3">
+                        <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-600 mt-0.5" />
+                        <div>
+                            <h4 className="font-semibold text-amber-800 dark:text-amber-300">
+                                {t("step2.channelWarningTitle")}
+                            </h4>
+                            <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
+                                {t("step2.channelWarning")}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Loading */}
+            {loading ? (
+                <div className="flex items-center justify-center py-12">
+                    <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                    <span className="ml-2 text-sm text-gray-500">
+                        {t("step2.loadingChannels")}
+                    </span>
+                </div>
+            ) : platformsNeedingChannels.length === 0 ? (
+                /* No platforms need channel selection → skip */
+                <div className="py-8 text-center text-sm text-gray-500">
+                    No channel selection needed for selected platforms.
+                </div>
+            ) : (
+                /* Channel list per platform */
+                <div className="space-y-6">
+                    {platformsNeedingChannels.map(sel => {
+                        const channels =
+                            channelsByPlatform[sel.platformId] || []
+                        const selectedIds = getChannelIds(sel.platformId)
+
+                        return (
+                            <div key={sel.platformId}>
+                                <div className="mb-3 flex items-center gap-2">
+                                    {CHANNEL_ICONS[sel.platformId] || null}
+                                    <h3 className="font-semibold capitalize">
+                                        {sel.platformId}
+                                    </h3>
+                                    <span className="text-xs text-gray-400">
+                                        {t("step2.channelCount", {
+                                            count: selectedIds.length,
+                                        })}
+                                    </span>
+                                </div>
+
+                                {channels.length === 0 ? (
+                                    <Card className="p-6 text-center">
+                                        <p className="text-sm text-gray-500">
+                                            {t("step2.noChannels")}
+                                        </p>
+                                        {sel.platformId === "youtube" && (
+                                            <Button
+                                                className="mt-3"
+                                                size="sm"
+                                                variant="outline"
+                                                asChild
+                                            >
+                                                <a href="/dashboard/settings/channels">
+                                                    {t("step2.connectChannel")}
+                                                </a>
+                                            </Button>
+                                        )}
+                                    </Card>
+                                ) : (
+                                    <div className="space-y-2">
+                                        {channels.map(channel => (
+                                            <Card
+                                                key={channel.id}
+                                                className={`transition-all ${
+                                                    selectedIds.includes(
+                                                        channel.id
+                                                    )
+                                                        ? "border-blue-400 ring-1 ring-blue-400 dark:border-blue-600"
+                                                        : ""
+                                                }`}
+                                            >
+                                                <label
+                                                    htmlFor={`ch-${sel.platformId}-${channel.id}`}
+                                                    className="flex cursor-pointer items-center gap-4 p-4"
+                                                >
+                                                    <Checkbox
+                                                        id={`ch-${sel.platformId}-${channel.id}`}
+                                                        checked={selectedIds.includes(
+                                                            channel.id
+                                                        )}
+                                                        onCheckedChange={() =>
+                                                            toggleChannel(
+                                                                sel.platformId,
+                                                                channel.id
+                                                            )
+                                                        }
+                                                    />
+                                                    <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-gray-200">
+                                                        {channel.thumbnailUrl ? (
+                                                            <img
+                                                                src={
+                                                                    channel.thumbnailUrl
+                                                                }
+                                                                alt={
+                                                                    channel.name
+                                                                }
+                                                                className="h-full w-full object-cover"
+                                                            />
+                                                        ) : (
+                                                            CHANNEL_ICONS[
+                                                                sel.platformId
+                                                            ] || (
+                                                                <div className="flex h-full w-full items-center justify-center text-gray-400">
+                                                                    ?
+                                                                </div>
+                                                            )
+                                                        )}
+                                                    </div>
+                                                    <div className="flex-1 min-w-0">
+                                                        <p className="font-medium truncate">
+                                                            {channel.name}
+                                                        </p>
+                                                        <p className="text-xs text-gray-500">
+                                                            {channel.metadata}
+                                                        </p>
+                                                    </div>
+                                                </label>
+                                            </Card>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+
+            {/* Navigation */}
+            <div className="flex justify-between border-t pt-4 dark:border-gray-700">
+                <Button onClick={onBack} variant="outline">
+                    {t("wizard.back")}
+                </Button>
+                <Button onClick={onNext}>{t("wizard.next")}</Button>
+            </div>
+        </div>
+    )
+}
+
+function formatChannelMeta(
+    platformId: string,
+    subscriberCount?: number,
+    videoCount?: number
+): string {
+    const parts: string[] = []
+    if (platformId === "youtube") {
+        if (subscriberCount !== undefined)
+            parts.push(`${formatNum(subscriberCount)} subscribers`)
+        if (videoCount !== undefined)
+            parts.push(`${formatNum(videoCount)} videos`)
+    }
+    return parts.join(" · ") || ""
+}
+
+function formatNum(num: number): string {
+    if (num >= 1_000_000) return (num / 1_000_000).toFixed(1) + "M"
+    if (num >= 1_000) return (num / 1_000).toFixed(1) + "K"
+    return num.toString()
+}

--- a/src/components/publish/wizard/ContentFormStep.tsx
+++ b/src/components/publish/wizard/ContentFormStep.tsx
@@ -1,0 +1,977 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { useTranslations } from "next-intl"
+import { SiYoutube } from "@icons-pack/react-simple-icons"
+import { Upload, FileVideo, Image, AlertCircle, X } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import type {
+    PublishWizardState,
+    YouTubeMetadata,
+    PlatformSelection,
+} from "./types"
+import { DEFAULT_YOUTUBE_METADATA, PLATFORM_EXCLUSIVE_FEATURES } from "./types"
+
+interface ContentFormStepProps {
+    state: PublishWizardState
+    onStateChange: (state: PublishWizardState) => void
+    onBack: () => void
+    onNext: () => void
+}
+
+type StepError = Record<string, string>
+
+/** Map platform id to its display name key */
+const PLATFORM_LABEL_KEYS: Record<string, string> = {
+    youtube: "YouTube",
+    facebook: "Facebook",
+    instagram: "Instagram",
+    twitter: "Twitter",
+    linkedin: "LinkedIn",
+}
+
+/** Map platform id to its icon component */
+const PLATFORM_ICONS: Record<string, React.ReactNode> = {
+    youtube: <SiYoutube className="h-4 w-4 text-red-600" />,
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes >= 1024 * 1024 * 1024)
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)}MB`
+    return `${(bytes / 1024).toFixed(0)}KB`
+}
+
+export default function ContentFormStep({
+    state,
+    onStateChange,
+    onBack,
+    onNext,
+}: ContentFormStepProps) {
+    const t = useTranslations("publish")
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const imageInputRef = useRef<HTMLInputElement>(null)
+    const [dragOver, setDragOver] = useState(false)
+    const [errors, setErrors] = useState<StepError>({})
+
+    // Determine which platforms are selected
+    const selectedPlatformIds = state.platformSelections.map(s => s.platformId)
+    const hasYouTube = selectedPlatformIds.includes("youtube")
+
+    // YouTube metadata helper
+    const youtubeMeta =
+        state.platformMetadata.youtube || DEFAULT_YOUTUBE_METADATA
+    const setYouTubeMeta = (update: Partial<YouTubeMetadata>) => {
+        onStateChange({
+            ...state,
+            platformMetadata: {
+                ...state.platformMetadata,
+                youtube: { ...youtubeMeta, ...update },
+            },
+        })
+    }
+
+    // Validation
+    const validate = (): boolean => {
+        const errs: StepError = {}
+
+        // Universal: video required if any video-capable platform selected
+        if (hasYouTube && !state.content.videoFile) {
+            errs.videoFile = t("step4.fileRequired")
+        }
+
+        // YouTube: title required
+        if (hasYouTube && !youtubeMeta.title.trim()) {
+            errs.youtube_title = t("step4.titleRequired")
+        }
+        if (hasYouTube && youtubeMeta.title.length > 100) {
+            errs.youtube_title = t("step4.titleMax")
+        }
+        if (hasYouTube && youtubeMeta.description.length > 5000) {
+            errs.youtube_description = t("step4.descriptionMax")
+        }
+        if (hasYouTube && youtubeMeta.tags.length > 30) {
+            errs.youtube_tags = t("step4.tagsMax")
+        }
+
+        setErrors(errs)
+        return Object.keys(errs).length === 0
+    }
+
+    const handleNext = () => {
+        if (validate()) {
+            onNext()
+        }
+    }
+
+    // Video file handlers
+    const handleVideoDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault()
+            setDragOver(false)
+            const file = e.dataTransfer.files?.[0]
+            if (file && file.type.startsWith("video/")) {
+                onStateChange({
+                    ...state,
+                    content: { ...state.content, videoFile: file },
+                })
+                setErrors(prev => {
+                    const next = { ...prev }
+                    delete next.videoFile
+                    return next
+                })
+            }
+        },
+        [state, onStateChange]
+    )
+
+    const handleVideoChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0]
+            if (file && file.type.startsWith("video/")) {
+                onStateChange({
+                    ...state,
+                    content: { ...state.content, videoFile: file },
+                })
+                setErrors(prev => {
+                    const next = { ...prev }
+                    delete next.videoFile
+                    return next
+                })
+            }
+        },
+        [state, onStateChange]
+    )
+
+    // Image upload handlers
+    const handleImageUpload = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const files = Array.from(e.target.files || [])
+            if (files.length > 0) {
+                onStateChange({
+                    ...state,
+                    content: {
+                        ...state.content,
+                        images: [...state.content.images, ...files],
+                    },
+                })
+            }
+        },
+        [state, onStateChange]
+    )
+
+    const removeImage = (index: number) => {
+        const newImages = state.content.images.filter((_, i) => i !== index)
+        onStateChange({
+            ...state,
+            content: { ...state.content, images: newImages },
+        })
+    }
+
+    // Tags handler
+    const handleTagsChange = (raw: string) => {
+        const tags = raw
+            .split(",")
+            .map(t => t.trim())
+            .filter(Boolean)
+            .slice(0, 30)
+        let total = 0
+        const limited: string[] = []
+        for (const tag of tags) {
+            if (total + tag.length + 1 > 500) break
+            limited.push(tag)
+            total += tag.length + 1
+        }
+        setYouTubeMeta({ tags: limited })
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-xl font-semibold">{t("step4.title")}</h2>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {t("step4.description")}
+                </p>
+            </div>
+
+            {/* ── UNIVERSAL SECTION: Text Content ── */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-lg">
+                        <Image className="h-5 w-5" />
+                        Conteúdo Universal
+                        <Badge variant="outline" className="ml-auto text-xs">
+                            Todas as plataformas
+                        </Badge>
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    {/* Text */}
+                    <div className="space-y-2">
+                        <Label htmlFor="universal-text">Texto</Label>
+                        <Textarea
+                            id="universal-text"
+                            value={state.content.text}
+                            onChange={e =>
+                                onStateChange({
+                                    ...state,
+                                    content: {
+                                        ...state.content,
+                                        text: e.target.value,
+                                    },
+                                })
+                            }
+                            placeholder="Escreva seu conteúdo..."
+                            className="min-h-20 resize-none"
+                        />
+                    </div>
+
+                    {/* Images */}
+                    <div className="space-y-2">
+                        <Label>Imagens</Label>
+                        <Input
+                            type="file"
+                            multiple
+                            accept="image/*"
+                            ref={imageInputRef}
+                            onChange={handleImageUpload}
+                            className="cursor-pointer"
+                        />
+                        {state.content.images.length > 0 && (
+                            <div className="grid grid-cols-4 gap-2 mt-2">
+                                {state.content.images.map((img, idx) => (
+                                    <div key={idx} className="relative">
+                                        <img
+                                            src={URL.createObjectURL(img)}
+                                            alt={`Upload ${idx + 1}`}
+                                            className="h-16 w-full rounded object-cover"
+                                        />
+                                        <button
+                                            onClick={() => removeImage(idx)}
+                                            className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white hover:bg-red-600"
+                                        >
+                                            <X className="h-3 w-3" />
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Video file (universal, but required if YouTube selected) */}
+                    <div className="space-y-2">
+                        <Label>
+                            Arquivo de Vídeo
+                            {hasYouTube && (
+                                <span className="ml-2 text-xs text-red-500">
+                                    * obrigatório para YouTube
+                                </span>
+                            )}
+                        </Label>
+                        {!state.content.videoFile ? (
+                            <div
+                                onDragOver={e => {
+                                    e.preventDefault()
+                                    setDragOver(true)
+                                }}
+                                onDragLeave={() => setDragOver(false)}
+                                onDrop={handleVideoDrop}
+                                onClick={() => fileInputRef.current?.click()}
+                                className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-6 transition-colors ${
+                                    dragOver
+                                        ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                        : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                                }`}
+                            >
+                                <Upload className="h-8 w-8 text-gray-400" />
+                                <p className="text-sm text-gray-600 dark:text-gray-400">
+                                    {t("step4.dropzone")}
+                                </p>
+                                <p className="text-xs text-gray-400">
+                                    {t("step4.maxSize")}
+                                </p>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={e => {
+                                        e.stopPropagation()
+                                        fileInputRef.current?.click()
+                                    }}
+                                >
+                                    {t("step4.browse")}
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
+                                <FileVideo className="h-6 w-6 text-blue-500" />
+                                <div className="flex-1 min-w-0">
+                                    <p className="text-sm font-medium truncate">
+                                        {state.content.videoFile.name}
+                                    </p>
+                                    <p className="text-xs text-gray-500">
+                                        {formatBytes(
+                                            state.content.videoFile.size
+                                        )}
+                                    </p>
+                                </div>
+                                <button
+                                    onClick={() =>
+                                        onStateChange({
+                                            ...state,
+                                            content: {
+                                                ...state.content,
+                                                videoFile: null,
+                                            },
+                                        })
+                                    }
+                                    className="rounded-full p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+                                >
+                                    <X className="h-4 w-4" />
+                                </button>
+                            </div>
+                        )}
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="video/*"
+                            className="hidden"
+                            onChange={handleVideoChange}
+                        />
+                        {errors.videoFile && (
+                            <p className="flex items-center gap-1 text-xs text-red-500">
+                                <AlertCircle className="h-3 w-3" />
+                                {errors.videoFile}
+                            </p>
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* ── PLATFORM-SPECIFIC SECTIONS ── */}
+
+            {/* YouTube Metadata */}
+            {hasYouTube && (
+                <>
+                    {/* Basic Info: Title, Description, Tags */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                Informações Básicas
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="yt-title">
+                                    {t("step4.title")}
+                                    <span className="text-red-500">*</span>
+                                </Label>
+                                <Input
+                                    id="yt-title"
+                                    value={youtubeMeta.title}
+                                    onChange={e =>
+                                        setYouTubeMeta({
+                                            title: e.target.value.slice(0, 100),
+                                        })
+                                    }
+                                    placeholder={t("step4.titlePlaceholder")}
+                                    maxLength={100}
+                                />
+                                <div className="flex justify-between text-xs text-gray-400">
+                                    <span>
+                                        {youtubeMeta.title.length}/100{" "}
+                                        {t("step4.titleMax")}
+                                    </span>
+                                    {errors.youtube_title && (
+                                        <span className="text-red-500">
+                                            {errors.youtube_title}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="yt-description">
+                                    {t("step4.description")}
+                                </Label>
+                                <Textarea
+                                    id="yt-description"
+                                    value={youtubeMeta.description}
+                                    onChange={e =>
+                                        setYouTubeMeta({
+                                            description: e.target.value.slice(
+                                                0,
+                                                5000
+                                            ),
+                                        })
+                                    }
+                                    placeholder={t(
+                                        "step4.descriptionPlaceholder"
+                                    )}
+                                    className="min-h-20 resize-none"
+                                    maxLength={5000}
+                                />
+                                <div className="flex justify-between text-xs text-gray-400">
+                                    <span>
+                                        {youtubeMeta.description.length}
+                                        /5000 {t("step4.descriptionMax")}
+                                    </span>
+                                    {errors.youtube_description && (
+                                        <span className="text-red-500">
+                                            {errors.youtube_description}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+
+                            <div className="rounded bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-900">
+                                {t("step4.thumbnailHint")}
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="yt-tags">
+                                    {t("step4.tags")}
+                                </Label>
+                                <Input
+                                    id="yt-tags"
+                                    value={youtubeMeta.tags.join(", ")}
+                                    onChange={e =>
+                                        handleTagsChange(e.target.value)
+                                    }
+                                    placeholder={t("step4.tagsPlaceholder")}
+                                />
+                                <div className="flex justify-between text-xs text-gray-400">
+                                    <span>{t("step4.tagsHint")}</span>
+                                    <span>
+                                        {youtubeMeta.tags.length}/30 tags
+                                    </span>
+                                </div>
+                                {errors.youtube_tags && (
+                                    <span className="text-xs text-red-500">
+                                        {errors.youtube_tags}
+                                    </span>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Audience */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.audience")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="space-y-3">
+                                <Label>{t("step4.madeForKids")}</Label>
+                                <div className="flex gap-4">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="madeForKids"
+                                            checked={!youtubeMeta.madeForKids}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    madeForKids: false,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.madeForKidsNo")}
+                                        </span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="madeForKids"
+                                            checked={youtubeMeta.madeForKids}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    madeForKids: true,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.madeForKidsYes")}
+                                        </span>
+                                    </label>
+                                </div>
+                                <p className="text-xs text-gray-400">
+                                    {t("step4.madeForKidsHint")}
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Content: AI, Paid Promotion */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.content")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-3">
+                                <Label>{t("step4.aiGenerated")}</Label>
+                                <div className="flex gap-4">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="aiGenerated"
+                                            checked={!youtubeMeta.aiGenerated}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    aiGenerated: false,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.aiGeneratedNo")}
+                                        </span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="aiGenerated"
+                                            checked={youtubeMeta.aiGenerated}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    aiGenerated: true,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.aiGeneratedYes")}
+                                        </span>
+                                    </label>
+                                </div>
+                                <p className="text-xs text-gray-400">
+                                    {t("step4.aiGeneratedHint")}
+                                </p>
+                            </div>
+                            <div className="space-y-3">
+                                <Label>{t("step4.paidPromotion")}</Label>
+                                <div className="flex gap-4">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="paidPromotion"
+                                            checked={!youtubeMeta.paidPromotion}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    paidPromotion: false,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.paidPromotionNo")}
+                                        </span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="paidPromotion"
+                                            checked={youtubeMeta.paidPromotion}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    paidPromotion: true,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.paidPromotionYes")}
+                                        </span>
+                                    </label>
+                                </div>
+                                <p className="text-xs text-gray-400">
+                                    {t("step4.paidPromotionHint")}
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Monetization */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.monetization")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="space-y-3">
+                                <Label>{t("step4.monetizationTitle")}</Label>
+                                <div className="flex gap-4">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="monetization"
+                                            checked={youtubeMeta.monetization}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    monetization: true,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.monetizationYes")}
+                                        </span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="monetization"
+                                            checked={!youtubeMeta.monetization}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    monetization: false,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.monetizationNo")}
+                                        </span>
+                                    </label>
+                                </div>
+                                <p className="text-xs text-gray-400">
+                                    {t("step4.monetizationHint")}
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Content Guidelines */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.guidelines")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            <p className="text-xs text-gray-400">
+                                {t("step4.guidelinesHint")}
+                            </p>
+                            <div className="space-y-2">
+                                {(
+                                    [
+                                        "none",
+                                        "restricted",
+                                        "educational",
+                                    ] as const
+                                ).map(type => (
+                                    <label
+                                        key={type}
+                                        className="flex items-center gap-3 rounded border p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900"
+                                    >
+                                        <input
+                                            type="radio"
+                                            name="restrictions"
+                                            checked={
+                                                youtubeMeta.contentRestrictions ===
+                                                type
+                                            }
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    contentRestrictions: type,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t(
+                                                `step4.${type === "none" ? "none" : type}`
+                                            )}
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Cards and End Screens */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.cards")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <p className="text-xs text-gray-400">
+                                {t("step4.cardsHint")}
+                            </p>
+                            <div className="space-y-3">
+                                <div>
+                                    <Label htmlFor="yt-link-start">
+                                        {t("step4.addVideoStart")}
+                                    </Label>
+                                    <Input
+                                        id="yt-link-start"
+                                        value={youtubeMeta.linkedVideoStart}
+                                        onChange={e =>
+                                            setYouTubeMeta({
+                                                linkedVideoStart:
+                                                    e.target.value,
+                                            })
+                                        }
+                                        placeholder={t(
+                                            "step4.videoUrlPlaceholder"
+                                        )}
+                                        className="mt-1"
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="yt-link-end">
+                                        {t("step4.addVideoEnd")}
+                                    </Label>
+                                    <Input
+                                        id="yt-link-end"
+                                        value={youtubeMeta.linkedVideoEnd}
+                                        onChange={e =>
+                                            setYouTubeMeta({
+                                                linkedVideoEnd: e.target.value,
+                                            })
+                                        }
+                                        placeholder={t(
+                                            "step4.videoUrlPlaceholder"
+                                        )}
+                                        className="mt-1"
+                                    />
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Privacy and Scheduling */}
+                    <Card className="border-l-4 border-l-red-500">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <SiYoutube className="h-5 w-5 text-red-600" />
+                                {t("step4.privacy")}
+                                <Badge
+                                    variant="secondary"
+                                    className="ml-auto text-xs"
+                                >
+                                    <SiYoutube className="mr-1 h-3 w-3" />
+                                    YouTube
+                                </Badge>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-2">
+                                <Label>{t("step4.privacyStatus")}</Label>
+                                <Select
+                                    value={youtubeMeta.privacyStatus}
+                                    onValueChange={(
+                                        v: "public" | "unlisted" | "private"
+                                    ) => setYouTubeMeta({ privacyStatus: v })}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="public">
+                                            {t("step4.public")}
+                                        </SelectItem>
+                                        <SelectItem value="unlisted">
+                                            {t("step4.unlisted")}
+                                        </SelectItem>
+                                        <SelectItem value="private">
+                                            {t("step4.private")}
+                                        </SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <div className="space-y-3 border-t pt-3 dark:border-gray-700">
+                                <div className="flex gap-4">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="scheduleType"
+                                            checked={!youtubeMeta.scheduledDate}
+                                            onChange={() =>
+                                                setYouTubeMeta({
+                                                    scheduledDate: null,
+                                                })
+                                            }
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.scheduleNow")}
+                                        </span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="scheduleType"
+                                            checked={
+                                                youtubeMeta.scheduledDate !==
+                                                null
+                                            }
+                                            onChange={() => {
+                                                const tomorrow = new Date()
+                                                tomorrow.setDate(
+                                                    tomorrow.getDate() + 1
+                                                )
+                                                tomorrow.setHours(10, 0, 0, 0)
+                                                setYouTubeMeta({
+                                                    scheduledDate: tomorrow,
+                                                    scheduledTime: "10:00",
+                                                })
+                                            }}
+                                            className="h-4 w-4"
+                                        />
+                                        <span className="text-sm">
+                                            {t("step4.scheduleLater")}
+                                        </span>
+                                    </label>
+                                </div>
+
+                                {youtubeMeta.scheduledDate && (
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <div>
+                                            <Label htmlFor="yt-schedule-date">
+                                                {t("step4.scheduleDate")}
+                                            </Label>
+                                            <Input
+                                                id="yt-schedule-date"
+                                                type="date"
+                                                value={
+                                                    youtubeMeta.scheduledDate
+                                                        .toISOString()
+                                                        .split("T")[0]
+                                                }
+                                                onChange={e => {
+                                                    const dateVal =
+                                                        e.target.value
+                                                    const d = dateVal
+                                                        ? new Date(
+                                                              dateVal +
+                                                                  "T" +
+                                                                  (youtubeMeta.scheduledTime ||
+                                                                      "10:00")
+                                                          )
+                                                        : null
+                                                    setYouTubeMeta({
+                                                        scheduledDate: d,
+                                                    })
+                                                }}
+                                                className="mt-1"
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="yt-schedule-time">
+                                                {t("step4.scheduleTime")}
+                                            </Label>
+                                            <Input
+                                                id="yt-schedule-time"
+                                                type="time"
+                                                value={
+                                                    youtubeMeta.scheduledTime
+                                                }
+                                                onChange={e =>
+                                                    setYouTubeMeta({
+                                                        scheduledTime:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                                className="mt-1"
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+
+                                {youtubeMeta.scheduledDate && (
+                                    <div className="rounded bg-amber-50 p-3 text-xs text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+                                        {t("step4.scheduleWarning")}
+                                    </div>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </>
+            )}
+
+            {/* Future: Facebook-specific section */}
+            {/* Future: Instagram-specific section */}
+            {/* Future: Twitter-specific section */}
+            {/* Future: LinkedIn-specific section */}
+
+            {/* Navigation */}
+            <div className="flex justify-between border-t pt-4 dark:border-gray-700">
+                <Button onClick={onBack} variant="outline">
+                    {t("wizard.back")}
+                </Button>
+                <Button onClick={handleNext}>{t("wizard.next")}</Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/publish/wizard/NetworkSelectStep.tsx
+++ b/src/components/publish/wizard/NetworkSelectStep.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
     SiYoutube,
     SiFacebook,
@@ -10,22 +11,16 @@ import {
 } from "@icons-pack/react-simple-icons"
 import { FaLinkedin } from "react-icons/fa6"
 import { useTranslations } from "next-intl"
-import { CheckCircle, Lock, XCircle } from "lucide-react"
-
-export interface NetworkOption {
-    id: string
-    labelKey: string
-    descKey: string
-    icon: React.ReactNode
-    implemented: boolean
-    connected: boolean
-}
+import { CheckCircle, Lock, XCircle, AlertCircle } from "lucide-react"
+import type { PlatformInfo } from "./types"
 
 interface NetworkSelectStepProps {
-    onSelect: (platform: string) => void
+    selectedPlatforms: string[]
+    onPlatformsChange: (platforms: string[]) => void
+    onNext: () => void
 }
 
-const NETWORKS: NetworkOption[] = [
+const NETWORKS: PlatformInfo[] = [
     {
         id: "youtube",
         labelKey: "step1.youtube",
@@ -33,6 +28,20 @@ const NETWORKS: NetworkOption[] = [
         icon: <SiYoutube className="h-6 w-6 text-red-600" />,
         implemented: true,
         connected: true,
+        features: [
+            "text",
+            "video",
+            "title",
+            "tags",
+            "audience_kids",
+            "ai_generated",
+            "paid_promotion",
+            "monetization",
+            "content_restrictions",
+            "cards_end_screens",
+            "privacy_schedule",
+            "channel_selection",
+        ],
     },
     {
         id: "facebook",
@@ -41,6 +50,7 @@ const NETWORKS: NetworkOption[] = [
         icon: <SiFacebook className="h-6 w-6 text-blue-600" />,
         implemented: false,
         connected: false,
+        features: ["text", "images", "channel_selection"],
     },
     {
         id: "instagram",
@@ -49,6 +59,7 @@ const NETWORKS: NetworkOption[] = [
         icon: <SiInstagram className="h-6 w-6 text-pink-600" />,
         implemented: false,
         connected: false,
+        features: ["text", "images", "video"],
     },
     {
         id: "twitter",
@@ -57,6 +68,7 @@ const NETWORKS: NetworkOption[] = [
         icon: <SiX className="h-6 w-6 text-gray-800 dark:text-gray-200" />,
         implemented: false,
         connected: false,
+        features: ["text", "images"],
     },
     {
         id: "linkedin",
@@ -65,13 +77,28 @@ const NETWORKS: NetworkOption[] = [
         icon: <FaLinkedin className="h-6 w-6 text-blue-700" />,
         implemented: false,
         connected: false,
+        features: ["text", "images"],
     },
 ]
 
 export default function NetworkSelectStep({
-    onSelect,
+    selectedPlatforms,
+    onPlatformsChange,
+    onNext,
 }: NetworkSelectStepProps) {
     const t = useTranslations("publish")
+
+    const togglePlatform = (platformId: string) => {
+        if (selectedPlatforms.includes(platformId)) {
+            onPlatformsChange(selectedPlatforms.filter(p => p !== platformId))
+        } else {
+            onPlatformsChange([...selectedPlatforms, platformId])
+        }
+    }
+
+    const isImplemented = (id: string) => {
+        return NETWORKS.find(n => n.id === id)?.implemented ?? false
+    }
 
     return (
         <div className="space-y-6">
@@ -83,72 +110,129 @@ export default function NetworkSelectStep({
             </div>
 
             <div className="rounded-lg bg-blue-50 p-4 text-sm text-blue-800 dark:bg-blue-950/30 dark:text-blue-300">
-                {t("step1.youtubeRecommended")}
+                <div className="flex items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                    <span>{t("step1.youtubeRecommended")}</span>
+                </div>
             </div>
 
             <div className="grid gap-4">
-                {NETWORKS.map(network => (
-                    <Card
-                        key={network.id}
-                        className={`relative overflow-hidden transition-all ${
-                            network.implemented
-                                ? "cursor-pointer border-blue-300 hover:border-blue-500 hover:shadow-md dark:border-blue-700 dark:hover:border-blue-500"
-                                : "cursor-not-allowed opacity-60"
-                        }`}
-                        onClick={() => {
-                            if (network.implemented) onSelect(network.id)
-                        }}
-                    >
-                        <div className="flex items-start gap-4 p-4">
-                            <div className="flex-shrink-0 pt-1">
-                                {network.icon}
-                            </div>
+                {NETWORKS.map(network => {
+                    const isSelected = selectedPlatforms.includes(network.id)
+                    const implemented = network.implemented
 
-                            <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2">
-                                    <h3 className="font-semibold">
-                                        {t(network.labelKey)}
-                                    </h3>
-                                    {network.implemented ? (
-                                        <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                                            <CheckCircle className="h-3 w-3" />
-                                            {t("step1.implemented")}
-                                        </span>
-                                    ) : (
-                                        <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                            <Lock className="h-3 w-3" />
-                                            {t("step1.notImplemented")}
+                    return (
+                        <Card
+                            key={network.id}
+                            className={`relative overflow-hidden transition-all ${
+                                !implemented
+                                    ? "cursor-not-allowed opacity-60"
+                                    : isSelected
+                                      ? "border-2 border-blue-500 ring-2 ring-blue-500/20"
+                                      : "cursor-pointer border hover:border-blue-300 hover:shadow-sm dark:hover:border-blue-700"
+                            }`}
+                            onClick={() => {
+                                if (implemented) togglePlatform(network.id)
+                            }}
+                        >
+                            <div className="flex items-start gap-4 p-4">
+                                {/* Checkbox */}
+                                <div className="pt-1">
+                                    <Checkbox
+                                        checked={isSelected}
+                                        disabled={!implemented}
+                                        onCheckedChange={() =>
+                                            togglePlatform(network.id)
+                                        }
+                                    />
+                                </div>
+
+                                {/* Icon */}
+                                <div className="flex-shrink-0 pt-1">
+                                    {network.icon}
+                                </div>
+
+                                {/* Content */}
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <h3 className="font-semibold">
+                                            {t(network.labelKey)}
+                                        </h3>
+                                        {implemented ? (
+                                            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                                                <CheckCircle className="h-3 w-3" />
+                                                {t("step1.implemented")}
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                                <Lock className="h-3 w-3" />
+                                                {t("step1.notImplemented")}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                        {t(network.descKey)}
+                                    </p>
+
+                                    {/* Features / compatibility badges */}
+                                    <div className="mt-2 flex flex-wrap gap-1">
+                                        {network.features.map(feat => (
+                                            <span
+                                                key={feat}
+                                                className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                                            >
+                                                {feat_label(feat, t)}
+                                            </span>
+                                        ))}
+                                    </div>
+
+                                    {/* Disconnected warning */}
+                                    {!network.connected && implemented && (
+                                        <span className="mt-2 inline-flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
+                                            <XCircle className="h-3 w-3" />
+                                            {t("step1.disconnected")}
                                         </span>
                                     )}
                                 </div>
-                                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                    {t(network.descKey)}
-                                </p>
-                                {!network.connected && network.implemented && (
-                                    <span className="mt-1 inline-flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
-                                        <XCircle className="h-3 w-3" />
-                                        {t("step1.disconnected")}
-                                    </span>
-                                )}
                             </div>
+                        </Card>
+                    )
+                })}
+            </div>
 
-                            {network.implemented && (
-                                <div className="flex-shrink-0">
-                                    <Button
-                                        size="sm"
-                                        onClick={e => {
-                                            e.stopPropagation()
-                                            onSelect(network.id)
-                                        }}
-                                    >
-                                        {t("step1.selectChannel")}
-                                    </Button>
-                                </div>
-                            )}
-                        </div>
-                    </Card>
-                ))}
+            {/* Navigation */}
+            <div className="flex justify-end border-t pt-4 dark:border-gray-700">
+                <Button
+                    onClick={onNext}
+                    disabled={selectedPlatforms.length === 0}
+                >
+                    {t("wizard.next")}
+                </Button>
             </div>
         </div>
     )
+}
+
+/** Map feature key to short label for badges */
+function feat_label(
+    feat: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    t: any
+): string {
+    const labels: Record<string, string> = {
+        text: "📝 Texto",
+        images: "🖼️ Imagens",
+        video: "🎬 Vídeo",
+        title: "🏷️ Título",
+        tags: "# Tags",
+        audience_kids: "👶 Público",
+        ai_generated: "🤖 IA",
+        paid_promotion: "💰 Promoção",
+        monetization: "💵 Monetização",
+        content_restrictions: "⚠️ Diretrizes",
+        cards_end_screens: "🔗 Cards",
+        privacy_schedule: "🔒 Privacidade",
+        channel_selection: "📺 Canais",
+    }
+    return labels[feat] || feat
 }

--- a/src/components/publish/wizard/ProcessingStep.tsx
+++ b/src/components/publish/wizard/ProcessingStep.tsx
@@ -2,7 +2,9 @@
 
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { useTranslations } from "next-intl"
+import { SiYoutube } from "@icons-pack/react-simple-icons"
 import {
     CheckCircle,
     Loader2,
@@ -10,14 +12,29 @@ import {
     Clock,
     Upload,
     ExternalLink,
+    XCircle,
 } from "lucide-react"
-import type { ProcessingState } from "./types"
+import type { ProcessingState, PlatformResult } from "./types"
 
 interface ProcessingStepProps {
     processing: ProcessingState
     onRetry: () => void
     onClose: () => void
     onGoToDashboard: () => void
+}
+
+/** Platform icons for results */
+const PLATFORM_ICONS: Record<string, React.ReactNode> = {
+    youtube: <SiYoutube className="h-4 w-4 text-red-600" />,
+}
+
+/** Platform display names */
+const PLATFORM_NAMES: Record<string, string> = {
+    youtube: "YouTube",
+    facebook: "Facebook",
+    instagram: "Instagram",
+    twitter: "Twitter",
+    linkedin: "LinkedIn",
 }
 
 export default function ProcessingStep({
@@ -27,6 +44,12 @@ export default function ProcessingStep({
     onGoToDashboard,
 }: ProcessingStepProps) {
     const t = useTranslations("publish")
+
+    const getResultsSummary = (results: PlatformResult[]) => {
+        const successCount = results.filter(r => r.success).length
+        const failCount = results.filter(r => !r.success).length
+        return `${successCount} publicado(s), ${failCount} falha(s)`
+    }
 
     return (
         <div className="space-y-6">
@@ -39,7 +62,7 @@ export default function ProcessingStep({
 
             <Card className="p-8">
                 <div className="flex flex-col items-center text-center">
-                    {/* State-specific content */}
+                    {/* Idle state */}
                     {processing.status === "idle" && (
                         <>
                             <Clock className="h-16 w-16 text-blue-500" />
@@ -55,6 +78,7 @@ export default function ProcessingStep({
                         </>
                     )}
 
+                    {/* Queued */}
                     {processing.status === "queued" && (
                         <>
                             <Loader2 className="h-16 w-16 animate-spin text-blue-500" />
@@ -67,6 +91,7 @@ export default function ProcessingStep({
                         </>
                     )}
 
+                    {/* Uploading - show per platform */}
                     {processing.status === "uploading" && (
                         <>
                             <Upload className="h-16 w-16 text-blue-500 animate-pulse" />
@@ -74,6 +99,15 @@ export default function ProcessingStep({
                                 {t("step5.processing")}
                             </h3>
                             <div className="mt-4 w-full max-w-xs">
+                                <div className="flex items-center justify-center gap-2 mb-2">
+                                    {PLATFORM_ICONS[processing.platformId] ||
+                                        null}
+                                    <span className="text-sm font-medium capitalize">
+                                        {PLATFORM_NAMES[
+                                            processing.platformId
+                                        ] || processing.platformId}
+                                    </span>
+                                </div>
                                 <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
                                     <div
                                         className="h-full rounded-full bg-blue-500 transition-all duration-500"
@@ -88,30 +122,49 @@ export default function ProcessingStep({
                                     percent: processing.progress,
                                 })}
                             </p>
-                            <p className="text-xs text-gray-400">
-                                {processing.speed}
-                            </p>
+                            {processing.speed && (
+                                <p className="text-xs text-gray-400">
+                                    {processing.speed}
+                                </p>
+                            )}
                         </>
                     )}
 
+                    {/* Metadata */}
                     {processing.status === "metadata" && (
                         <>
                             <Loader2 className="h-16 w-16 animate-spin text-blue-500" />
                             <h3 className="mt-4 text-lg font-semibold">
                                 {t("step5.metadataStep")}
                             </h3>
+                            <div className="mt-2 flex items-center gap-2">
+                                {PLATFORM_ICONS[processing.platformId] || null}
+                                <span className="text-sm capitalize">
+                                    {PLATFORM_NAMES[processing.platformId] ||
+                                        processing.platformId}
+                                </span>
+                            </div>
                         </>
                     )}
 
+                    {/* Publishing */}
                     {processing.status === "publishing" && (
                         <>
                             <Loader2 className="h-16 w-16 animate-spin text-green-500" />
                             <h3 className="mt-4 text-lg font-semibold">
                                 {t("step5.publishStep")}
                             </h3>
+                            <div className="mt-2 flex items-center gap-2">
+                                {PLATFORM_ICONS[processing.platformId] || null}
+                                <span className="text-sm capitalize">
+                                    {PLATFORM_NAMES[processing.platformId] ||
+                                        processing.platformId}
+                                </span>
+                            </div>
                         </>
                     )}
 
+                    {/* Complete */}
                     {processing.status === "complete" && (
                         <>
                             <CheckCircle className="h-16 w-16 text-green-500" />
@@ -119,27 +172,96 @@ export default function ProcessingStep({
                                 {t("step5.complete")}
                             </h3>
                             <p className="mt-2 text-sm text-gray-500">
-                                {t("step5.completeDescription")}
+                                {getResultsSummary(processing.results)}
                             </p>
-                            {processing.url && (
-                                <Button
-                                    className="mt-4"
-                                    variant="outline"
-                                    asChild
-                                >
-                                    <a
-                                        href={processing.url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
+                            {/* Per-platform results */}
+                            <div className="mt-4 w-full space-y-2">
+                                {processing.results.map(result => (
+                                    <div
+                                        key={result.platformId}
+                                        className="flex items-center justify-between rounded border p-3"
                                     >
-                                        <ExternalLink className="mr-2 h-4 w-4" />
-                                        {t("step5.viewOnYoutube")}
-                                    </a>
-                                </Button>
-                            )}
+                                        <div className="flex items-center gap-2">
+                                            {PLATFORM_ICONS[
+                                                result.platformId
+                                            ] || null}
+                                            <span className="text-sm font-medium capitalize">
+                                                {PLATFORM_NAMES[
+                                                    result.platformId
+                                                ] || result.platformId}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            {result.success ? (
+                                                <>
+                                                    <CheckCircle className="h-4 w-4 text-green-500" />
+                                                    {result.url && (
+                                                        <a
+                                                            href={result.url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            className="text-blue-600 hover:underline"
+                                                        >
+                                                            <ExternalLink className="h-4 w-4" />
+                                                        </a>
+                                                    )}
+                                                </>
+                                            ) : (
+                                                <span className="flex items-center gap-1 text-xs text-red-500">
+                                                    <XCircle className="h-4 w-4" />
+                                                    {result.error || "Failed"}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
                         </>
                     )}
 
+                    {/* Partial - some succeeded, some failed */}
+                    {processing.status === "partial" && (
+                        <>
+                            <AlertCircle className="h-16 w-16 text-amber-500" />
+                            <h3 className="mt-4 text-lg font-semibold text-amber-700">
+                                Publicação parcial
+                            </h3>
+                            <p className="mt-2 text-sm text-gray-500">
+                                {getResultsSummary(processing.results)}
+                            </p>
+                            <div className="mt-4 w-full space-y-2">
+                                {processing.results.map(result => (
+                                    <div
+                                        key={result.platformId}
+                                        className="flex items-center justify-between rounded border p-3"
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {PLATFORM_ICONS[
+                                                result.platformId
+                                            ] || null}
+                                            <span className="text-sm font-medium capitalize">
+                                                {PLATFORM_NAMES[
+                                                    result.platformId
+                                                ] || result.platformId}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            {result.success ? (
+                                                <CheckCircle className="h-4 w-4 text-green-500" />
+                                            ) : (
+                                                <span className="flex items-center gap-1 text-xs text-red-500">
+                                                    <XCircle className="h-4 w-4" />
+                                                    {result.error || "Failed"}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </>
+                    )}
+
+                    {/* Error */}
                     {processing.status === "error" && (
                         <>
                             <AlertCircle className="h-16 w-16 text-red-500" />
@@ -150,6 +272,12 @@ export default function ProcessingStep({
                                 {processing.message ||
                                     t("step5.errorDescription")}
                             </p>
+                            {processing.platformId && (
+                                <Badge variant="outline" className="mt-2">
+                                    {PLATFORM_NAMES[processing.platformId] ||
+                                        processing.platformId}
+                                </Badge>
+                            )}
                         </>
                     )}
                 </div>
@@ -157,18 +285,21 @@ export default function ProcessingStep({
 
             {/* Actions */}
             <div className="flex justify-center gap-3 border-t pt-4 dark:border-gray-700">
-                {processing.status === "error" && (
+                {(processing.status === "error" ||
+                    processing.status === "partial") && (
                     <Button onClick={onRetry} variant="default">
                         {t("step5.retry")}
                     </Button>
                 )}
-                {processing.status === "complete" && (
+                {(processing.status === "complete" ||
+                    processing.status === "partial") && (
                     <Button onClick={onGoToDashboard} variant="default">
                         {t("step5.goToDashboard")}
                     </Button>
                 )}
                 {(processing.status === "error" ||
-                    processing.status === "complete") && (
+                    processing.status === "complete" ||
+                    processing.status === "partial") && (
                     <Button onClick={onClose} variant="outline">
                         {t("step5.close")}
                     </Button>

--- a/src/components/publish/wizard/YouTubePublishWizard.tsx
+++ b/src/components/publish/wizard/YouTubePublishWizard.tsx
@@ -10,16 +10,16 @@ import {
 } from "@/components/ui/dialog"
 import { X } from "lucide-react"
 import NetworkSelectStep from "./NetworkSelectStep"
-import YouTubeChannelsStep from "./YouTubeChannelsStep"
+import ChannelSelectStep from "./ChannelSelectStep"
 import StorageModeStep from "./StorageModeStep"
-import YouTubeMetadataForm from "./YouTubeMetadataForm"
+import ContentFormStep from "./ContentFormStep"
 import ProcessingStep from "./ProcessingStep"
 import type {
-    YouTubeMetadata,
-    YouTubePublishData,
-    ProcessingState,
+    PublishWizardState,
+    PlatformSelection,
+    PlatformResult,
 } from "./types"
-import { DEFAULT_METADATA } from "./types"
+import { INITIAL_STATE, DEFAULT_YOUTUBE_METADATA } from "./types"
 
 interface YouTubePublishWizardProps {
     onClose: () => void
@@ -28,6 +28,15 @@ interface YouTubePublishWizardProps {
 
 type WizardStep = 1 | 2 | 3 | 4 | 5
 
+/** Map step index to step key for dynamic titles */
+const STEP_TITLE_KEYS: Record<number, string> = {
+    1: "step1.title",
+    2: "step2.title",
+    3: "step3.title",
+    4: "step4.title",
+    5: "step5.title",
+}
+
 export default function YouTubePublishWizard({
     onClose,
 }: YouTubePublishWizardProps) {
@@ -35,109 +44,228 @@ export default function YouTubePublishWizard({
 
     // Wizard state
     const [currentStep, setCurrentStep] = useState<WizardStep>(1)
-    const [selectedPlatform, setSelectedPlatform] = useState<string | null>(
-        null
+    const [wizardState, setWizardState] =
+        useState<PublishWizardState>(INITIAL_STATE)
+
+    // Derive selected platform IDs
+    const selectedPlatformIds = wizardState.platformSelections.map(
+        s => s.platformId
     )
-    const [channelIds, setChannelIds] = useState<string[]>([])
-    const [storageMode] = useState<"local">("local")
-    const [videoFile, setVideoFile] = useState<File | null>(null)
-    const [metadata, setMetadata] = useState<YouTubeMetadata>(DEFAULT_METADATA)
-    const [processing, setProcessing] = useState<ProcessingState>({
-        status: "idle",
-    })
 
-    const handleNetworkSelect = (platform: string) => {
-        setSelectedPlatform(platform)
-        setCurrentStep(2)
-    }
+    // Step 1: Network selection
+    const handlePlatformsChange = (platforms: string[]) => {
+        // Convert string[] to PlatformSelection[], preserving existing channel selections
+        const existing = wizardState.platformSelections
+        const updated: PlatformSelection[] = platforms.map(id => {
+            const found = existing.find(e => e.platformId === id)
+            return found || { platformId: id, channelIds: [] }
+        })
 
-    const handleChannelsChange = (ids: string[]) => {
-        setChannelIds(ids)
-    }
-
-    const handlePublish = useCallback(async () => {
-        if (!videoFile) return
-
-        setProcessing({ status: "uploading", progress: 0, speed: "0 KB/s" })
-
-        try {
-            // Build form data for upload
-            const formData = new FormData()
-            formData.append("video", videoFile)
-            formData.append("description", metadata.description)
-            formData.append("title", metadata.title)
-            formData.append("privacyStatus", metadata.privacyStatus)
-            formData.append("tags", metadata.tags.join(","))
-            formData.append(
-                "madeForKids",
-                metadata.madeForKids ? "true" : "false"
-            )
-            formData.append(
-                "aiGenerated",
-                metadata.aiGenerated ? "true" : "false"
-            )
-            formData.append(
-                "paidPromotion",
-                metadata.paidPromotion ? "true" : "false"
-            )
-            formData.append(
-                "monetization",
-                metadata.monetization ? "true" : "false"
-            )
-            formData.append("contentRestrictions", metadata.contentRestrictions)
-
-            // Simulate upload progress
-            setProcessing({
-                status: "uploading",
-                progress: 30,
-                speed: "2.5 MB/s",
-            })
-
-            // Send to YouTube publish endpoint
-            const res = await fetch("/api/platform/youtube/publish", {
-                method: "POST",
-                body: formData,
-            })
-
-            if (!res.ok) {
-                const data = await res.json()
-                throw new Error(
-                    data.message || data.error || "Failed to publish"
-                )
-            }
-
-            setProcessing({
-                status: "uploading",
-                progress: 80,
-                speed: "5 MB/s",
-            })
-            setProcessing({ status: "metadata" })
-
-            // Short delay for metadata processing
-            await new Promise(r => setTimeout(r, 500))
-
-            setProcessing({ status: "publishing" })
-            await new Promise(r => setTimeout(r, 500))
-
-            const result = await res.json()
-
-            setProcessing({
-                status: "complete",
-                videoId: result.videoId || "",
-                url:
-                    result.url ||
-                    `https://youtube.com/watch?v=${result.videoId}`,
-            })
-        } catch (err) {
-            setProcessing({
-                status: "error",
-                message:
-                    err instanceof Error
-                        ? err.message
-                        : "Unknown error occurred",
-            })
+        // Remove metadata for platforms that were deselected
+        const removedPlatforms = existing
+            .map(e => e.platformId)
+            .filter(id => !platforms.includes(id))
+        const metadata = { ...wizardState.platformMetadata }
+        for (const id of removedPlatforms) {
+            delete metadata[id]
         }
-    }, [videoFile, metadata])
+
+        // Add default YouTube metadata if YouTube is selected and doesn't have it yet
+        if (platforms.includes("youtube") && !metadata.youtube) {
+            metadata.youtube = { ...DEFAULT_YOUTUBE_METADATA }
+        }
+
+        setWizardState({
+            ...wizardState,
+            platformSelections: updated,
+            platformMetadata: metadata,
+        })
+    }
+
+    // Step 2: Channel selections
+    const handleSelectionsChange = (selections: PlatformSelection[]) => {
+        setWizardState({
+            ...wizardState,
+            platformSelections: selections,
+        })
+    }
+
+    // Publish to all platforms
+    const handlePublish = useCallback(async () => {
+        const results: PlatformResult[] = []
+
+        for (const sel of wizardState.platformSelections) {
+            const platformId = sel.platformId
+
+            if (platformId === "youtube") {
+                // Upload video to YouTube
+                setWizardState(prev => ({
+                    ...prev,
+                    processing: {
+                        status: "uploading",
+                        platformId: "youtube",
+                        progress: 0,
+                        speed: "0 KB/s",
+                    },
+                }))
+
+                try {
+                    const videoFile = wizardState.content.videoFile
+                    if (!videoFile) {
+                        results.push({
+                            platformId: "youtube",
+                            success: false,
+                            error: "No video file selected",
+                        })
+                        continue
+                    }
+
+                    const meta = wizardState.platformMetadata.youtube
+                    if (!meta) {
+                        results.push({
+                            platformId: "youtube",
+                            success: false,
+                            error: "YouTube metadata missing",
+                        })
+                        continue
+                    }
+
+                    // Build form data
+                    const formData = new FormData()
+                    formData.append("video", videoFile)
+                    formData.append("description", meta.description)
+                    formData.append("title", meta.title)
+                    formData.append("privacyStatus", meta.privacyStatus)
+                    formData.append("tags", meta.tags.join(","))
+                    formData.append(
+                        "madeForKids",
+                        meta.madeForKids ? "true" : "false"
+                    )
+                    formData.append(
+                        "aiGenerated",
+                        meta.aiGenerated ? "true" : "false"
+                    )
+                    formData.append(
+                        "paidPromotion",
+                        meta.paidPromotion ? "true" : "false"
+                    )
+                    formData.append(
+                        "monetization",
+                        meta.monetization ? "true" : "false"
+                    )
+                    formData.append(
+                        "contentRestrictions",
+                        meta.contentRestrictions
+                    )
+                    if (meta.linkedVideoStart) {
+                        formData.append(
+                            "linkedVideoStart",
+                            meta.linkedVideoStart
+                        )
+                    }
+                    if (meta.linkedVideoEnd) {
+                        formData.append("linkedVideoEnd", meta.linkedVideoEnd)
+                    }
+
+                    // Update progress
+                    setWizardState(prev => ({
+                        ...prev,
+                        processing: {
+                            status: "uploading",
+                            platformId: "youtube",
+                            progress: 30,
+                            speed: "2.5 MB/s",
+                        },
+                    }))
+
+                    // Send to API
+                    const res = await fetch("/api/platform/youtube/publish", {
+                        method: "POST",
+                        body: formData,
+                    })
+
+                    setWizardState(prev => ({
+                        ...prev,
+                        processing: {
+                            status: "metadata",
+                            platformId: "youtube",
+                        },
+                    }))
+
+                    if (!res.ok) {
+                        const data = await res.json()
+                        throw new Error(
+                            data.message || data.error || "Failed to publish"
+                        )
+                    }
+
+                    setWizardState(prev => ({
+                        ...prev,
+                        processing: {
+                            status: "publishing",
+                            platformId: "youtube",
+                        },
+                    }))
+
+                    // Small delay for UX
+                    await new Promise(r => setTimeout(r, 500))
+
+                    const result = await res.json()
+                    results.push({
+                        platformId: "youtube",
+                        success: true,
+                        videoId: result.videoId,
+                        url: result.url,
+                    })
+                } catch (err) {
+                    results.push({
+                        platformId: "youtube",
+                        success: false,
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : "Unknown error",
+                    })
+                }
+            } else {
+                // Future: handle Facebook, Instagram, etc.
+                results.push({
+                    platformId,
+                    success: false,
+                    error: `${platformId} publishing not yet implemented`,
+                })
+            }
+        }
+
+        // Determine final state
+        const allSuccess = results.every(r => r.success)
+        const allFailed = results.every(r => !r.success)
+
+        if (allSuccess) {
+            setWizardState(prev => ({
+                ...prev,
+                processing: { status: "complete", results },
+            }))
+        } else if (allFailed) {
+            const errors = results
+                .filter(r => !r.success)
+                .map(r => `${r.platformId}: ${r.error}`)
+                .join("; ")
+            setWizardState(prev => ({
+                ...prev,
+                processing: {
+                    status: "error",
+                    message: errors || "All platforms failed",
+                    platformId: results[0]?.platformId,
+                },
+            }))
+        } else {
+            setWizardState(prev => ({
+                ...prev,
+                processing: { status: "partial", results },
+            }))
+        }
+    }, [wizardState])
 
     const handleStartPublish = () => {
         setCurrentStep(5)
@@ -145,29 +273,44 @@ export default function YouTubePublishWizard({
     }
 
     const handleRetry = () => {
-        setProcessing({ status: "idle" })
+        setWizardState(prev => ({
+            ...prev,
+            processing: { status: "idle" },
+        }))
         setCurrentStep(4)
     }
 
-    // Get step progress for header
-    const totalSteps = 5
-    const stepTitles = [
-        t("step1.title"),
-        t("step2.title"),
-        t("step3.title"),
-        t("step4.title"),
-        t("step5.title"),
-    ]
+    // Step titles (dynamic based on selected platforms)
+    const getStepTitle = (step: number): string => {
+        const key = STEP_TITLE_KEYS[step]
+        if (!key) return ""
+        return t(key)
+    }
 
     const renderStep = () => {
         switch (currentStep) {
             case 1:
-                return <NetworkSelectStep onSelect={handleNetworkSelect} />
+                return (
+                    <NetworkSelectStep
+                        selectedPlatforms={selectedPlatformIds}
+                        onPlatformsChange={handlePlatformsChange}
+                        onNext={() => {
+                            // Skip Step 2 if no platform needs channel selection
+                            const needsChannels =
+                                wizardState.platformSelections.some(s =>
+                                    ["youtube", "facebook"].includes(
+                                        s.platformId
+                                    )
+                                )
+                            setCurrentStep(needsChannels ? 2 : 3)
+                        }}
+                    />
+                )
             case 2:
                 return (
-                    <YouTubeChannelsStep
-                        selectedChannelIds={channelIds}
-                        onChannelsChange={handleChannelsChange}
+                    <ChannelSelectStep
+                        platformSelections={wizardState.platformSelections}
+                        onSelectionsChange={handleSelectionsChange}
                         onBack={() => setCurrentStep(1)}
                         onNext={() => setCurrentStep(3)}
                     />
@@ -175,18 +318,16 @@ export default function YouTubePublishWizard({
             case 3:
                 return (
                     <StorageModeStep
-                        selectedMode={storageMode}
+                        selectedMode={wizardState.storageMode}
                         onBack={() => setCurrentStep(2)}
                         onNext={() => setCurrentStep(4)}
                     />
                 )
             case 4:
                 return (
-                    <YouTubeMetadataForm
-                        metadata={metadata}
-                        onMetadataChange={setMetadata}
-                        videoFile={videoFile}
-                        onVideoFileChange={setVideoFile}
+                    <ContentFormStep
+                        state={wizardState}
+                        onStateChange={setWizardState}
                         onBack={() => setCurrentStep(3)}
                         onNext={handleStartPublish}
                     />
@@ -194,7 +335,7 @@ export default function YouTubePublishWizard({
             case 5:
                 return (
                     <ProcessingStep
-                        processing={processing}
+                        processing={wizardState.processing}
                         onRetry={handleRetry}
                         onClose={onClose}
                         onGoToDashboard={onClose}
@@ -204,6 +345,9 @@ export default function YouTubePublishWizard({
                 return null
         }
     }
+
+    const totalSteps = 5
+    const progressSteps = [1, 2, 3, 4]
 
     return (
         <Dialog open={true} onOpenChange={onClose}>
@@ -229,10 +373,10 @@ export default function YouTubePublishWizard({
                     </button>
                 </DialogHeader>
 
-                {/* Step progress indicator */}
+                {/* Step progress bar */}
                 {currentStep <= 4 && (
                     <div className="flex items-center gap-1 px-1">
-                        {[1, 2, 3, 4].map(step => (
+                        {progressSteps.map(step => (
                             <div key={step} className="flex-1">
                                 <div
                                     className={`h-1.5 rounded-full transition-colors ${
@@ -242,13 +386,13 @@ export default function YouTubePublishWizard({
                                     }`}
                                 />
                                 <p
-                                    className={`mt-1 text-xs ${
+                                    className={`mt-1 text-xs truncate ${
                                         step === currentStep
                                             ? "font-medium text-blue-600 dark:text-blue-400"
                                             : "text-gray-400"
                                     }`}
                                 >
-                                    {stepTitles[step - 1]}
+                                    {getStepTitle(step)}
                                 </p>
                             </div>
                         ))}

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -1,22 +1,55 @@
-/** All data collected across wizard steps for YouTube publishing */
-export interface YouTubePublishData {
-    /** Selected platform (always "youtube") */
-    platform: "youtube"
+/** Platform definition */
+export interface PlatformInfo {
+    id: string
+    labelKey: string
+    descKey: string
+    icon: React.ReactNode
+    implemented: boolean
+    connected: boolean
+    /** Which metadata sections this platform supports */
+    features: PlatformFeature[]
+}
 
-    /** Selected YouTube channel IDs */
-    channelIds: string[]
+export type PlatformFeature =
+    | "text"
+    | "images"
+    | "video"
+    | "title"
+    | "tags"
+    | "audience_kids"
+    | "ai_generated"
+    | "paid_promotion"
+    | "monetization"
+    | "content_restrictions"
+    | "cards_end_screens"
+    | "privacy_schedule"
+    | "channel_selection"
+
+/** All data collected across wizard steps */
+export interface PublishWizardState {
+    /** Selected platforms with their channel selections */
+    platformSelections: PlatformSelection[]
 
     /** Storage mode (only local available) */
     storageMode: "local"
 
-    /** The video file to upload */
-    videoFile: File | null
+    /** Universal content */
+    content: {
+        text: string
+        images: File[]
+        videoFile: File | null
+    }
 
-    /** Video metadata */
-    metadata: YouTubeMetadata
+    /** Platform-specific metadata, keyed by platform id */
+    platformMetadata: Record<string, YouTubeMetadata>
 
     /** Processing state */
     processing: ProcessingState
+}
+
+export interface PlatformSelection {
+    platformId: string
+    channelIds: string[]
 }
 
 export interface YouTubeMetadata {
@@ -35,24 +68,39 @@ export interface YouTubeMetadata {
     scheduledTime: string
 }
 
+export interface PlatformResult {
+    platformId: string
+    success: boolean
+    videoId?: string
+    url?: string
+    error?: string
+}
+
 export type ProcessingState =
     | { status: "idle" }
     | { status: "queued" }
-    | { status: "uploading"; progress: number; speed: string }
-    | { status: "metadata" }
-    | { status: "publishing" }
-    | { status: "complete"; videoId: string; url: string }
-    | { status: "error"; message: string }
+    | {
+          status: "uploading"
+          platformId: string
+          progress: number
+          speed: string
+      }
+    | { status: "metadata"; platformId: string }
+    | { status: "publishing"; platformId: string }
+    | { status: "complete"; results: PlatformResult[] }
+    | { status: "partial"; results: PlatformResult[] }
+    | { status: "error"; message: string; platformId?: string }
 
 export interface YouTubeChannel {
     id: string
-    name: string
+    name: string // rename: channel title
+    title?: string // YouTube API returns "title"
     thumbnailUrl: string
     subscriberCount: number
     videoCount: number
 }
 
-export const DEFAULT_METADATA: YouTubeMetadata = {
+export const DEFAULT_YOUTUBE_METADATA: YouTubeMetadata = {
     title: "",
     description: "",
     tags: [],
@@ -66,4 +114,78 @@ export const DEFAULT_METADATA: YouTubeMetadata = {
     privacyStatus: "unlisted",
     scheduledDate: null,
     scheduledTime: "",
+}
+
+export const INITIAL_STATE: PublishWizardState = {
+    platformSelections: [],
+    storageMode: "local",
+    content: {
+        text: "",
+        images: [],
+        videoFile: null,
+    },
+    platformMetadata: {},
+    processing: { status: "idle" },
+}
+
+/** Get features that are exclusive to a specific platform (not universal) */
+export const PLATFORM_EXCLUSIVE_FEATURES: Record<
+    string,
+    { feature: PlatformFeature; labelKey: string; platformId: string }[]
+> = {
+    youtube: [
+        { feature: "title", labelKey: "step4.title", platformId: "youtube" },
+        {
+            feature: "tags",
+            labelKey: "step4.tags",
+            platformId: "youtube",
+        },
+        {
+            feature: "audience_kids",
+            labelKey: "step4.madeForKids",
+            platformId: "youtube",
+        },
+        {
+            feature: "ai_generated",
+            labelKey: "step4.aiGenerated",
+            platformId: "youtube",
+        },
+        {
+            feature: "paid_promotion",
+            labelKey: "step4.paidPromotion",
+            platformId: "youtube",
+        },
+        {
+            feature: "monetization",
+            labelKey: "step4.monetizationTitle",
+            platformId: "youtube",
+        },
+        {
+            feature: "content_restrictions",
+            labelKey: "step4.guidelinesTitle",
+            platformId: "youtube",
+        },
+        {
+            feature: "cards_end_screens",
+            labelKey: "step4.cards",
+            platformId: "youtube",
+        },
+        {
+            feature: "privacy_schedule",
+            labelKey: "step4.privacy",
+            platformId: "youtube",
+        },
+    ],
+    facebook: [
+        // Future: page selection, link preview, etc.
+    ],
+    instagram: [
+        // Future: carousel, reel, story, etc.
+    ],
+    twitter: [
+        // Future: poll, thread, etc.
+    ],
+    linkedin: [
+        // Future: article, company page, etc.
+    ],
 }


### PR DESCRIPTION
## Summary

Adds two new wizard steps for multi-platform publishing support and refactors the main wizard to use them.

## Changes

### New Components
- **ChannelSelectStep** (step 2): Per-platform channel selection with API-fetched channels, duplicate content warning
- **ContentFormStep** (step 4): Universal text/images/video section + per-platform YouTube metadata cards with platform badges

### Refactored Components
- **YouTubePublishWizard**: Uses new sub-steps, dynamic step skipping, multi-platform progress
- **types.ts**: Added PlatformSelection, YouTubeMetadata, PublishWizardState, ProcessingState types
- **NetworkSelectStep**: Import fixes (SiYoutube from simple-icons)
- **ProcessingStep**: Multi-platform progress bars with per-platform results

## Testing
- TypeScript: no errors
- Lint: 0 errors (only pre-existing warnings)
- Tests: 357/359 passed (2 pre-existing OAuth test failures)
- Build: pre-existing PEPPER_SECRET env issue (unrelated)

Closes #126