### PR TITLE
feat: add content-type selection (Post vs Video) as first wizard step

### DIFF
--- a/src/components/publish/wizard/ContentFormStep.tsx
+++ b/src/components/publish/wizard/ContentFormStep.tsx
@@ -15,7 +15,14 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { useTranslations } from "next-intl"
 import { SiYoutube } from "@icons-pack/react-simple-icons"
-import { Upload, FileVideo, Image, AlertCircle, X } from "lucide-react"
+import {
+    Upload,
+    FileVideo,
+    Image,
+    AlertCircle,
+    X,
+    FileImage,
+} from "lucide-react"
 import { useCallback, useRef, useState } from "react"
 import type {
     PublishWizardState,
@@ -63,8 +70,13 @@ export default function ContentFormStep({
     const t = useTranslations("publish")
     const fileInputRef = useRef<HTMLInputElement>(null)
     const imageInputRef = useRef<HTMLInputElement>(null)
+    const thumbnailInputRef = useRef<HTMLInputElement>(null)
     const [dragOver, setDragOver] = useState(false)
+    const [thumbnailDragOver, setThumbnailDragOver] = useState(false)
     const [errors, setErrors] = useState<StepError>({})
+
+    const isVideo = state.contentType === "video"
+    const isPost = state.contentType === "post"
 
     // Determine which platforms are selected
     const selectedPlatformIds = state.platformSelections.map(s => s.platformId)
@@ -87,12 +99,21 @@ export default function ContentFormStep({
     const validate = (): boolean => {
         const errs: StepError = {}
 
-        // Universal: video required if any video-capable platform selected
-        if (hasYouTube && !state.content.videoFile) {
+        // Video content type: required video file
+        if (isVideo && !state.content.videoFile) {
             errs.videoFile = t("step4.fileRequired")
         }
 
-        // YouTube: title required
+        // Post content type: needs at least text or images
+        if (
+            isPost &&
+            !state.content.text.trim() &&
+            state.content.images.length === 0
+        ) {
+            errs.text = t("step4.textRequired")
+        }
+
+        // YouTube: title required when YouTube is selected
         if (hasYouTube && !youtubeMeta.title.trim()) {
             errs.youtube_title = t("step4.titleRequired")
         }
@@ -155,6 +176,35 @@ export default function ContentFormStep({
         [state, onStateChange]
     )
 
+    // Thumbnail file handlers
+    const handleThumbnailDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault()
+            setThumbnailDragOver(false)
+            const file = e.dataTransfer.files?.[0]
+            if (file && file.type.startsWith("image/")) {
+                onStateChange({
+                    ...state,
+                    content: { ...state.content, thumbnailFile: file },
+                })
+            }
+        },
+        [state, onStateChange]
+    )
+
+    const handleThumbnailChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0]
+            if (file && file.type.startsWith("image/")) {
+                onStateChange({
+                    ...state,
+                    content: { ...state.content, thumbnailFile: file },
+                })
+            }
+        },
+        [state, onStateChange]
+    )
+
     // Image upload handlers
     const handleImageUpload = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -206,21 +256,34 @@ export default function ContentFormStep({
                 </p>
             </div>
 
-            {/* ── UNIVERSAL SECTION: Text Content ── */}
+            {/* ── UNIVERSAL SECTION ── */}
             <Card>
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-lg">
-                        <Image className="h-5 w-5" />
-                        Conteúdo Universal
+                        {isVideo ? (
+                            <FileVideo className="h-5 w-5" />
+                        ) : (
+                            <Image className="h-5 w-5" />
+                        )}
+                        {isVideo
+                            ? t("step4.contentVideo")
+                            : t("step4.contentPost")}
                         <Badge variant="outline" className="ml-auto text-xs">
-                            Todas as plataformas
+                            {t("step4.allPlatforms")}
                         </Badge>
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                    {/* Text */}
+                    {/* Text — always shown */}
                     <div className="space-y-2">
-                        <Label htmlFor="universal-text">Texto</Label>
+                        <Label htmlFor="universal-text">
+                            {t("step4.text")}
+                            {isPost && !state.content.images.length && (
+                                <span className="ml-2 text-xs text-red-500">
+                                    *
+                                </span>
+                            )}
+                        </Label>
                         <Textarea
                             id="universal-text"
                             value={state.content.text}
@@ -233,130 +296,218 @@ export default function ContentFormStep({
                                     },
                                 })
                             }
-                            placeholder="Escreva seu conteúdo..."
+                            placeholder={
+                                isVideo
+                                    ? t("step4.textVideoPlaceholder")
+                                    : t("step4.textPostPlaceholder")
+                            }
                             className="min-h-20 resize-none"
                         />
-                    </div>
-
-                    {/* Images */}
-                    <div className="space-y-2">
-                        <Label>Imagens</Label>
-                        <Input
-                            type="file"
-                            multiple
-                            accept="image/*"
-                            ref={imageInputRef}
-                            onChange={handleImageUpload}
-                            className="cursor-pointer"
-                        />
-                        {state.content.images.length > 0 && (
-                            <div className="grid grid-cols-4 gap-2 mt-2">
-                                {state.content.images.map((img, idx) => (
-                                    <div key={idx} className="relative">
-                                        <img
-                                            src={URL.createObjectURL(img)}
-                                            alt={`Upload ${idx + 1}`}
-                                            className="h-16 w-full rounded object-cover"
-                                        />
-                                        <button
-                                            onClick={() => removeImage(idx)}
-                                            className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white hover:bg-red-600"
-                                        >
-                                            <X className="h-3 w-3" />
-                                        </button>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
-
-                    {/* Video file (universal, but required if YouTube selected) */}
-                    <div className="space-y-2">
-                        <Label>
-                            Arquivo de Vídeo
-                            {hasYouTube && (
-                                <span className="ml-2 text-xs text-red-500">
-                                    * obrigatório para YouTube
-                                </span>
-                            )}
-                        </Label>
-                        {!state.content.videoFile ? (
-                            <div
-                                onDragOver={e => {
-                                    e.preventDefault()
-                                    setDragOver(true)
-                                }}
-                                onDragLeave={() => setDragOver(false)}
-                                onDrop={handleVideoDrop}
-                                onClick={() => fileInputRef.current?.click()}
-                                className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-6 transition-colors ${
-                                    dragOver
-                                        ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
-                                        : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
-                                }`}
-                            >
-                                <Upload className="h-8 w-8 text-gray-400" />
-                                <p className="text-sm text-gray-600 dark:text-gray-400">
-                                    {t("step4.dropzone")}
-                                </p>
-                                <p className="text-xs text-gray-400">
-                                    {t("step4.maxSize")}
-                                </p>
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={e => {
-                                        e.stopPropagation()
-                                        fileInputRef.current?.click()
-                                    }}
-                                >
-                                    {t("step4.browse")}
-                                </Button>
-                            </div>
-                        ) : (
-                            <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
-                                <FileVideo className="h-6 w-6 text-blue-500" />
-                                <div className="flex-1 min-w-0">
-                                    <p className="text-sm font-medium truncate">
-                                        {state.content.videoFile.name}
-                                    </p>
-                                    <p className="text-xs text-gray-500">
-                                        {formatBytes(
-                                            state.content.videoFile.size
-                                        )}
-                                    </p>
-                                </div>
-                                <button
-                                    onClick={() =>
-                                        onStateChange({
-                                            ...state,
-                                            content: {
-                                                ...state.content,
-                                                videoFile: null,
-                                            },
-                                        })
-                                    }
-                                    className="rounded-full p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-                                >
-                                    <X className="h-4 w-4" />
-                                </button>
-                            </div>
-                        )}
-                        <input
-                            ref={fileInputRef}
-                            type="file"
-                            accept="video/*"
-                            className="hidden"
-                            onChange={handleVideoChange}
-                        />
-                        {errors.videoFile && (
+                        {errors.text && (
                             <p className="flex items-center gap-1 text-xs text-red-500">
                                 <AlertCircle className="h-3 w-3" />
-                                {errors.videoFile}
+                                {errors.text}
                             </p>
                         )}
                     </div>
+
+                    {/* Images — only for Post content type */}
+                    {isPost && (
+                        <div className="space-y-2">
+                            <Label>{t("step4.images")}</Label>
+                            <Input
+                                type="file"
+                                multiple
+                                accept="image/*"
+                                ref={imageInputRef}
+                                onChange={handleImageUpload}
+                                className="cursor-pointer"
+                            />
+                            {state.content.images.length > 0 && (
+                                <div className="grid grid-cols-4 gap-2 mt-2">
+                                    {state.content.images.map((img, idx) => (
+                                        <div key={idx} className="relative">
+                                            <img
+                                                src={URL.createObjectURL(img)}
+                                                alt={`Upload ${idx + 1}`}
+                                                className="h-16 w-full rounded object-cover"
+                                            />
+                                            <button
+                                                onClick={() => removeImage(idx)}
+                                                className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white hover:bg-red-600"
+                                            >
+                                                <X className="h-3 w-3" />
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Video file — only for Video content type */}
+                    {isVideo && (
+                        <div className="space-y-2">
+                            <Label>
+                                {t("step4.videoFile")}
+                                <span className="ml-2 text-xs text-red-500">
+                                    *
+                                </span>
+                            </Label>
+                            {!state.content.videoFile ? (
+                                <div
+                                    onDragOver={e => {
+                                        e.preventDefault()
+                                        setDragOver(true)
+                                    }}
+                                    onDragLeave={() => setDragOver(false)}
+                                    onDrop={handleVideoDrop}
+                                    onClick={() =>
+                                        fileInputRef.current?.click()
+                                    }
+                                    className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-6 transition-colors ${
+                                        dragOver
+                                            ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                            : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                                    }`}
+                                >
+                                    <Upload className="h-8 w-8 text-gray-400" />
+                                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                                        {t("step4.dropzone")}
+                                    </p>
+                                    <p className="text-xs text-gray-400">
+                                        {t("step4.maxSize")}
+                                    </p>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={e => {
+                                            e.stopPropagation()
+                                            fileInputRef.current?.click()
+                                        }}
+                                    >
+                                        {t("step4.browse")}
+                                    </Button>
+                                </div>
+                            ) : (
+                                <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
+                                    <FileVideo className="h-6 w-6 text-blue-500" />
+                                    <div className="flex-1 min-w-0">
+                                        <p className="text-sm font-medium truncate">
+                                            {state.content.videoFile.name}
+                                        </p>
+                                        <p className="text-xs text-gray-500">
+                                            {formatBytes(
+                                                state.content.videoFile.size
+                                            )}
+                                        </p>
+                                    </div>
+                                    <button
+                                        onClick={() =>
+                                            onStateChange({
+                                                ...state,
+                                                content: {
+                                                    ...state.content,
+                                                    videoFile: null,
+                                                },
+                                            })
+                                        }
+                                        className="rounded-full p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </button>
+                                </div>
+                            )}
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept="video/*"
+                                className="hidden"
+                                onChange={handleVideoChange}
+                            />
+                            {errors.videoFile && (
+                                <p className="flex items-center gap-1 text-xs text-red-500">
+                                    <AlertCircle className="h-3 w-3" />
+                                    {errors.videoFile}
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Thumbnail — only for Video content type */}
+                    {isVideo && (
+                        <div className="space-y-2">
+                            <Label>{t("step4.thumbnail")}</Label>
+                            {!state.content.thumbnailFile ? (
+                                <div
+                                    onDragOver={e => {
+                                        e.preventDefault()
+                                        setThumbnailDragOver(true)
+                                    }}
+                                    onDragLeave={() =>
+                                        setThumbnailDragOver(false)
+                                    }
+                                    onDrop={handleThumbnailDrop}
+                                    onClick={() =>
+                                        thumbnailInputRef.current?.click()
+                                    }
+                                    className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-4 transition-colors ${
+                                        thumbnailDragOver
+                                            ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                            : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                                    }`}
+                                >
+                                    <FileImage className="h-6 w-6 text-gray-400" />
+                                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                                        {t("step4.thumbnailHint")}
+                                    </p>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={e => {
+                                            e.stopPropagation()
+                                            thumbnailInputRef.current?.click()
+                                        }}
+                                    >
+                                        {t("step4.browseImage")}
+                                    </Button>
+                                </div>
+                            ) : (
+                                <div className="relative">
+                                    <img
+                                        src={URL.createObjectURL(
+                                            state.content.thumbnailFile
+                                        )}
+                                        alt="Thumbnail preview"
+                                        className="h-32 w-full rounded-lg object-cover"
+                                    />
+                                    <button
+                                        onClick={() =>
+                                            onStateChange({
+                                                ...state,
+                                                content: {
+                                                    ...state.content,
+                                                    thumbnailFile: null,
+                                                },
+                                            })
+                                        }
+                                        className="absolute right-2 top-2 rounded-full bg-red-500 p-1 text-white hover:bg-red-600"
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </button>
+                                </div>
+                            )}
+                            <input
+                                ref={thumbnailInputRef}
+                                type="file"
+                                accept="image/*"
+                                className="hidden"
+                                onChange={handleThumbnailChange}
+                            />
+                        </div>
+                    )}
                 </CardContent>
             </Card>
 
@@ -370,7 +521,7 @@ export default function ContentFormStep({
                         <CardHeader>
                             <CardTitle className="flex items-center gap-2 text-lg">
                                 <SiYoutube className="h-5 w-5 text-red-600" />
-                                Informações Básicas
+                                {t("step4.basicInfo")}
                                 <Badge
                                     variant="secondary"
                                     className="ml-auto text-xs"
@@ -445,7 +596,9 @@ export default function ContentFormStep({
                             </div>
 
                             <div className="rounded bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-900">
-                                {t("step4.thumbnailHint")}
+                                {isVideo
+                                    ? t("step4.thumbnailUploaded")
+                                    : t("step4.thumbnailHint")}
                             </div>
 
                             <div className="space-y-2">

--- a/src/components/publish/wizard/ContentTypeSelect.tsx
+++ b/src/components/publish/wizard/ContentTypeSelect.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { FileVideo, Newspaper } from "lucide-react"
+import type { ContentType } from "./types"
+
+interface ContentTypeSelectProps {
+    selectedType: ContentType
+    onSelect: (type: ContentType) => void
+    onNext: () => void
+}
+
+const CONTENT_TYPES: {
+    id: ContentType
+    labelKey: string
+    descKey: string
+    icon: React.ReactNode
+}[] = [
+    {
+        id: "post",
+        labelKey: "contentType.post.label",
+        descKey: "contentType.post.description",
+        icon: <Newspaper className="h-8 w-8" />,
+    },
+    {
+        id: "video",
+        labelKey: "contentType.video.label",
+        descKey: "contentType.video.description",
+        icon: <FileVideo className="h-8 w-8" />,
+    },
+]
+
+export default function ContentTypeSelect({
+    selectedType,
+    onSelect,
+    onNext,
+}: ContentTypeSelectProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-xl font-semibold">
+                    {t("contentType.title")}
+                </h2>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {t("contentType.description")}
+                </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+                {CONTENT_TYPES.map(ct => {
+                    const isSelected = selectedType === ct.id
+                    return (
+                        <button
+                            key={ct.id}
+                            type="button"
+                            onClick={() => onSelect(ct.id)}
+                            className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 text-center transition-all ${
+                                isSelected
+                                    ? "border-blue-500 bg-blue-50 ring-2 ring-blue-200 dark:border-blue-400 dark:bg-blue-950/20"
+                                    : "border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
+                            }`}
+                        >
+                            <div
+                                className={`flex h-16 w-16 items-center justify-center rounded-full ${
+                                    isSelected
+                                        ? "bg-blue-100 text-blue-600 dark:bg-blue-900/50 dark:text-blue-400"
+                                        : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                                }`}
+                            >
+                                {ct.icon}
+                            </div>
+                            <div>
+                                <p
+                                    className={`text-lg font-semibold ${
+                                        isSelected
+                                            ? "text-blue-700 dark:text-blue-300"
+                                            : "text-gray-900 dark:text-white"
+                                    }`}
+                                >
+                                    {t(ct.labelKey)}
+                                </p>
+                                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    {t(ct.descKey)}
+                                </p>
+                            </div>
+                        </button>
+                    )
+                })}
+            </div>
+
+            <div className="flex justify-end border-t pt-4 dark:border-gray-700">
+                <button
+                    type="button"
+                    onClick={onNext}
+                    className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                    {t("wizard.next")}
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/publish/wizard/NetworkSelectStep.tsx
+++ b/src/components/publish/wizard/NetworkSelectStep.tsx
@@ -12,12 +12,14 @@ import {
 import { FaLinkedin } from "react-icons/fa6"
 import { useTranslations } from "next-intl"
 import { CheckCircle, Lock, XCircle, AlertCircle } from "lucide-react"
-import type { PlatformInfo } from "./types"
+import type { PlatformInfo, ContentType } from "./types"
+import { CONTENT_TYPE_PLATFORMS } from "./types"
 
 interface NetworkSelectStepProps {
     selectedPlatforms: string[]
     onPlatformsChange: (platforms: string[]) => void
     onNext: () => void
+    contentType: ContentType
 }
 
 const NETWORKS: PlatformInfo[] = [
@@ -85,8 +87,13 @@ export default function NetworkSelectStep({
     selectedPlatforms,
     onPlatformsChange,
     onNext,
+    contentType,
 }: NetworkSelectStepProps) {
     const t = useTranslations("publish")
+
+    // Filter platforms by content type compatibility
+    const compatibleIds = CONTENT_TYPE_PLATFORMS[contentType] || []
+    const filteredNetworks = NETWORKS.filter(n => compatibleIds.includes(n.id))
 
     const togglePlatform = (platformId: string) => {
         if (selectedPlatforms.includes(platformId)) {
@@ -117,7 +124,7 @@ export default function NetworkSelectStep({
             </div>
 
             <div className="grid gap-4">
-                {NETWORKS.map(network => {
+                {filteredNetworks.map(network => {
                     const isSelected = selectedPlatforms.includes(network.id)
                     const implemented = network.implemented
 

--- a/src/components/publish/wizard/YouTubePublishWizard.tsx
+++ b/src/components/publish/wizard/YouTubePublishWizard.tsx
@@ -9,6 +9,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog"
 import { X } from "lucide-react"
+import ContentTypeSelect from "./ContentTypeSelect"
 import NetworkSelectStep from "./NetworkSelectStep"
 import ChannelSelectStep from "./ChannelSelectStep"
 import StorageModeStep from "./StorageModeStep"
@@ -18,6 +19,7 @@ import type {
     PublishWizardState,
     PlatformSelection,
     PlatformResult,
+    ContentType,
 } from "./types"
 import { INITIAL_STATE, DEFAULT_YOUTUBE_METADATA } from "./types"
 
@@ -26,10 +28,11 @@ interface YouTubePublishWizardProps {
     defaultDate?: Date
 }
 
-type WizardStep = 1 | 2 | 3 | 4 | 5
+type WizardStep = 0 | 1 | 2 | 3 | 4 | 5
 
 /** Map step index to step key for dynamic titles */
 const STEP_TITLE_KEYS: Record<number, string> = {
+    0: "contentType.title",
     1: "step1.title",
     2: "step2.title",
     3: "step3.title",
@@ -43,7 +46,7 @@ export default function YouTubePublishWizard({
     const t = useTranslations("publish")
 
     // Wizard state
-    const [currentStep, setCurrentStep] = useState<WizardStep>(1)
+    const [currentStep, setCurrentStep] = useState<WizardStep>(0)
     const [wizardState, setWizardState] =
         useState<PublishWizardState>(INITIAL_STATE)
 
@@ -52,9 +55,17 @@ export default function YouTubePublishWizard({
         s => s.platformId
     )
 
+    // Step 0: Content type selection
+    const handleContentTypeChange = (type: ContentType) => {
+        // Reset platforms when content type changes
+        setWizardState({
+            ...INITIAL_STATE,
+            contentType: type,
+        })
+    }
+
     // Step 1: Network selection
     const handlePlatformsChange = (platforms: string[]) => {
-        // Convert string[] to PlatformSelection[], preserving existing channel selections
         const existing = wizardState.platformSelections
         const updated: PlatformSelection[] = platforms.map(id => {
             const found = existing.find(e => e.platformId === id)
@@ -70,7 +81,7 @@ export default function YouTubePublishWizard({
             delete metadata[id]
         }
 
-        // Add default YouTube metadata if YouTube is selected and doesn't have it yet
+        // Add default YouTube metadata if YouTube is selected
         if (platforms.includes("youtube") && !metadata.youtube) {
             metadata.youtube = { ...DEFAULT_YOUTUBE_METADATA }
         }
@@ -97,7 +108,10 @@ export default function YouTubePublishWizard({
         for (const sel of wizardState.platformSelections) {
             const platformId = sel.platformId
 
-            if (platformId === "youtube") {
+            if (
+                platformId === "youtube" &&
+                wizardState.contentType === "video"
+            ) {
                 // Upload video to YouTube
                 setWizardState(prev => ({
                     ...prev,
@@ -167,6 +181,14 @@ export default function YouTubePublishWizard({
                         formData.append("linkedVideoEnd", meta.linkedVideoEnd)
                     }
 
+                    // Attach thumbnail if provided
+                    if (wizardState.content.thumbnailFile) {
+                        formData.append(
+                            "thumbnail",
+                            wizardState.content.thumbnailFile
+                        )
+                    }
+
                     // Update progress
                     setWizardState(prev => ({
                         ...prev,
@@ -207,7 +229,6 @@ export default function YouTubePublishWizard({
                         },
                     }))
 
-                    // Small delay for UX
                     await new Promise(r => setTimeout(r, 500))
 
                     const result = await res.json()
@@ -228,7 +249,7 @@ export default function YouTubePublishWizard({
                     })
                 }
             } else {
-                // Future: handle Facebook, Instagram, etc.
+                // Future: handle other platforms and post type
                 results.push({
                     platformId,
                     success: false,
@@ -280,7 +301,7 @@ export default function YouTubePublishWizard({
         setCurrentStep(4)
     }
 
-    // Step titles (dynamic based on selected platforms)
+    // Step titles
     const getStepTitle = (step: number): string => {
         const key = STEP_TITLE_KEYS[step]
         if (!key) return ""
@@ -289,13 +310,21 @@ export default function YouTubePublishWizard({
 
     const renderStep = () => {
         switch (currentStep) {
+            case 0:
+                return (
+                    <ContentTypeSelect
+                        selectedType={wizardState.contentType}
+                        onSelect={handleContentTypeChange}
+                        onNext={() => setCurrentStep(1)}
+                    />
+                )
             case 1:
                 return (
                     <NetworkSelectStep
                         selectedPlatforms={selectedPlatformIds}
                         onPlatformsChange={handlePlatformsChange}
+                        contentType={wizardState.contentType}
                         onNext={() => {
-                            // Skip Step 2 if no platform needs channel selection
                             const needsChannels =
                                 wizardState.platformSelections.some(s =>
                                     ["youtube", "facebook"].includes(
@@ -346,8 +375,9 @@ export default function YouTubePublishWizard({
         }
     }
 
-    const totalSteps = 5
-    const progressSteps = [1, 2, 3, 4]
+    // Show first 5 steps in progress bar (0-4), skip step 5 (processing)
+    const progressSteps = [0, 1, 2, 3, 4]
+    const totalSteps = 6
 
     return (
         <Dialog open={true} onOpenChange={onClose}>
@@ -355,10 +385,10 @@ export default function YouTubePublishWizard({
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <span>{t("wizard.title")}</span>
-                        {currentStep <= totalSteps && (
+                        {currentStep < totalSteps && (
                             <span className="text-sm font-normal text-gray-500">
                                 {t("wizard.step", {
-                                    current: currentStep,
+                                    current: currentStep + 1,
                                     total: totalSteps,
                                 })}
                             </span>

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -1,3 +1,32 @@
+/** Content type: Post (text+images) or Video (video+thumbnail) */
+export type ContentType = "post" | "video"
+
+/** Platforms that support each content type */
+export const CONTENT_TYPE_PLATFORMS: Record<ContentType, string[]> = {
+    post: [
+        "youtube",
+        "facebook",
+        "instagram",
+        "twitter",
+        "linkedin",
+        "tiktok",
+        "kick",
+        "twitch",
+        "trovo",
+        "kwai",
+    ],
+    video: [
+        "youtube",
+        "facebook",
+        "instagram",
+        "tiktok",
+        "kick",
+        "twitch",
+        "trovo",
+        "kwai",
+    ],
+}
+
 /** Platform definition */
 export interface PlatformInfo {
     id: string
@@ -27,6 +56,9 @@ export type PlatformFeature =
 
 /** All data collected across wizard steps */
 export interface PublishWizardState {
+    /** Content type: Post (text+images) or Video (video+thumbnail) */
+    contentType: ContentType
+
     /** Selected platforms with their channel selections */
     platformSelections: PlatformSelection[]
 
@@ -38,6 +70,7 @@ export interface PublishWizardState {
         text: string
         images: File[]
         videoFile: File | null
+        thumbnailFile: File | null
     }
 
     /** Platform-specific metadata, keyed by platform id */
@@ -117,12 +150,14 @@ export const DEFAULT_YOUTUBE_METADATA: YouTubeMetadata = {
 }
 
 export const INITIAL_STATE: PublishWizardState = {
+    contentType: "post",
     platformSelections: [],
     storageMode: "local",
     content: {
         text: "",
         images: [],
         videoFile: null,
+        thumbnailFile: null,
     },
     platformMetadata: {},
     processing: { status: "idle" },

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -10,6 +10,18 @@
         "success": "Video erfolgreich veröffentlicht!",
         "error": "Fehler beim Veröffentlichen. Bitte versuche es erneut."
     },
+    "contentType": {
+        "title": "Inhaltstyp",
+        "description": "Wähle den Inhaltstyp, den du veröffentlichen möchtest",
+        "post": {
+            "label": "Beitrag",
+            "description": "Text mit Bildern für soziale Netzwerke"
+        },
+        "video": {
+            "label": "Video",
+            "description": "Video-Upload mit Miniaturansichten und Metadaten"
+        }
+    },
     "step1": {
         "title": "Soziales Netzwerk auswählen",
         "description": "Wähle aus, auf welchem sozialen Netzwerk du veröffentlichen möchtest",
@@ -64,6 +76,16 @@
         "selectedFile": "{name} ({size})",
         "removeFile": "Datei entfernen",
         "fileRequired": "Wähle eine Videodatei aus, um fortzufahren",
+        "allPlatforms": "Alle Plattformen",
+        "contentVideo": "Video-Inhalt",
+        "contentPost": "Beitragsinhalt",
+        "text": "Text",
+        "textVideoPlaceholder": "Gib deine Videobeschreibung ein (plattformübergreifend geteilt)",
+        "textPostPlaceholder": "Gib deinen Beitragstext ein",
+        "textRequired": "Füge Text oder Bilder hinzu, um fortzufahren",
+        "images": "Bilder",
+        "browseImage": "Bild Durchsuchen",
+        "thumbnailUploaded": "Das oben ausgewählte Vorschaubild wird verwendet. Du kannst es nach der Veröffentlichung im YouTube Studio anpassen.",
         "basicInfo": "Basisdaten",
         "title": "Titel",
         "titlePlaceholder": "Gib deinen Videotitel ein",

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -10,6 +10,18 @@
         "success": "Video published successfully!",
         "error": "Error publishing. Please try again."
     },
+    "contentType": {
+        "title": "Content Type",
+        "description": "Choose the type of content you want to publish",
+        "post": {
+            "label": "Post",
+            "description": "Text with images for social networks"
+        },
+        "video": {
+            "label": "Video",
+            "description": "Video upload with thumbnails and metadata"
+        }
+    },
     "step1": {
         "title": "Select Social Network",
         "description": "Choose which social network to publish to",
@@ -64,6 +76,16 @@
         "selectedFile": "{name} ({size})",
         "removeFile": "Remove file",
         "fileRequired": "Select a video file to continue",
+        "allPlatforms": "All platforms",
+        "contentVideo": "Video Content",
+        "contentPost": "Post Content",
+        "text": "Text",
+        "textVideoPlaceholder": "Enter your video description (shared across platforms)",
+        "textPostPlaceholder": "Enter your post text",
+        "textRequired": "Add text or images to continue",
+        "images": "Images",
+        "browseImage": "Browse Image",
+        "thumbnailUploaded": "The thumbnail selected above will be used. You can customize after publishing in YouTube Studio.",
         "basicInfo": "Basic Information",
         "title": "Title",
         "titlePlaceholder": "Enter your video title",

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -10,6 +10,18 @@
         "success": "¡Video publicado con éxito!",
         "error": "Error al publicar. Intenta de nuevo."
     },
+    "contentType": {
+        "title": "Tipo de Contenido",
+        "description": "Elige el tipo de contenido que deseas publicar",
+        "post": {
+            "label": "Publicación",
+            "description": "Texto con imágenes para redes sociales"
+        },
+        "video": {
+            "label": "Video",
+            "description": "Subida de video con miniaturas y metadatos"
+        }
+    },
     "step1": {
         "title": "Seleccionar Red Social",
         "description": "Elige a qué red social deseas publicar",
@@ -64,6 +76,16 @@
         "selectedFile": "{name} ({size})",
         "removeFile": "Eliminar archivo",
         "fileRequired": "Selecciona un archivo de video para continuar",
+        "allPlatforms": "Todas las plataformas",
+        "contentVideo": "Contenido del Video",
+        "contentPost": "Contenido de la Publicación",
+        "text": "Texto",
+        "textVideoPlaceholder": "Ingresa la descripción de tu video (compartida entre plataformas)",
+        "textPostPlaceholder": "Ingresa el texto de tu publicación",
+        "textRequired": "Agrega texto o imágenes para continuar",
+        "images": "Imágenes",
+        "browseImage": "Buscar Imagen",
+        "thumbnailUploaded": "La miniatura seleccionada arriba se utilizará. Puedes personalizar después de publicar en YouTube Studio.",
         "basicInfo": "Información Básica",
         "title": "Título",
         "titlePlaceholder": "Ingresa el título de tu video",

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -10,6 +10,18 @@
         "success": "Vídeo publicado com sucesso!",
         "error": "Erro ao publicar. Tente novamente."
     },
+    "contentType": {
+        "title": "Tipo de Conteúdo",
+        "description": "Escolha o tipo de conteúdo que deseja publicar",
+        "post": {
+            "label": "Post",
+            "description": "Texto com imagens para redes sociais"
+        },
+        "video": {
+            "label": "Vídeo",
+            "description": "Envio de vídeo com miniaturas e metadados"
+        }
+    },
     "step1": {
         "title": "Selecionar Rede Social",
         "description": "Escolha para qual rede social deseja publicar",
@@ -64,6 +76,16 @@
         "selectedFile": "{name} ({size})",
         "removeFile": "Remover arquivo",
         "fileRequired": "Selecione um arquivo de vídeo para continuar",
+        "allPlatforms": "Todas as plataformas",
+        "contentVideo": "Conteúdo do Vídeo",
+        "contentPost": "Conteúdo do Post",
+        "text": "Texto",
+        "textVideoPlaceholder": "Digite a descrição do seu vídeo (compartilhada entre plataformas)",
+        "textPostPlaceholder": "Digite o texto do seu post",
+        "textRequired": "Adicione texto ou imagens para continuar",
+        "images": "Imagens",
+        "browseImage": "Procurar Imagem",
+        "thumbnailUploaded": "A miniatura selecionada acima será usada. Você pode personalizar após a publicação no YouTube Studio.",
         "basicInfo": "Informações Básicas",
         "title": "Título",
         "titlePlaceholder": "Digite o título do seu vídeo",


### PR DESCRIPTION
## Description

Adds a ContentType selection step at the beginning of the publish wizard, allowing users to choose between **Post** (text+images) and **Video** (video+thumbnail) before selecting platforms.

### Changes
- **New** \ContentTypeSelect\ component as wizard Step 0
- **NetworkSelectStep** now filters platforms by content-type compatibility
- **ContentFormStep** shows conditional content sections:
  - Post: text + image upload (no video/thumbnail)
  - Video: text + video upload + thumbnail upload (no images)
- **added** \	humbnailFile\ and \contentType\ to wizard state/types
- **i18n** translations for pt-BR, en, es, de

Closes #138