### PR TITLE
fix: dark mode colors in all settings tabs

### DIFF
--- a/src/components/settings/BillingSection.tsx
+++ b/src/components/settings/BillingSection.tsx
@@ -97,13 +97,13 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
     const getStatusColor = (status: string): string => {
         switch (status) {
             case "paid":
-                return "bg-green-100 text-green-800"
+                return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
             case "pending":
-                return "bg-yellow-100 text-yellow-800"
+                return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
             case "failed":
-                return "bg-red-100 text-red-800"
+                return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
             default:
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
         }
     }
 
@@ -117,22 +117,22 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
                 </CardHeader>
                 <CardContent className="space-y-6">
                     {/* Plan Details */}
-                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-6">
+                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-950/30">
                         <div className="flex items-start justify-between">
                             <div>
-                                <h3 className="text-2xl font-bold text-gray-900">
+                                <h3 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
                                     {t("planValue", { plan: billing.plan }) ||
                                         billing.plan + " " + t("plan")}
                                 </h3>
-                                <p className="mt-2 text-sm text-gray-600">
+                                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                                     {t("youAreOnPlan", { plan: billing.plan })}
                                 </p>
                             </div>
                             <div className="text-right">
-                                <p className="text-3xl font-bold text-gray-900">
+                                <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
                                     {formatCurrency(billing.price)}
                                 </p>
-                                <p className="text-sm text-gray-600">
+                                <p className="text-sm text-gray-600 dark:text-gray-300">
                                     {t("perMonth")}
                                 </p>
                             </div>
@@ -140,10 +140,10 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
 
                         {/* Plan Features */}
                         <div className="mt-6 space-y-2">
-                            <p className="text-sm font-medium text-gray-900">
+                            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                                 {t("planIncludes")}:
                             </p>
-                            <ul className="space-y-1 text-sm text-gray-700">
+                            <ul className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
                                 <li>✓ {t("unlimitedPosts")}</li>
                                 <li>
                                     ✓ {t("connectedChannels", { count: 5 })}
@@ -154,10 +154,10 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
                         </div>
 
                         {/* Next Billing Date */}
-                        <div className="mt-6 border-t border-blue-200 pt-4">
-                            <p className="text-sm text-gray-600">
+                        <div className="mt-6 border-t border-blue-200 pt-4 dark:border-blue-800">
+                            <p className="text-sm text-gray-600 dark:text-gray-300">
                                 {t("nextBillingDate")}
-                                <span className="font-medium text-gray-900">
+                                <span className="font-medium text-gray-900 dark:text-gray-100">
                                     {formatDate(billing.nextBillingDate)}
                                 </span>
                             </p>
@@ -189,17 +189,17 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
                         <div className="overflow-x-auto">
                             <table className="w-full">
                                 <thead>
-                                    <tr className="border-b border-gray-200">
-                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900">
+                                    <tr className="border-b border-gray-200 dark:border-gray-700">
+                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
                                             {t("date")}
                                         </th>
-                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900">
+                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
                                             {t("amount")}
                                         </th>
-                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900">
+                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
                                             {t("status")}
                                         </th>
-                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900">
+                                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
                                             {t("action")}
                                         </th>
                                     </tr>
