### PR TITLE
fix(publish-wizard): barra de progresso mostra apenas título do passo atual e corrige scroll interno

### DIFF
--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -519,8 +519,8 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
     return (
         <>
             <Dialog open={true} onOpenChange={handleCloseAttempt}>
-                <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
-                    <DialogHeader>
+                <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col">
+                    <DialogHeader className="flex-shrink-0">
                         <DialogTitle className="flex items-center gap-2">
                             <span>{t("wizard.title")}</span>
                             {currentStep < totalSteps && (
@@ -541,9 +541,9 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                         </button>
                     </DialogHeader>
 
-                    {/* Step progress bar */}
+                    {/* Step progress bar — only shows title for current step */}
                     {currentStep <= 6 && (
-                        <div className="flex items-center gap-1 px-1">
+                        <div className="flex items-center gap-1 px-1 flex-shrink-0">
                             {progressSteps.map(step => (
                                 <div key={step} className="flex-1">
                                     <div
@@ -553,21 +553,20 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                                                 : "bg-gray-200 dark:bg-gray-700"
                                         }`}
                                     />
-                                    <p
-                                        className={`mt-1 text-xs truncate ${
-                                            step === currentStep
-                                                ? "font-medium text-blue-600 dark:text-blue-400"
-                                                : "text-gray-400"
-                                        }`}
-                                    >
-                                        {getStepTitle(step)}
-                                    </p>
+                                    {step === currentStep && (
+                                        <p className="mt-1 text-xs font-medium text-blue-600 dark:text-blue-400 truncate">
+                                            {getStepTitle(step)}
+                                        </p>
+                                    )}
                                 </div>
                             ))}
                         </div>
                     )}
 
-                    <div className="mt-4">{renderStep()}</div>
+                    {/* Scrollable step content — header and progress bar stay fixed */}
+                    <div className="flex-1 min-h-0 overflow-y-auto mt-4">
+                        {renderStep()}
+                    </div>
                 </DialogContent>
             </Dialog>
 


### PR DESCRIPTION
## Mudanças

### 1. Barra de progresso — mostra apenas o título do passo atual
Antes: todos os 7 títulos apareciam (Tipo de Conteúdo, Selecionar Rede Social, etc.)
Depois: apenas o título do passo atualmente aberto aparece abaixo da barra de progresso.

### 2. Scroll interno do dialog corrigido
Antes: \DialogContent\ com \overflow-y-auto\ no nível inteiro, criando scroll que escondia o header.
Depois: layout \lex column\ com:
- Header fixo (\lex-shrink-0\)
- Barra de progresso fixa (\lex-shrink-0\)
- Área de conteúdo scrollável separada (\lex-1 min-h-0 overflow-y-auto\)

## Arquivo alterado
- \src/components/publish/wizard/PublishWizard.tsx\

Closes #152