### PR TITLE
fix: null type error in csrf-protection test

### DIFF
--- a/src/lib/middleware/csrf-protection.test.ts
+++ b/src/lib/middleware/csrf-protection.test.ts
@@ -104,10 +104,10 @@ describe("CSRF Protection", () => {
 
             expect(token).toBeDefined()
             expect(typeof token).toBe("string")
-            expect(token.length).toBeGreaterThan(0)
+            expect((token as string).length).toBeGreaterThan(0)
 
             // The generated token should be valid for the session
-            const isValid = validateCsrfToken(sessionToken, token)
+            const isValid = validateCsrfToken(sessionToken, token as string)
             expect(isValid).toBe(true)
         })
 


### PR DESCRIPTION
## Fix

\getCsrfToken()\ returns \string | null\, causing \	sc --noEmit -p tsconfig.test.json\ to fail.

Changed \	oken.length\ and \alidateCsrfToken(sessionToken, token)\ to use \s string\ after the \	oBeDefined()\ runtime check.

Closes #128