### PR TITLE
fix: channels page i18n, show all platforms, add Twitch/Trovo/Kwai

### DIFF
--- a/src/app/[locale]/dashboard/channels/page.tsx
+++ b/src/app/[locale]/dashboard/channels/page.tsx
@@ -2,6 +2,7 @@
 
 import { DynamicIcon } from "@/components/ui/dynamic-icon"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { logger } from "@/lib/logger"
 import { useTranslations } from "next-intl"
 import { useParams } from "next/navigation"
@@ -13,19 +14,24 @@ interface ConnectedChannel {
     accountId: string
     accountName: string
     isConnected: boolean
+    thumbnailUrl?: string
     connectedAt?: string
     needsReconnect?: boolean
 }
 
-const PLATFORM_NAMES: Record<string, string> = {
-    youtube: "YouTube",
-    facebook: "Facebook",
-    instagram: "Instagram",
-    twitter: "Twitter/X",
-    tiktok: "TikTok",
-    linkedin: "LinkedIn",
-    kick: "Kick",
-}
+/** All available platforms */
+const ALL_PLATFORMS = [
+    { id: "youtube", name: "YouTube", implemented: true },
+    { id: "facebook", name: "Facebook", implemented: false },
+    { id: "instagram", name: "Instagram", implemented: false },
+    { id: "twitter", name: "Twitter/X", implemented: false },
+    { id: "tiktok", name: "TikTok", implemented: false },
+    { id: "linkedin", name: "LinkedIn", implemented: false },
+    { id: "kick", name: "Kick", implemented: false },
+    { id: "twitch", name: "Twitch", implemented: false },
+    { id: "trovo", name: "Trovo", implemented: false },
+    { id: "kwai", name: "Kwai", implemented: false },
+] as const
 
 const PLATFORM_ICONS: Record<string, string> = {
     youtube: "Youtube",
@@ -35,6 +41,9 @@ const PLATFORM_ICONS: Record<string, string> = {
     tiktok: "TikTok",
     linkedin: "Linkedin",
     kick: "Kick",
+    twitch: "Twitch",
+    trovo: "Trovo",
+    kwai: "Kwai",
 }
 
 export default function ChannelsPage() {
@@ -141,23 +150,31 @@ export default function ChannelsPage() {
                     className="mt-2"
                     onClick={fetchChannels}
                 >
-                    Retry
+                    {t("publish.retry")}
                 </Button>
             </div>
         )
     }
 
     const connectedChannels = channels.filter(c => c.isConnected)
-    const disconnectedChannels = channels.filter(c => !c.isConnected)
+
+    // Build a map of which platforms are connected and how many channels each has
+    const platformConnectedChannels = connectedChannels.reduce<
+        Record<string, ConnectedChannel[]>
+    >((acc, ch) => {
+        if (!acc[ch.platform]) acc[ch.platform] = []
+        acc[ch.platform].push(ch)
+        return acc
+    }, {})
 
     return (
         <div className="space-y-6">
             <div>
                 <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-                    Channels
+                    {t("channels.channels")}
                 </h1>
                 <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    Manage all your connected social media channels
+                    {t("channels.description")}
                 </p>
             </div>
 
@@ -165,16 +182,18 @@ export default function ChannelsPage() {
             <section>
                 <div className="flex items-center justify-between mb-4">
                     <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                        Connected ({connectedChannels.length})
+                        {t("channels.connected", {
+                            count: connectedChannels.length,
+                        })}
                     </h2>
                 </div>
                 {connectedChannels.length === 0 ? (
                     <div className="rounded-lg border-2 border-dashed border-gray-200 p-8 text-center dark:border-gray-700">
                         <p className="text-gray-500 dark:text-gray-400">
-                            No channels connected yet
+                            {t("channels.noConnected")}
                         </p>
                         <p className="mt-1 text-sm text-gray-400 dark:text-gray-500">
-                            Connect a channel below to start publishing
+                            {t("channels.connectPrompt")}
                         </p>
                     </div>
                 ) : (
@@ -197,24 +216,32 @@ export default function ChannelsPage() {
                                     </div>
                                     <div>
                                         <p className="font-medium text-gray-900 dark:text-white">
-                                            {PLATFORM_NAMES[channel.platform] ||
-                                                channel.platform}
-                                        </p>
-                                        <p className="text-sm text-gray-600 dark:text-gray-400">
                                             {channel.accountName}
+                                        </p>
+                                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                                            {t("channels.onPlatform", {
+                                                platform:
+                                                    ALL_PLATFORMS.find(
+                                                        p =>
+                                                            p.id ===
+                                                            channel.platform
+                                                    )?.name || channel.platform,
+                                            })}
                                         </p>
                                         {channel.connectedAt && (
                                             <p className="text-xs text-gray-500 dark:text-gray-500">
-                                                Connected{" "}
-                                                {new Date(
-                                                    channel.connectedAt
-                                                ).toLocaleDateString()}
+                                                {t("channels.connectedSince", {
+                                                    date: new Date(
+                                                        channel.connectedAt
+                                                    ).toLocaleDateString(),
+                                                })}
                                             </p>
                                         )}
                                         {channel.needsReconnect && (
                                             <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                                                Reconnect required for new
-                                                features
+                                                {t(
+                                                    "channels.reconnectRequired"
+                                                )}
                                             </p>
                                         )}
                                     </div>
@@ -228,8 +255,8 @@ export default function ChannelsPage() {
                                         }`}
                                     >
                                         {channel.needsReconnect
-                                            ? "Update needed"
-                                            : "Connected"}
+                                            ? t("channels.updateNeeded")
+                                            : t("channels.connectedStatus")}
                                     </span>
                                     <Button
                                         size="sm"
@@ -244,7 +271,7 @@ export default function ChannelsPage() {
                                     >
                                         {disconnectingId === channel.id
                                             ? "..."
-                                            : "Disconnect"}
+                                            : t("channels.disconnect")}
                                     </Button>
                                 </div>
                             </div>
@@ -253,49 +280,89 @@ export default function ChannelsPage() {
                 )}
             </section>
 
-            {/* Available Channels */}
+            {/* Available Platforms — ALL platforms always visible */}
             <section>
-                <h2 className="text-lg font-semibold text-gray-900 mb-4 dark:text-white">
-                    Available Channels
-                </h2>
+                <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                        {t("channels.available")}
+                    </h2>
+                </div>
                 <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                    {Object.entries(PLATFORM_NAMES).map(([platform, name]) => {
-                        const isConnected = connectedChannels.some(
-                            c => c.platform === platform
-                        )
-                        if (isConnected) return null
+                    {ALL_PLATFORMS.map(platform => {
+                        const connectedList =
+                            platformConnectedChannels[platform.id] || []
+                        const hasConnected = connectedList.length > 0
+
                         return (
                             <div
-                                key={platform}
-                                className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900"
+                                key={platform.id}
+                                className="flex flex-col rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900"
                             >
-                                <div className="flex items-center gap-3">
-                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800">
-                                        <DynamicIcon
-                                            name={
-                                                PLATFORM_ICONS[platform] as any
-                                            }
-                                            size={24}
-                                        />
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-3">
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800">
+                                            <DynamicIcon
+                                                name={
+                                                    PLATFORM_ICONS[
+                                                        platform.id
+                                                    ] as any
+                                                }
+                                                size={24}
+                                            />
+                                        </div>
+                                        <div>
+                                            <p className="font-medium text-gray-900 dark:text-white">
+                                                {platform.name}
+                                            </p>
+                                            {!platform.implemented && (
+                                                <Badge
+                                                    variant="secondary"
+                                                    className="mt-0.5 text-xs"
+                                                >
+                                                    {t(
+                                                        "channels.notImplemented"
+                                                    )}
+                                                </Badge>
+                                            )}
+                                        </div>
                                     </div>
-                                    <div>
-                                        <p className="font-medium text-gray-900 dark:text-white">
-                                            {name}
-                                        </p>
-                                        <p className="text-sm text-gray-500 dark:text-gray-400">
-                                            Not connected
-                                        </p>
-                                    </div>
+                                    <Button
+                                        size="sm"
+                                        disabled={
+                                            connectingPlatform === platform.id
+                                        }
+                                        onClick={() =>
+                                            handleConnect(platform.id)
+                                        }
+                                    >
+                                        {connectingPlatform === platform.id
+                                            ? "..."
+                                            : hasConnected
+                                              ? t("channels.addAnother")
+                                              : t("channels.connect")}
+                                    </Button>
                                 </div>
-                                <Button
-                                    size="sm"
-                                    onClick={() => handleConnect(platform)}
-                                    disabled={connectingPlatform === platform}
-                                >
-                                    {connectingPlatform === platform
-                                        ? "..."
-                                        : "Connect"}
-                                </Button>
+
+                                {/* Show connected accounts for this platform */}
+                                {connectedList.length > 0 && (
+                                    <div className="mt-3 space-y-1.5 border-t border-gray-100 pt-3 dark:border-gray-700">
+                                        {connectedList.map(ch => (
+                                            <div
+                                                key={ch.id}
+                                                className="flex items-center justify-between text-sm"
+                                            >
+                                                <span className="truncate text-gray-700 dark:text-gray-300">
+                                                    {ch.accountName}
+                                                </span>
+                                                <span className="ml-2 flex-shrink-0 text-xs text-green-600">
+                                                    {t(
+                                                        "channels.connectedStatus"
+                                                    )}
+                                                </span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
                             </div>
                         )
                     })}

--- a/src/i18n/de/dashboard.json
+++ b/src/i18n/de/dashboard.json
@@ -317,5 +317,22 @@
         "failedToStartYoutubeLinking": "Fehler beim Starten der YouTube-Verknüpfung",
         "noAuthUrl": "Keine Autorisierungs-URL zurückgegeben",
         "failedToDisconnectYoutube": "Fehler beim Trennen von YouTube"
+    },
+    "channels": {
+        "channels": "Kanäle",
+        "description": "Verwalte alle deine verbundenen Social-Media-Kanäle",
+        "connected": "Verbunden ({count})",
+        "noConnected": "Noch keine Kanäle verbunden",
+        "connectPrompt": "Verbinde unten einen Kanal, um mit dem Veröffentlichen zu beginnen",
+        "onPlatform": "auf {platform}",
+        "connectedSince": "Verbunden seit {date}",
+        "reconnectRequired": "Wiederverbindung für neue Funktionen erforderlich",
+        "updateNeeded": "Aktualisierung erforderlich",
+        "connectedStatus": "Verbunden",
+        "disconnect": "Trennen",
+        "available": "Verfügbare Plattformen",
+        "notImplemented": "Nicht implementiert",
+        "addAnother": "Weiteren hinzufügen",
+        "connect": "Verbinden"
     }
 }

--- a/src/i18n/en/dashboard.json
+++ b/src/i18n/en/dashboard.json
@@ -317,5 +317,22 @@
         "failedToStartYoutubeLinking": "Failed to start YouTube linking",
         "noAuthUrl": "No authorization URL returned",
         "failedToDisconnectYoutube": "Failed to disconnect YouTube"
+    },
+    "channels": {
+        "channels": "Channels",
+        "description": "Manage all your connected social media channels",
+        "connected": "Connected ({count})",
+        "noConnected": "No channels connected yet",
+        "connectPrompt": "Connect a channel below to start publishing",
+        "onPlatform": "on {platform}",
+        "connectedSince": "Connected {date}",
+        "reconnectRequired": "Reconnect required for new features",
+        "updateNeeded": "Update needed",
+        "connectedStatus": "Connected",
+        "disconnect": "Disconnect",
+        "available": "Available Platforms",
+        "notImplemented": "Not implemented",
+        "addAnother": "Add Another",
+        "connect": "Connect"
     }
 }

--- a/src/i18n/es/dashboard.json
+++ b/src/i18n/es/dashboard.json
@@ -317,5 +317,22 @@
         "failedToStartYoutubeLinking": "Error al iniciar vinculación de YouTube",
         "noAuthUrl": "No se devolvió ninguna URL de autorización",
         "failedToDisconnectYoutube": "Error al desconectar YouTube"
+    },
+    "channels": {
+        "channels": "Canales",
+        "description": "Administra todos tus canales de redes sociales conectados",
+        "connected": "Conectados ({count})",
+        "noConnected": "Ningún canal conectado todavía",
+        "connectPrompt": "Conecta un canal a continuación para empezar a publicar",
+        "onPlatform": "en {platform}",
+        "connectedSince": "Conectado desde {date}",
+        "reconnectRequired": "Reconexión necesaria para nuevas funciones",
+        "updateNeeded": "Actualización necesaria",
+        "connectedStatus": "Conectado",
+        "disconnect": "Desconectar",
+        "available": "Plataformas Disponibles",
+        "notImplemented": "No implementado",
+        "addAnother": "Añadir Otro",
+        "connect": "Conectar"
     }
 }

--- a/src/i18n/pt-BR/dashboard.json
+++ b/src/i18n/pt-BR/dashboard.json
@@ -318,5 +318,22 @@
         "failedToStartYoutubeLinking": "Falha ao iniciar vinculação do YouTube",
         "noAuthUrl": "Nenhuma URL de autorização retornada",
         "failedToDisconnectYoutube": "Falha ao desconectar YouTube"
+    },
+    "channels": {
+        "channels": "Canais",
+        "description": "Gerencie todos os seus canais de mídia social conectados",
+        "connected": "Conectados ({count})",
+        "noConnected": "Nenhum canal conectado ainda",
+        "connectPrompt": "Conecte um canal abaixo para começar a publicar",
+        "onPlatform": "no {platform}",
+        "connectedSince": "Conectado desde {date}",
+        "reconnectRequired": "Reconexão necessária para novos recursos",
+        "updateNeeded": "Atualização necessária",
+        "connectedStatus": "Conectado",
+        "disconnect": "Desconectar",
+        "available": "Plataformas Disponíveis",
+        "notImplemented": "Não implementado",
+        "addAnother": "Adicionar Outro",
+        "connect": "Conectar"
     }
 }

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -9,9 +9,11 @@ import {
     FaLinkedin,
     FaTiktok,
     FaTwitter,
+    FaTwitch,
     FaYoutube,
 } from "react-icons/fa"
 import { SiKick } from "react-icons/si"
+import { MdLiveTv, MdVideocam } from "react-icons/md"
 
 export type IconName =
     | keyof typeof LucideIcons
@@ -25,6 +27,9 @@ export type IconName =
     | "TikTok"
     | "Linkedin"
     | "Kick"
+    | "Twitch"
+    | "Trovo"
+    | "Kwai"
 
 export const getIconByName = (name: IconName): LucideIcon | IconType => {
     // Handle special cases first
@@ -38,6 +43,9 @@ export const getIconByName = (name: IconName): LucideIcon | IconType => {
     if (name === "TikTok") return FaTiktok
     if (name === "Linkedin") return FaLinkedin
     if (name === "Kick") return SiKick
+    if (name === "Twitch") return FaTwitch
+    if (name === "Trovo") return MdLiveTv
+    if (name === "Kwai") return MdVideocam
 
     // Handle Lucide icons
     return LucideIcons[name as keyof typeof LucideIcons] as LucideIcon


### PR DESCRIPTION
﻿## Problems Fixed

### 1. Channels page not translating
All text was hardcoded in English. Added `channels.*` i18n keys to all 4 locales and updated the page to use `useTranslations("dashboard")`.

### 2. Could not add more channels from same platform
Available platforms section was hiding already-connected platforms (`if (isConnected) return null`). Now shows ALL platforms always, with:
- "Connect" button for not-connected platforms
- "Add Another" button for already-connected platforms
- Connected accounts listed under each platform card

### 3. Missing platform indicator
Added `implemented: boolean` field to platform list. Not-implemented platforms show a "Not implemented" badge.

### 4. New platforms added
Added Twitch, Trovo, Kwai to the platform list with icons.
