### PR TITLE
fix: YouTube video upload Buffer-to-Readable stream conversion

### DIFF
--- a/src/lib/posting/adapters/youtube.ts
+++ b/src/lib/posting/adapters/youtube.ts
@@ -1,6 +1,7 @@
 import { getValidYouTubeToken } from "@/lib/youtube/get-valid-token"
 import { createLogger } from "@/lib/logger"
 import { google } from "googleapis"
+import { Readable } from "stream"
 
 const logger = createLogger("YouTubeAdapter")
 
@@ -64,7 +65,7 @@ export async function uploadVideo(
                 },
             },
             media: {
-                body: videoBuffer,
+                body: Readable.from(videoBuffer),
                 mimeType,
             },
         })


### PR DESCRIPTION
## Problema
YouTube upload quebra com 500: \	.body.pipe is not a function\

## Causa
\media.body\ na googleapis espera um \Readable\ stream do Node.js, mas recebia um \Buffer\.

## Fix
Converter Buffer para Readable stream com \Readable.from(videoBuffer)\.

## Arquivo alterado
- \src/lib/posting/adapters/youtube.ts\ (+2 linhas)

## Validação
- ✅ TypeScript: 0 erros
- ✅ Lint: 0 erros
- ✅ Testes: 220/220 (módulo YouTube)
- ✅ Build: OK

Closes #154