@@ -208,12 +208,12 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
                                     {billing.invoices.map(invoice => (
                                         <tr
                                             key={invoice.id}
-                                            className="border-b border-gray-100 hover:bg-gray-50"
+                                            className="border-b border-gray-100 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-900/50"
                                         >
-                                            <td className="px-4 py-3 text-sm text-gray-900">
+                                            <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
                                                 {formatDate(invoice.date)}
                                             </td>
-                                            <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                                            <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
                                                 {formatCurrency(invoice.amount)}
                                             </td>
                                             <td className="px-4 py-3">
@@ -254,8 +254,8 @@ export const BillingSection: React.FC<BillingSectionProps> = ({
                             </table>
                         </div>
                     ) : (
-                        <div className="rounded-lg bg-gray-50 p-8 text-center">
-                            <p className="text-sm text-gray-600">
+                        <div className="rounded-lg bg-gray-50 p-8 text-center dark:bg-gray-900/50">
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
                                 {t("noInvoices")}
                             </p>
                         </div>

--- a/src/components/settings/ChannelsSection.tsx
+++ b/src/components/settings/ChannelsSection.tsx
@@ -181,21 +181,21 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
             </CardHeader>
             <CardContent className="space-y-6">
                 {/* YouTube Connect Card */}
-                <div className="rounded-lg border border-gray-200 p-4">
+                <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-3">
                             <DynamicIcon name="Youtube" size={32} />
                             <div>
-                                <p className="font-medium text-gray-900">
+                                <p className="font-medium text-gray-900 dark:text-gray-100">
                                     YouTube
                                 </p>
                                 {youtubeChannel?.isConnected ? (
                                     <>
-                                        <p className="text-sm text-gray-600">
+                                        <p className="text-sm text-gray-600 dark:text-gray-300">
                                             {youtubeChannel.accountName}
                                         </p>
                                         {youtubeChannel.connectedAt && (
-                                            <p className="text-xs text-gray-500">
+                                            <p className="text-xs text-gray-500 dark:text-gray-400">
                                                 {t("youtube.connectedSince")}{" "}
                                                 {new Date(
                                                     youtubeChannel.connectedAt
@@ -203,7 +203,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                             </p>
                                         )}
                                         {youtubeChannel.needsReconnect && (
-                                            <p className="mt-1 text-xs text-amber-600">
+                                            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
                                                 Disconnect and reconnect to
                                                 enable analytics & monetization
                                                 features
@@ -211,7 +211,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                         )}
                                     </>
                                 ) : (
-                                    <p className="text-sm text-gray-500">
+                                    <p className="text-sm text-gray-500 dark:text-gray-400">
                                         {t("youtube.noChannel")}
                                     </p>
                                 )}
@@ -219,12 +219,12 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                         </div>
                         {youtubeChannel?.isConnected ? (
                             <div className="flex items-center gap-2">
-                                <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800">
+                                <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
                                     {t("youtube.connected")}
                                 </span>
                                 {youtubeChannel.needsReconnect && (
                                     <span
-                                        className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800 cursor-help"
+                                        className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800 cursor-help dark:bg-amber-900/30 dark:text-amber-300"
                                         title="New scopes required: disconnect and reconnect to access analytics, members, and affiliates data"
                                     >
                                         Reconnect needed
@@ -244,7 +244,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                         <Button
                                             size="sm"
                                             variant="outline"
-                                            className="text-red-600 hover:bg-red-50"
+                                            className="text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                                             onClick={() =>
                                                 handlePlatformDisconnect(
                                                     youtubeChannel.id,
@@ -268,7 +268,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                     <Button
                                         size="sm"
                                         variant="outline"
-                                        className="text-red-600 hover:bg-red-50"
+                                        className="text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                                         onClick={() =>
                                             handleDisconnectClick(
                                                 youtubeChannel.id
@@ -297,7 +297,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                 {/* Other Connected Channels */}
                 {nonYoutubeConnected.length > 0 && (
                     <div className="space-y-4">
-                        <h3 className="text-sm font-semibold text-gray-900">
+                        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
                             {t("youtube.connected")} (
                             {nonYoutubeConnected.length})
                         </h3>
@@ -305,7 +305,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                             {nonYoutubeConnected.map(channel => (
                                 <div
                                     key={channel.id}
-                                    className="flex items-center justify-between rounded-lg border border-gray-200 p-4"
+                                    className="flex items-center justify-between rounded-lg border border-gray-200 p-4 dark:border-gray-700"
                                 >
                                     <div className="flex items-center gap-3">
                                         <DynamicIcon
@@ -317,16 +317,16 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                             size={24}
                                         />
                                         <div>
-                                            <p className="font-medium text-gray-900">
+                                            <p className="font-medium text-gray-900 dark:text-gray-100">
                                                 {getPlatformName(
                                                     channel.platform
                                                 )}
                                             </p>
-                                            <p className="text-sm text-gray-600">
+                                            <p className="text-sm text-gray-600 dark:text-gray-300">
                                                 {channel.accountName}
                                             </p>
                                             {channel.connectedAt && (
-                                                <p className="text-xs text-gray-500">
+                                                <p className="text-xs text-gray-500 dark:text-gray-400">
                                                     {t(
                                                         "youtube.connectedSince"
                                                     )}{" "}
@@ -338,12 +338,12 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                         </div>
                                     </div>
                                     <div className="flex items-center gap-2">
-                                        <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800">
+                                        <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
                                             {t("youtube.connected")}
                                         </span>
                                         {channel.needsReconnect && (
                                             <span
-                                                className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800 cursor-help"
+                                                className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800 cursor-help dark:bg-amber-900/30 dark:text-amber-300"
                                                 title="New scopes required: disconnect and reconnect to access new features"
                                             >
                                                 Reconnect needed
@@ -365,7 +365,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                                 <Button
                                                     size="sm"
                                                     variant="outline"
-                                                    className="text-red-600 hover:bg-red-50"
+                                                    className="text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                                                     onClick={() =>
                                                         handlePlatformDisconnect(
                                                             channel.id,
@@ -391,7 +391,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                             <Button
                                                 size="sm"
                                                 variant="outline"
-                                                className="text-red-600 hover:bg-red-50"
+                                                className="text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                                                 onClick={() =>
                                                     handleDisconnectClick(
                                                         channel.id
@@ -411,7 +411,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                 {/* Other Available Channels */}
                 {nonYoutubeDisconnected.length > 0 && (
                     <div className="space-y-4">
-                        <h3 className="text-sm font-semibold text-gray-900">
+                        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
                             {t("youtube.notConnected")} (
                             {nonYoutubeDisconnected.length})
                         </h3>
@@ -419,7 +419,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                             {nonYoutubeDisconnected.map(channel => (
                                 <div
                                     key={channel.id}
-                                    className="flex items-center justify-between rounded-lg border border-gray-200 p-4"
+                                    className="flex items-center justify-between rounded-lg border border-gray-200 p-4 dark:border-gray-700"
                                 >
                                     <div className="flex items-center gap-3">
                                         <DynamicIcon
@@ -431,12 +431,12 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
                                             size={24}
                                         />
                                         <div>
-                                            <p className="font-medium text-gray-900">
+                                            <p className="font-medium text-gray-900 dark:text-gray-100">
                                                 {getPlatformName(
                                                     channel.platform
                                                 )}
                                             </p>
-                                            <p className="text-sm text-gray-600">
+                                            <p className="text-sm text-gray-600 dark:text-gray-300">
                                                 {t("youtube.notConnected")}
                                             </p>
                                         </div>

--- a/src/components/settings/NetworkGroupManager.tsx
+++ b/src/components/settings/NetworkGroupManager.tsx
@@ -94,7 +94,7 @@ export default function NetworkGroupManager({
             <div className="flex items-center justify-between">
                 <div className="space-y-1">
                     <h3 className="font-semibold">{t("networkGroups")}</h3>
-                    <p className="text-sm text-gray-600">
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
                         {t("networkGroupsDescription")}
                     </p>
                 </div>
@@ -192,8 +192,10 @@ export default function NetworkGroupManager({
 
             {groups.length === 0 ? (
                 <div className="rounded-lg border border-dashed p-8 text-center">
-                    <p className="text-sm text-gray-600">{t("noGroups")}</p>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                        {t("noGroups")}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t("createGroupPrompt")}
                     </p>
                 </div>
@@ -202,13 +204,13 @@ export default function NetworkGroupManager({
                     {groups.map(group => (
                         <div
                             key={group.id}
-                            className="flex items-center justify-between rounded-lg border p-3 hover:bg-gray-50"
+                            className="flex items-center justify-between rounded-lg border p-3 hover:bg-gray-50 dark:hover:bg-gray-900/50"
                         >
                             <div className="flex items-center gap-3 flex-1">
-                                <GripVertical className="h-4 w-4 text-gray-400" />
+                                <GripVertical className="h-4 w-4 text-gray-400 dark:text-gray-500" />
                                 <div>
                                     <p className="font-medium">{group.name}</p>
-                                    <p className="text-xs text-gray-600">
+                                    <p className="text-xs text-gray-600 dark:text-gray-400">
                                         {group.networkIds.length}{" "}
                                         {group.networkIds.length !== 1
                                             ? "networks"
@@ -336,7 +338,7 @@ export default function NetworkGroupManager({
                                     <Button
                                         size="sm"
                                         variant="ghost"
-                                        className="text-red-600 hover:text-red-700"
+                                        className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
                                         onClick={() =>
                                             setDeleteGroupId(group.id)
                                         }

--- a/src/components/settings/PreferencesSection.tsx
+++ b/src/components/settings/PreferencesSection.tsx
@@ -129,10 +129,10 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                 {/* Notifications Toggle */}
                 <div className="flex items-center justify-between">
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             {t("notifications")}
                         </label>
-                        <p className="mt-1 text-sm text-gray-600">
+                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                             {t("notificationsDescription")}
                         </p>
                     </div>
@@ -151,7 +151,7 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                 <div className="space-y-2">
                     <label
                         htmlFor="language"
-                        className="block text-sm font-medium text-gray-700"
+                        className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                         {t("language")}
                     </label>
@@ -177,7 +177,7 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                             </SelectItem>
                         </SelectContent>
                     </Select>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t("languageDescription")}
                     </p>
                 </div>
@@ -186,7 +186,7 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                 <div className="space-y-2">
                     <label
                         htmlFor="theme"
-                        className="block text-sm font-medium text-gray-700"
+                        className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                         {t("theme")}
                     </label>
@@ -205,7 +205,7 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                             </SelectItem>
                         </SelectContent>
                     </Select>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t("themeDescription")}
                     </p>
                 </div>
@@ -214,7 +214,7 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                 <div className="space-y-2">
                     <label
                         htmlFor="timezone"
-                        className="block text-sm font-medium text-gray-700"
+                        className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                         {t("timezone")}
                     </label>
@@ -245,13 +245,13 @@ export const PreferencesSection: React.FC<PreferencesSectionProps> = ({
                             ))}
                         </SelectContent>
                     </Select>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t("timezoneDescription")}
                     </p>
                 </div>
 
                 {/* Info Message */}
-                <div className="rounded-md bg-blue-50 p-4 text-sm text-blue-700">
+                <div className="rounded-md bg-blue-50 p-4 text-sm text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
                     {t("preferencesSavedAutomatically")}
                 </div>
             </CardContent>

--- a/src/components/settings/ProfileSection.tsx
+++ b/src/components/settings/ProfileSection.tsx
@@ -200,7 +200,7 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
                                 type="file"
                                 accept="image/*"
                                 onChange={handlePhotoUpload}
-                                className="block w-full text-xs sm:text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:sm:px-4 file:py-2 file:text-xs file:sm:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100"
+                                className="block w-full text-xs sm:text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:sm:px-4 file:py-2 file:text-xs file:sm:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100 dark:text-gray-400 dark:file:bg-blue-950/50 dark:file:text-blue-300 dark:hover:file:bg-blue-950/70"
                             />
                         </div>
                     </div>
@@ -209,7 +209,7 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
                     <div className="space-y-2">
                         <label
                             htmlFor="name"
-                            className="block text-sm font-medium text-gray-700"
+                            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >
                             {t("fullName")}
                         </label>
@@ -227,7 +227,10 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
                             }
                         />
                         {errors.name && (
-                            <p id="name-error" className="text-sm text-red-600">
+                            <p
+                                id="name-error"
+                                className="text-sm text-red-600 dark:text-red-400"
+                            >
                                 {errors.name}
                             </p>
                         )}
@@ -237,7 +240,7 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
                     <div className="space-y-2">
                         <label
                             htmlFor="email"
-                            className="block text-sm font-medium text-gray-700"
+                            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >
                             {t("emailAddress")}
                         </label>
@@ -257,7 +260,7 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
                         {errors.email && (
                             <p
                                 id="email-error"
-                                className="text-sm text-red-600"
+                                className="text-sm text-red-600 dark:text-red-400"
                             >
                                 {errors.email}
                             </p>

--- a/src/components/settings/SecuritySection.tsx
+++ b/src/components/settings/SecuritySection.tsx
@@ -233,12 +233,12 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                 <CardContent className="space-y-4">
                     <div className="flex items-center justify-between">
                         <div>
-                            <p className="font-medium text-gray-900">
+                            <p className="font-medium text-gray-900 dark:text-gray-100">
                                 {twoFactorEnabled
                                     ? t("twoFactorEnabled")
                                     : t("twoFactorDisabled")}
                             </p>
-                            <p className="text-sm text-gray-600">
+                            <p className="text-sm text-gray-600 dark:text-gray-300">
                                 {twoFactorEnabled
                                     ? t("twoFactorProtected")
                                     : t("twoFactorEnablePrompt")}
@@ -255,11 +255,11 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
 
                     {/* 2FA Setup Instructions */}
                     {showTwoFactorSetup && !twoFactorEnabled && (
-                        <div className="space-y-4 rounded-lg bg-blue-50 p-4">
-                            <p className="text-sm font-medium text-blue-900">
+                        <div className="space-y-4 rounded-lg bg-blue-50 p-4 dark:bg-blue-950/30">
+                            <p className="text-sm font-medium text-blue-900 dark:text-blue-200">
                                 {t("setup2FA")}
                             </p>
-                            <ol className="space-y-2 text-sm text-blue-800">
+                            <ol className="space-y-2 text-sm text-blue-800 dark:text-blue-300">
                                 <li>
                                     1. Download an authenticator app (Google
                                     Authenticator, Authy, etc.)
@@ -273,13 +273,13 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                                     confirm
                                 </li>
                             </ol>
-                            <div className="flex justify-center rounded-lg bg-white p-4">
-                                <div className="h-32 w-32 bg-gray-200" />
+                            <div className="flex justify-center rounded-lg bg-white p-4 dark:bg-gray-800">
+                                <div className="h-32 w-32 bg-gray-200 dark:bg-gray-700" />
                             </div>
                             <div className="space-y-2">
                                 <label
                                     htmlFor="2fa-code"
-                                    className="block text-sm font-medium text-blue-900"
+                                    className="block text-sm font-medium text-blue-900 dark:text-blue-200"
                                 >
                                     {t("enter6DigitCode")}
                                 </label>
@@ -320,7 +320,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                 </CardHeader>
                 <CardContent className="space-y-4">
                     {passwordSuccess && (
-                        <div className="rounded-md bg-green-50 p-4 text-sm text-green-700">
+                        <div className="rounded-md bg-green-50 p-4 text-sm text-green-700 dark:bg-green-900/30 dark:text-green-300">
                             {passwordSuccess}
                         </div>
                     )}
@@ -341,7 +341,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                             <div className="space-y-2">
                                 <label
                                     htmlFor="currentPassword"
-                                    className="block text-sm font-medium text-gray-700"
+                                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                                 >
                                     {t("currentPassword")}
                                 </label>
@@ -365,7 +365,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                                 {passwordErrors.currentPassword && (
                                     <p
                                         id="currentPassword-error"
-                                        className="text-sm text-red-600"
+                                        className="text-sm text-red-600 dark:text-red-400"
                                     >
                                         {passwordErrors.currentPassword}
                                     </p>
@@ -376,7 +376,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                             <div className="space-y-2">
                                 <label
                                     htmlFor="newPassword"
-                                    className="block text-sm font-medium text-gray-700"
+                                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                                 >
                                     {t("newPassword")}
                                 </label>
@@ -398,7 +398,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                                 {passwordErrors.newPassword && (
                                     <p
                                         id="newPassword-error"
-                                        className="text-sm text-red-600"
+                                        className="text-sm text-red-600 dark:text-red-400"
                                     >
                                         {passwordErrors.newPassword}
                                     </p>
@@ -406,8 +406,8 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
 
                                 {/* Password Requirements */}
                                 {passwordForm.newPassword && (
-                                    <div className="space-y-2 rounded-lg bg-gray-50 p-3">
-                                        <p className="text-xs font-medium text-gray-700">
+                                    <div className="space-y-2 rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">
+                                        <p className="text-xs font-medium text-gray-700 dark:text-gray-300">
                                             {t("passwordRequirements")}:
                                         </p>
                                         <ul className="space-y-1">
@@ -417,8 +417,8 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                                                         key={idx}
                                                         className={`text-xs ${
                                                             req.met
-                                                                ? "text-green-600"
-                                                                : "text-gray-600"
+                                                                ? "text-green-600 dark:text-green-400"
+                                                                : "text-gray-600 dark:text-gray-400"
                                                         }`}
                                                     >
                                                         {req.met ? "✓" : "○"}{" "}
@@ -435,7 +435,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                             <div className="space-y-2">
                                 <label
                                     htmlFor="confirmPassword"
-                                    className="block text-sm font-medium text-gray-700"
+                                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                                 >
                                     {t("confirmPassword")}
                                 </label>
@@ -459,7 +459,7 @@ export const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                                 {passwordErrors.confirmPassword && (
                                     <p
                                         id="confirmPassword-error"
-                                        className="text-sm text-red-600"
+                                        className="text-sm text-red-600 dark:text-red-400"
                                     >
                                         {passwordErrors.confirmPassword}
                                     </p>

--- a/src/components/settings/UserPreferences.tsx
+++ b/src/components/settings/UserPreferences.tsx
@@ -104,20 +104,20 @@ export default function UserPreferences({
         <div className="space-y-6 rounded-lg border p-4">
             <div className="space-y-2">
                 <h3 className="font-semibold">{t("userPreferences")}</h3>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                     {t("userPreferencesDescription")}
                 </p>
             </div>
 
             {error && (
-                <div className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-red-800">
+                <div className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-red-800 dark:bg-red-950/30 dark:text-red-300">
                     <AlertCircle className="h-5 w-5 flex-shrink-0" />
                     <p className="text-sm">{error}</p>
                 </div>
             )}
 
             {isSaved && (
-                <div className="flex items-center gap-2 rounded-lg bg-green-50 p-3 text-green-800">
+                <div className="flex items-center gap-2 rounded-lg bg-green-50 p-3 text-green-800 dark:bg-green-900/30 dark:text-green-300">
                     <CheckCircle className="h-5 w-5 flex-shrink-0" />
                     <p className="text-sm">{t("preferencesSaved")}</p>
                 </div>
@@ -162,7 +162,7 @@ export default function UserPreferences({
                             })
                         }
                     />
-                    <p className="text-xs text-gray-600">
+                    <p className="text-xs text-gray-600 dark:text-gray-400">
                         {t("retryDescription")}
                     </p>
                 </div>
@@ -186,7 +186,7 @@ export default function UserPreferences({
 
             <div className="space-y-4 border-b pb-4">
                 <h4 className="font-medium">{t("privacySettings")}</h4>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                     {t("privacyDescription")}
                 </p>
 
@@ -235,7 +235,7 @@ export default function UserPreferences({
 
             <div className="space-y-4 border-b pb-4">
                 <h4 className="font-medium">{t("importExport")}</h4>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                     {t("importExportDescription")}
                 </p>
 


### PR DESCRIPTION
## Descrição
Adiciona Tailwind dark: variants a todas as cores hardcoded nas abas de configurações que estavam ilegíveis em dark mode.

## Issues relacionadas
Closes #145

## Arquivos alterados
- src/components/settings/BillingSection.tsx
- src/components/settings/ChannelsSection.tsx
- src/components/settings/NetworkGroupManager.tsx
- src/components/settings/PreferencesSection.tsx
- src/components/settings/ProfileSection.tsx
- src/components/settings/SecuritySection.tsx
- src/components/settings/UserPreferences.tsx

## Mudanças
- text-gray-900 → dark:text-gray-100 (títulos, nomes)
- text-gray-700 → dark:text-gray-300 (labels)
- text-gray-600 → dark:text-gray-300/400 (descrições)
- text-gray-500 → dark:text-gray-400 (texto de ajuda)
- border-gray-200 → dark:border-gray-700
- bg-green/amber/red/blue-100 → dark:* variantes
- text-red-600/hover → dark:text-red-400/hover
- file input: dark: blue variant

## Validação
- npx prettier --write ✓
- npx tsc --noEmit ✓
- npx vitest run: 8 failures (same 8 pre-existing, 0 new)