### PR TITLE
refactor: rename YouTubePublishWizard to PublishWizard and fix double-modal overlap

### DIFF
--- a/src/app/[locale]/dashboard/publish/page.tsx
+++ b/src/app/[locale]/dashboard/publish/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import CalendarView from "@/components/publish/CalendarView"
-import YouTubePublishWizard from "@/components/publish/wizard/YouTubePublishWizard"
+import PublishWizard from "@/components/publish/wizard/PublishWizard"
 import { PostList } from "@/components/publish/PostList"
 import { Post } from "@/components/publish/PostCard"
 import { UniversalPostingButton } from "@/components/publish"
@@ -36,7 +36,7 @@ export default function PublishPage() {
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [selectedDate, setSelectedDate] = useState<Date | null>(null)
-    const [showPostingInterface, setShowPostingInterface] = useState(false)
+    const [showPublishWizard, setShowPublishWizard] = useState(false)
     const [interfaceDate, setInterfaceDate] = useState<Date | undefined>()
 
     const fetchPosts = useCallback(async () => {
@@ -91,23 +91,23 @@ export default function PublishPage() {
     const handleSelectDate = useCallback((date: Date) => {
         setSelectedDate(date)
         setInterfaceDate(date)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleCloseInterface = useCallback(() => {
-        setShowPostingInterface(false)
+        setShowPublishWizard(false)
         setInterfaceDate(undefined)
         fetchPosts()
     }, [fetchPosts])
 
     const handleNewPost = useCallback(() => {
         setInterfaceDate(undefined)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleEditPost = useCallback((post: Post) => {
         setInterfaceDate(post.scheduledAt)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleDeletePost = useCallback(
@@ -195,8 +195,8 @@ export default function PublishPage() {
                 />
             </div>
 
-            {showPostingInterface && (
-                <YouTubePublishWizard
+            {showPublishWizard && (
+                <PublishWizard
                     onClose={handleCloseInterface}
                     defaultDate={interfaceDate}
                 />

--- a/src/app/dashboard/publish/page.tsx
+++ b/src/app/dashboard/publish/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import CalendarView from "@/components/publish/CalendarView"
-import PostingInterface from "@/components/publish/PostingInterface"
+import PublishWizard from "@/components/publish/wizard/PublishWizard"
 import { PostList } from "@/components/publish/PostList"
 import { Post } from "@/components/publish/PostCard"
 import { UniversalPostingButton } from "@/components/publish"
@@ -36,7 +36,7 @@ export default function PublishPage() {
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [selectedDate, setSelectedDate] = useState<Date | null>(null)
-    const [showPostingInterface, setShowPostingInterface] = useState(false)
+    const [showPublishWizard, setShowPublishWizard] = useState(false)
     const [interfaceDate, setInterfaceDate] = useState<Date | undefined>()
 
     const fetchPosts = useCallback(async () => {
@@ -91,23 +91,23 @@ export default function PublishPage() {
     const handleSelectDate = useCallback((date: Date) => {
         setSelectedDate(date)
         setInterfaceDate(date)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleCloseInterface = useCallback(() => {
-        setShowPostingInterface(false)
+        setShowPublishWizard(false)
         setInterfaceDate(undefined)
         fetchPosts()
     }, [fetchPosts])
 
     const handleNewPost = useCallback(() => {
         setInterfaceDate(undefined)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleEditPost = useCallback((post: Post) => {
         setInterfaceDate(post.scheduledAt)
-        setShowPostingInterface(true)
+        setShowPublishWizard(true)
     }, [])
 
     const handleDeletePost = useCallback(
@@ -197,8 +197,8 @@ export default function PublishPage() {
                 />
             </div>
 
-            {showPostingInterface && (
-                <PostingInterface
+            {showPublishWizard && (
+                <PublishWizard
                     onClose={handleCloseInterface}
                     defaultDate={interfaceDate}
                 />

--- a/src/components/publish/UniversalPostingButton.test.tsx
+++ b/src/components/publish/UniversalPostingButton.test.tsx
@@ -2,10 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import UniversalPostingButton from "./UniversalPostingButton"
 
-vi.mock("./PostingInterface", () => ({
-    default: () => null,
-}))
-
 function getPostingButton() {
     return screen.getByRole("button", { name: /networks linked/i })
 }

--- a/src/components/publish/UniversalPostingButton.tsx
+++ b/src/components/publish/UniversalPostingButton.tsx
@@ -9,8 +9,6 @@ import {
 } from "@/components/ui/tooltip"
 import { Share2 } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useState } from "react"
-import PostingInterface from "./PostingInterface"
 
 export interface UniversalPostingButtonProps {
     linkedNetworksCount?: number
@@ -24,15 +22,9 @@ export default function UniversalPostingButton({
     onOpen,
 }: UniversalPostingButtonProps) {
     const t = useTranslations("dashboard.publish")
-    const [isOpen, setIsOpen] = useState(false)
 
     const handleClick = () => {
-        setIsOpen(true)
         onOpen?.()
-    }
-
-    const handleClose = () => {
-        setIsOpen(false)
     }
 
     const tooltipText = isDisabled
@@ -40,40 +32,34 @@ export default function UniversalPostingButton({
         : t("postToNetworks", { count: linkedNetworksCount })
 
     return (
-        <>
-            <TooltipProvider>
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            onClick={handleClick}
-                            disabled={isDisabled}
-                            className="relative gap-2"
-                            aria-label={t("networksLinked", {
-                                count: linkedNetworksCount,
-                            })}
-                            aria-disabled={isDisabled}
-                        >
-                            <Share2 className="h-4 w-4" />
-                            <span className="hidden sm:inline">
-                                {t("post")}
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        onClick={handleClick}
+                        disabled={isDisabled}
+                        className="relative gap-2"
+                        aria-label={t("networksLinked", {
+                            count: linkedNetworksCount,
+                        })}
+                        aria-disabled={isDisabled}
+                    >
+                        <Share2 className="h-4 w-4" />
+                        <span className="hidden sm:inline">{t("post")}</span>
+                        {linkedNetworksCount > 0 && (
+                            <span
+                                className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-green-500 text-xs font-bold text-white"
+                                aria-label={t("networksLinked", {
+                                    count: linkedNetworksCount,
+                                })}
+                            >
+                                {linkedNetworksCount}
                             </span>
-                            {linkedNetworksCount > 0 && (
-                                <span
-                                    className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-green-500 text-xs font-bold text-white"
-                                    aria-label={t("networksLinked", {
-                                        count: linkedNetworksCount,
-                                    })}
-                                >
-                                    {linkedNetworksCount}
-                                </span>
-                            )}
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{tooltipText}</TooltipContent>
-                </Tooltip>
-            </TooltipProvider>
-
-            {isOpen && <PostingInterface onClose={handleClose} />}
-        </>
+                        )}
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>{tooltipText}</TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
     )
 }

--- a/src/components/publish/index.ts
+++ b/src/components/publish/index.ts
@@ -28,7 +28,7 @@ export { default as PostingScheduler } from "./PostingScheduler"
 
 export { default as ContentCreator } from "./ContentCreator"
 
-export { default as PostingInterface } from "./PostingInterface"
+export { default as PublishWizard } from "./wizard/PublishWizard"
 
 export { default as VideoUploader } from "./VideoUploader"
 export { default as BillingSummaryCard } from "./BillingSummaryCard"

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -39,7 +39,7 @@ import { INITIAL_STATE, DEFAULT_YOUTUBE_METADATA } from "./types"
 /** localStorage key for saving drafts */
 const DRAFT_STORAGE_KEY = "publish_wizard_draft"
 
-interface YouTubePublishWizardProps {
+interface PublishWizardProps {
     onClose: () => void
     defaultDate?: Date
 }
@@ -58,9 +58,7 @@ const STEP_TITLE_KEYS: Record<number, string> = {
     7: "step7.title",
 }
 
-export default function YouTubePublishWizard({
-    onClose,
-}: YouTubePublishWizardProps) {
+export default function PublishWizard({ onClose }: PublishWizardProps) {
     const t = useTranslations("publish")
 
     // Wizard state
@@ -609,12 +607,12 @@ export default function YouTubePublishWizard({
                                     {t("closeConfirm.saveDraft")}
                                 </Button>
                             </AlertDialogAction>
-                        <AlertDialogAction asChild>
-                            <Button
-                                variant="ghost"
-                                onClick={handleDiscardAndClose}
-                                className="gap-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/30"
-                            >
+                            <AlertDialogAction asChild>
+                                <Button
+                                    variant="ghost"
+                                    onClick={handleDiscardAndClose}
+                                    className="gap-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/30"
+                                >
                                     <Trash2 className="h-4 w-4" />
                                     {t("closeConfirm.discard")}
                                 </Button>


### PR DESCRIPTION
## Summary

Renames the YouTubePublishWizard to PublishWizard and fixes the double-modal overlap bug.

### Changes
1. **YouTubePublishWizard → PublishWizard** — component/file rename. The wizard is universal (select content type → select networks → fill data → publish), not YouTube-specific.
2. **Fix double-modal overlap** — UniversalPostingButton was opening PostingInterface internally AND also calling onOpen which opened YouTubePublishWizard, causing two modals to overlap. Removed the internal modal; button now only delegates to the parent wizard.
3. **Unified wizard** — both \[locale]/dashboard/publish\ and \dashboard/publish\ (non-locale) now use \PublishWizard\.

Closes #150