### PR TITLE
fix: allow multiple YouTube channels per account

### DIFF
--- a/src/app/api/oauth/callback/[platform]/route.ts
+++ b/src/app/api/oauth/callback/[platform]/route.ts
@@ -169,18 +169,21 @@ export async function GET(
                 )
                 if (channelResponse.ok) {
                     const channelData = await channelResponse.json()
-                    const channel = channelData?.items?.[0]?.snippet
-                    if (channel) {
+                    const items = channelData?.items || []
+                    // Loop through ALL channels from the API (personal + brand accounts)
+                    for (const item of items) {
+                        const channel = item.snippet
+                        if (!channel) continue
                         await supabase.from("social_networks").upsert(
                             {
                                 user_id: userId,
                                 platform: "youtube",
-                                platform_user_id: channelData.items[0].id,
+                                platform_user_id: item.id,
                                 platform_username: channel.title,
                                 status: "connected",
                                 linked_at: new Date().toISOString(),
                                 metadata: {
-                                    channelId: channelData.items[0].id,
+                                    channelId: item.id,
                                     channelTitle: channel.title,
                                     channelDescription: channel.description,
                                     customUrl: channel.customUrl,
@@ -190,7 +193,21 @@ export async function GET(
                                 },
                                 updated_at: new Date().toISOString(),
                             },
-                            { onConflict: "user_id, platform" }
+                            {
+                                onConflict:
+                                    "user_id, platform, platform_user_id",
+                            }
+                        )
+                        logger.info("YouTube channel saved", {
+                            channelId: item.id,
+                            channelTitle: channel.title,
+                        })
+                    }
+
+                    if (items.length === 0) {
+                        logger.warn(
+                            "YouTube API returned no channels for authenticated user",
+                            { userId }
                         )
                     }
                 }
@@ -209,7 +226,9 @@ export async function GET(
                         },
                         updated_at: new Date().toISOString(),
                     },
-                    { onConflict: "user_id, platform" }
+                    {
+                        onConflict: "user_id, platform, platform_user_id",
+                    }
                 )
             }
         } catch (socialError) {

--- a/supabase/migrations/20260702_fix_production_schema.sql
+++ b/supabase/migrations/20260702_fix_production_schema.sql
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS public.social_networks (
   metadata JSONB DEFAULT '{}',
   created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
   updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
-  UNIQUE(user_id, platform)
+  UNIQUE(user_id, platform, platform_user_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_social_networks_user_id ON public.social_networks(user_id);


### PR DESCRIPTION
﻿## Problem

Connecting a second YouTube channel REPLACES the existing one instead of adding it.

## Root Cause

The `social_networks` table had `UNIQUE(user_id, platform)` constraint, allowing only ONE row per platform per user. The OAuth callback only handled the first channel from the YouTube API (`items[0]`).

## Fixes

### Database (applied via Supabase MCP)
- Dropped `UNIQUE(user_id, platform)` 
- Added `UNIQUE(user_id, platform, platform_user_id)` — allows multiple channels on same platform as long as they have different channel IDs
- Updated `supabase/migrations/20260702_fix_production_schema.sql`

### OAuth Callback (`/api/oauth/callback/[platform]/route.ts`)
- Changed from handling only `items[0]` to looping through ALL channels returned by the YouTube API
- Each channel gets its own row in social_networks
- Updated `onConflict` to use the new compound unique key
- Added logging for each saved channel
