### PR TITLE
feat: extract video upload to dedicated wizard step (UX improvement)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
 
             - name: Build
               run: npm run build
+              env:
+                  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+                  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
     test-suite:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
               env:
                   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
                   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+                  PEPPER_SECRET: ${{ secrets.PEPPER_SECRET }}
+                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                  JWT_SECRET: ${{ secrets.JWT_SECRET }}
+                  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+                  TOKEN_ENCRYPTION_KEY: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
+                  GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+                  GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
     test-suite:
         runs-on: ubuntu-latest

--- a/project-words.txt
+++ b/project-words.txt
@@ -902,3 +902,13 @@ OPENAI
 Restli
 tiktokshop
 servicos
+kwai
+Kwai
+Videocam
+douchebag
+ungespeicherte
+posten
+Monetarisierungsrichtlinien
+Reconexión
+Controversiales
+controversiales

--- a/src/components/publish/wizard/ContentFormStep.tsx
+++ b/src/components/publish/wizard/ContentFormStep.tsx
@@ -8,22 +8,10 @@ import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { useTranslations } from "next-intl"
 import { SiYoutube } from "@icons-pack/react-simple-icons"
-import {
-    Upload,
-    FileVideo,
-    Image,
-    AlertCircle,
-    X,
-    FileImage,
-} from "lucide-react"
+import { FileVideo, Image, AlertCircle, X, FileImage } from "lucide-react"
 import { useCallback, useRef, useState } from "react"
 import type { PublishWizardState, YouTubeMetadata } from "./types"
-import {
-    DEFAULT_YOUTUBE_METADATA,
-    PLATFORM_VIDEO_LIMITS,
-    getCompatibleVideoLimit,
-    getPlatformsExceedingLimit,
-} from "./types"
+import { DEFAULT_YOUTUBE_METADATA } from "./types"
 import TagInput from "./TagInput"
 
 interface ContentFormStepProps {
@@ -35,27 +23,6 @@ interface ContentFormStepProps {
 
 type StepError = Record<string, string>
 
-/** Map platform id to its display name key */
-const PLATFORM_LABEL_KEYS: Record<string, string> = {
-    youtube: "YouTube",
-    facebook: "Facebook",
-    instagram: "Instagram",
-    twitter: "Twitter",
-    linkedin: "LinkedIn",
-}
-
-/** Map platform id to its icon component */
-const PLATFORM_ICONS: Record<string, React.ReactNode> = {
-    youtube: <SiYoutube className="h-4 w-4 text-red-600" />,
-}
-
-function formatBytes(bytes: number): string {
-    if (bytes >= 1024 * 1024 * 1024)
-        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
-    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)}MB`
-    return `${(bytes / 1024).toFixed(0)}KB`
-}
-
 export default function ContentFormStep({
     state,
     onStateChange,
@@ -63,10 +30,8 @@ export default function ContentFormStep({
     onNext,
 }: ContentFormStepProps) {
     const t = useTranslations("publish")
-    const fileInputRef = useRef<HTMLInputElement>(null)
     const imageInputRef = useRef<HTMLInputElement>(null)
     const thumbnailInputRef = useRef<HTMLInputElement>(null)
-    const [dragOver, setDragOver] = useState(false)
     const [thumbnailDragOver, setThumbnailDragOver] = useState(false)
     const [errors, setErrors] = useState<StepError>({})
 
@@ -76,13 +41,6 @@ export default function ContentFormStep({
     // Determine which platforms are selected
     const selectedPlatformIds = state.platformSelections.map(s => s.platformId)
     const hasYouTube = selectedPlatformIds.includes("youtube")
-
-    // Video size limit: lowest among selected platforms
-    const compatibleLimit = getCompatibleVideoLimit(selectedPlatformIds)
-    const videoFile = state.content.videoFile
-    const exceedingPlatforms = videoFile
-        ? getPlatformsExceedingLimit(selectedPlatformIds, videoFile.size)
-        : []
 
     // YouTube metadata helper
     const youtubeMeta =
@@ -100,21 +58,6 @@ export default function ContentFormStep({
     // Validation
     const validate = (): boolean => {
         const errs: StepError = {}
-
-        // Video content type: required video file + size check
-        if (isVideo && !state.content.videoFile) {
-            errs.videoFile = t("step4.fileRequired")
-        }
-        if (
-            isVideo &&
-            state.content.videoFile &&
-            compatibleLimit > 0 &&
-            state.content.videoFile.size > compatibleLimit
-        ) {
-            errs.videoFile = t("step4.fileTooLargeForPlatforms", {
-                limit: formatBytes(compatibleLimit),
-            })
-        }
 
         // Post content type: needs at least text or images
         if (
@@ -152,45 +95,6 @@ export default function ContentFormStep({
             onNext()
         }
     }
-
-    // Video file handlers
-    const handleVideoDrop = useCallback(
-        (e: React.DragEvent) => {
-            e.preventDefault()
-            setDragOver(false)
-            const file = e.dataTransfer.files?.[0]
-            if (file && file.type.startsWith("video/")) {
-                onStateChange({
-                    ...state,
-                    content: { ...state.content, videoFile: file },
-                })
-                setErrors(prev => {
-                    const next = { ...prev }
-                    delete next.videoFile
-                    return next
-                })
-            }
-        },
-        [state, onStateChange]
-    )
-
-    const handleVideoChange = useCallback(
-        (e: React.ChangeEvent<HTMLInputElement>) => {
-            const file = e.target.files?.[0]
-            if (file && file.type.startsWith("video/")) {
-                onStateChange({
-                    ...state,
-                    content: { ...state.content, videoFile: file },
-                })
-                setErrors(prev => {
-                    const next = { ...prev }
-                    delete next.videoFile
-                    return next
-                })
-            }
-        },
-        [state, onStateChange]
-    )
 
     // Thumbnail file handlers
     const handleThumbnailDrop = useCallback(
@@ -281,7 +185,7 @@ export default function ContentFormStep({
                     {/* Text — always shown */}
                     <div className="space-y-2">
                         <Label htmlFor="universal-text">
-                            {t("step4.text")}
+                            {isVideo ? t("step4.description") : t("step4.text")}
                             {isPost && !state.content.images.length && (
                                 <span className="ml-2 text-xs text-red-500">
                                     *
@@ -345,130 +249,6 @@ export default function ContentFormStep({
                                         </div>
                                     ))}
                                 </div>
-                            )}
-                        </div>
-                    )}
-
-                    {/* Video file — only for Video content type */}
-                    {isVideo && (
-                        <div className="space-y-2">
-                            <Label>
-                                {t("step4.videoFile")}
-                                <span className="ml-2 text-xs text-red-500">
-                                    *
-                                </span>
-                            </Label>
-                            {!state.content.videoFile ? (
-                                <div
-                                    onDragOver={e => {
-                                        e.preventDefault()
-                                        setDragOver(true)
-                                    }}
-                                    onDragLeave={() => setDragOver(false)}
-                                    onDrop={handleVideoDrop}
-                                    onClick={() =>
-                                        fileInputRef.current?.click()
-                                    }
-                                    className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-6 transition-colors ${
-                                        dragOver
-                                            ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
-                                            : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
-                                    }`}
-                                >
-                                    <Upload className="h-8 w-8 text-gray-400" />
-                                    <p className="text-sm text-gray-600 dark:text-gray-400">
-                                        {t("step4.dropzone")}
-                                    </p>
-                                    {compatibleLimit > 0 && (
-                                        <p className="text-xs text-gray-400">
-                                            {t("step4.maxSizeDynamic", {
-                                                limit: formatBytes(
-                                                    compatibleLimit
-                                                ),
-                                            })}
-                                        </p>
-                                    )}
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={e => {
-                                            e.stopPropagation()
-                                            fileInputRef.current?.click()
-                                        }}
-                                    >
-                                        {t("step4.browse")}
-                                    </Button>
-                                </div>
-                            ) : (
-                                <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
-                                    <FileVideo className="h-6 w-6 text-blue-500" />
-                                    <div className="flex-1 min-w-0">
-                                        <p className="text-sm font-medium truncate">
-                                            {state.content.videoFile.name}
-                                        </p>
-                                        <p className="text-xs text-gray-500">
-                                            {formatBytes(
-                                                state.content.videoFile.size
-                                            )}
-                                        </p>
-                                    </div>
-                                    <button
-                                        onClick={() =>
-                                            onStateChange({
-                                                ...state,
-                                                content: {
-                                                    ...state.content,
-                                                    videoFile: null,
-                                                },
-                                            })
-                                        }
-                                        className="rounded-full p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-                                    >
-                                        <X className="h-4 w-4" />
-                                    </button>
-                                </div>
-                            )}
-
-                            {/* Platform incompatibility warnings */}
-                            {exceedingPlatforms.length > 0 && (
-                                <div className="space-y-1.5 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/20">
-                                    <p className="flex items-center gap-1 text-xs font-medium text-amber-800 dark:text-amber-300">
-                                        <AlertCircle className="h-3.5 w-3.5" />
-                                        {t("step4.incompatiblePlatforms")}
-                                    </p>
-                                    <ul className="list-inside list-disc space-y-0.5 text-xs text-amber-700 dark:text-amber-400">
-                                        {exceedingPlatforms.map(p => (
-                                            <li key={p.id}>
-                                                {t("step4.platformExceeded", {
-                                                    platform:
-                                                        PLATFORM_LABEL_KEYS[
-                                                            p.id
-                                                        ] ??
-                                                        p.id
-                                                            .charAt(0)
-                                                            .toUpperCase() +
-                                                            p.id.slice(1),
-                                                    limit: formatBytes(p.limit),
-                                                })}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            )}
-
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                accept="video/*"
-                                className="hidden"
-                                onChange={handleVideoChange}
-                            />
-                            {errors.videoFile && (
-                                <p className="flex items-center gap-1 text-xs text-red-500">
-                                    <AlertCircle className="h-3 w-3" />
-                                    {errors.videoFile}
-                                </p>
                             )}
                         </div>
                     )}

--- a/src/components/publish/wizard/NetworkSelectStep.tsx
+++ b/src/components/publish/wizard/NetworkSelectStep.tsx
@@ -18,6 +18,7 @@ import { CONTENT_TYPE_PLATFORMS } from "./types"
 interface NetworkSelectStepProps {
     selectedPlatforms: string[]
     onPlatformsChange: (platforms: string[]) => void
+    onBack: () => void
     onNext: () => void
     contentType: ContentType
 }
@@ -86,6 +87,7 @@ const NETWORKS: PlatformInfo[] = [
 export default function NetworkSelectStep({
     selectedPlatforms,
     onPlatformsChange,
+    onBack,
     onNext,
     contentType,
 }: NetworkSelectStepProps) {
@@ -208,7 +210,10 @@ export default function NetworkSelectStep({
             </div>
 
             {/* Navigation */}
-            <div className="flex justify-end border-t pt-4 dark:border-gray-700">
+            <div className="flex justify-between border-t pt-4 dark:border-gray-700">
+                <Button onClick={onBack} variant="outline">
+                    {t("wizard.back")}
+                </Button>
                 <Button
                     onClick={onNext}
                     disabled={selectedPlatforms.length === 0}

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -24,6 +24,7 @@ import ContentTypeSelect from "./ContentTypeSelect"
 import NetworkSelectStep from "./NetworkSelectStep"
 import ChannelSelectStep from "./ChannelSelectStep"
 import StorageModeStep from "./StorageModeStep"
+import VideoUploadStep from "./VideoUploadStep"
 import ContentFormStep from "./ContentFormStep"
 import AdSuitabilityStep from "./AdSuitabilityStep"
 import VisibilityStep from "./VisibilityStep"
@@ -44,18 +45,19 @@ interface PublishWizardProps {
     defaultDate?: Date
 }
 
-type WizardStep = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+type WizardStep = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
 
 /** Map step index to step key for dynamic titles */
 const STEP_TITLE_KEYS: Record<number, string> = {
     0: "contentType.title",
-    1: "step1.title",
-    2: "step2.title",
-    3: "step3.title",
-    4: "step4.title",
-    5: "step5.title",
-    6: "step6.title",
-    7: "step7.title",
+    1: "videoUpload.title",
+    2: "step1.title",
+    3: "step2.title",
+    4: "step3.title",
+    5: "step4.title",
+    6: "step5.title",
+    7: "step6.title",
+    8: "step7.title",
 }
 
 export default function PublishWizard({ onClose }: PublishWizardProps) {
@@ -202,7 +204,10 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
 
         // Add default YouTube metadata if YouTube is selected
         if (platforms.includes("youtube") && !metadata.youtube) {
-            metadata.youtube = { ...DEFAULT_YOUTUBE_METADATA }
+            metadata.youtube = {
+                ...DEFAULT_YOUTUBE_METADATA,
+                title: wizardState.content.autoFillTitle || "",
+            }
         }
 
         setWizardState({
@@ -408,7 +413,7 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
     }, [wizardState])
 
     const handleStartPublish = () => {
-        setCurrentStep(7)
+        setCurrentStep(8)
         handlePublish()
     }
 
@@ -417,7 +422,7 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
             ...prev,
             processing: { status: "idle" },
         }))
-        setCurrentStep(6)
+        setCurrentStep(7)
     }
 
     // Step titles
@@ -434,15 +439,33 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                     <ContentTypeSelect
                         selectedType={wizardState.contentType}
                         onSelect={handleContentTypeChange}
-                        onNext={() => setCurrentStep(1)}
+                        onNext={() =>
+                            setCurrentStep(
+                                wizardState.contentType === "video" ? 1 : 2
+                            )
+                        }
                     />
                 )
             case 1:
+                return (
+                    <VideoUploadStep
+                        state={wizardState}
+                        onStateChange={setWizardState}
+                        onBack={() => setCurrentStep(0)}
+                        onNext={() => setCurrentStep(2)}
+                    />
+                )
+            case 2:
                 return (
                     <NetworkSelectStep
                         selectedPlatforms={selectedPlatformIds}
                         onPlatformsChange={handlePlatformsChange}
                         contentType={wizardState.contentType}
+                        onBack={() =>
+                            setCurrentStep(
+                                wizardState.contentType === "video" ? 1 : 0
+                            )
+                        }
                         onNext={() => {
                             const needsChannels =
                                 wizardState.platformSelections.some(s =>
@@ -450,39 +473,30 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                                         s.platformId
                                     )
                                 )
-                            setCurrentStep(needsChannels ? 2 : 3)
+                            setCurrentStep(needsChannels ? 3 : 4)
                         }}
-                    />
-                )
-            case 2:
-                return (
-                    <ChannelSelectStep
-                        platformSelections={wizardState.platformSelections}
-                        onSelectionsChange={handleSelectionsChange}
-                        onBack={() => setCurrentStep(1)}
-                        onNext={() => setCurrentStep(3)}
                     />
                 )
             case 3:
                 return (
-                    <StorageModeStep
-                        selectedMode={wizardState.storageMode}
+                    <ChannelSelectStep
+                        platformSelections={wizardState.platformSelections}
+                        onSelectionsChange={handleSelectionsChange}
                         onBack={() => setCurrentStep(2)}
                         onNext={() => setCurrentStep(4)}
                     />
                 )
             case 4:
                 return (
-                    <ContentFormStep
-                        state={wizardState}
-                        onStateChange={setWizardState}
+                    <StorageModeStep
+                        selectedMode={wizardState.storageMode}
                         onBack={() => setCurrentStep(3)}
                         onNext={() => setCurrentStep(5)}
                     />
                 )
             case 5:
                 return (
-                    <AdSuitabilityStep
+                    <ContentFormStep
                         state={wizardState}
                         onStateChange={setWizardState}
                         onBack={() => setCurrentStep(4)}
@@ -491,14 +505,23 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                 )
             case 6:
                 return (
-                    <VisibilityStep
+                    <AdSuitabilityStep
                         state={wizardState}
                         onStateChange={setWizardState}
                         onBack={() => setCurrentStep(5)}
-                        onNext={handleStartPublish}
+                        onNext={() => setCurrentStep(7)}
                     />
                 )
             case 7:
+                return (
+                    <VisibilityStep
+                        state={wizardState}
+                        onStateChange={setWizardState}
+                        onBack={() => setCurrentStep(6)}
+                        onNext={handleStartPublish}
+                    />
+                )
+            case 8:
                 return (
                     <ProcessingStep
                         processing={wizardState.processing}
@@ -512,9 +535,9 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
         }
     }
 
-    // Show first 7 steps in progress bar (0-6), skip step 7 (processing)
-    const progressSteps = [0, 1, 2, 3, 4, 5, 6]
-    const totalSteps = 8
+    // Show first 8 steps in progress bar (0-7), skip step 8 (processing)
+    const progressSteps = [0, 1, 2, 3, 4, 5, 6, 7]
+    const totalSteps = 9
 
     return (
         <>
@@ -542,7 +565,7 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                     </DialogHeader>
 
                     {/* Step progress bar — only shows title for current step */}
-                    {currentStep <= 6 && (
+                    {currentStep <= 7 && (
                         <div className="flex items-center gap-1 px-1 flex-shrink-0">
                             {progressSteps.map(step => (
                                 <div key={step} className="flex-1">

--- a/src/components/publish/wizard/VideoUploadStep.tsx
+++ b/src/components/publish/wizard/VideoUploadStep.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { useTranslations } from "next-intl"
+import { Upload, FileVideo, AlertCircle, X } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import type { PublishWizardState } from "./types"
+
+interface VideoUploadStepProps {
+    state: PublishWizardState
+    onStateChange: (state: PublishWizardState) => void
+    onBack: () => void
+    onNext: () => void
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes >= 1024 * 1024 * 1024)
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)}MB`
+    return `${(bytes / 1024).toFixed(0)}KB`
+}
+
+export default function VideoUploadStep({
+    state,
+    onStateChange,
+    onBack,
+    onNext,
+}: VideoUploadStepProps) {
+    const t = useTranslations("publish")
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const [dragOver, setDragOver] = useState(false)
+    const [errors, setErrors] = useState<Record<string, string>>({})
+
+    const videoFile = state.content.videoFile
+
+    /** Extract filename without extension to auto-fill the title */
+    const extractTitleFromFilename = (filename: string): string => {
+        return filename.replace(/\.[^.]+$/, "")
+    }
+
+    const selectFile = useCallback(
+        (file: File) => {
+            if (!file.type.startsWith("video/")) {
+                setErrors({ videoFile: t("videoUpload.fileRequired") })
+                return
+            }
+            const autoFillTitle = extractTitleFromFilename(file.name)
+            onStateChange({
+                ...state,
+                content: {
+                    ...state.content,
+                    videoFile: file,
+                    autoFillTitle,
+                },
+            })
+            setErrors({})
+        },
+        [state, onStateChange, t]
+    )
+
+    const handleVideoDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault()
+            setDragOver(false)
+            const file = e.dataTransfer.files?.[0]
+            if (file) selectFile(file)
+        },
+        [selectFile]
+    )
+
+    const handleVideoChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0]
+            if (file) selectFile(file)
+        },
+        [selectFile]
+    )
+
+    const removeFile = useCallback(() => {
+        onStateChange({
+            ...state,
+            content: {
+                ...state.content,
+                videoFile: null,
+                autoFillTitle: "",
+            },
+        })
+        setErrors({})
+    }, [state, onStateChange])
+
+    const validate = (): boolean => {
+        if (!state.content.videoFile) {
+            setErrors({ videoFile: t("videoUpload.fileRequired") })
+            return false
+        }
+        return true
+    }
+
+    const handleNext = () => {
+        if (validate()) onNext()
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-xl font-semibold">
+                    {t("videoUpload.title")}
+                </h2>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {t("videoUpload.description")}
+                </p>
+            </div>
+
+            {/* Video file drop zone or selected file display */}
+            <div className="space-y-2">
+                {!videoFile ? (
+                    <div
+                        onDragOver={e => {
+                            e.preventDefault()
+                            setDragOver(true)
+                        }}
+                        onDragLeave={() => setDragOver(false)}
+                        onDrop={handleVideoDrop}
+                        onClick={() => fileInputRef.current?.click()}
+                        className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors ${
+                            dragOver
+                                ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                        }`}
+                    >
+                        <Upload className="h-10 w-10 text-gray-400" />
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {t("videoUpload.dropzone")}
+                        </p>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={e => {
+                                e.stopPropagation()
+                                fileInputRef.current?.click()
+                            }}
+                        >
+                            {t("videoUpload.browse")}
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-4 dark:bg-gray-900">
+                        <FileVideo className="h-8 w-8 text-blue-500" />
+                        <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium truncate">
+                                {videoFile.name}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                                {t("videoUpload.selectedFile", {
+                                    name: videoFile.name,
+                                    size: formatBytes(videoFile.size),
+                                })}
+                            </p>
+                        </div>
+                        <button
+                            onClick={removeFile}
+                            className="rounded-full p-1.5 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+                            aria-label="Remove file"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                    </div>
+                )}
+
+                {/* Auto-fill title hint */}
+                {videoFile && state.content.autoFillTitle && (
+                    <p className="text-sm text-gray-500 italic">
+                        {t("videoUpload.autoFillTitle", {
+                            title: state.content.autoFillTitle,
+                        })}
+                    </p>
+                )}
+
+                {/* Error message */}
+                {errors.videoFile && (
+                    <p className="flex items-center gap-1 text-xs text-red-500">
+                        <AlertCircle className="h-3 w-3" />
+                        {errors.videoFile}
+                    </p>
+                )}
+
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="video/*"
+                    className="hidden"
+                    onChange={handleVideoChange}
+                />
+            </div>
+
+            {/* Navigation */}
+            <div className="flex justify-between border-t pt-4 dark:border-gray-700">
+                <Button onClick={onBack} variant="outline">
+                    {t("wizard.back")}
+                </Button>
+                <Button onClick={handleNext}>{t("wizard.next")}</Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -72,6 +72,8 @@ export interface PublishWizardState {
         images: File[]
         videoFile: File | null
         thumbnailFile: File | null
+        /** Auto-filled title extracted from video filename (minus extension). Used to pre-fill YouTube title. */
+        autoFillTitle: string
     }
 
     /** Platform-specific metadata, keyed by platform id */
@@ -209,6 +211,7 @@ export const INITIAL_STATE: PublishWizardState = {
         images: [],
         videoFile: null,
         thumbnailFile: null,
+        autoFillTitle: "",
     },
     platformMetadata: {},
     processing: { status: "idle" },

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -382,6 +382,17 @@
         "uploadComplete": "Upload abgeschlossen",
         "uploadFailed": "Upload fehlgeschlagen. Bitte versuche es erneut."
     },
+    "videoUpload": {
+        "title": "Video Hochladen",
+        "description": "Wähle die Videodatei zum Hochladen aus",
+        "dropzone": "Video hierher ziehen oder klicken zum Auswählen",
+        "browse": "Dateien Durchsuchen",
+        "maxSize": "Kompatible maximale Größe: {limit}",
+        "selectedFile": "{name} ({size})",
+        "removeFile": "Datei entfernen",
+        "fileRequired": "Bitte wähle eine Videodatei aus, um fortzufahren",
+        "autoFillTitle": "Titel automatisch aus Dateinamen übernommen: \"{title}\""
+    },
     "billingSummary": {
         "title": "Abrechnungsübersicht",
         "baseFee": "Grundgebühr (nicht erstattbar)",

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -382,6 +382,17 @@
         "uploadComplete": "Upload complete",
         "uploadFailed": "Upload failed. Please try again."
     },
+    "videoUpload": {
+        "title": "Upload Video",
+        "description": "Select the video file to upload",
+        "dropzone": "Drag & drop video file here, or click to select",
+        "browse": "Browse Files",
+        "maxSize": "Compatible max size: {limit}",
+        "selectedFile": "{name} ({size})",
+        "removeFile": "Remove file",
+        "fileRequired": "Please select a video file to continue",
+        "autoFillTitle": "Title auto-filled from filename: \"{title}\""
+    },
     "billingSummary": {
         "title": "Billing Summary",
         "baseFee": "Base fee (non-refundable)",

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -382,6 +382,17 @@
         "uploadComplete": "Subida completa",
         "uploadFailed": "Error al subir. Intenta de nuevo."
     },
+    "videoUpload": {
+        "title": "Subir Video",
+        "description": "Selecciona el archivo de video para subir",
+        "dropzone": "Arrastra el video aquí o haz clic para seleccionar",
+        "browse": "Buscar Archivos",
+        "maxSize": "Tamaño máximo compatible: {limit}",
+        "selectedFile": "{name} ({size})",
+        "removeFile": "Eliminar archivo",
+        "fileRequired": "Selecciona un archivo de video para continuar",
+        "autoFillTitle": "Título auto-completado del nombre del archivo: \"{title}\""
+    },
     "billingSummary": {
         "title": "Resumen de Facturación",
         "baseFee": "Tarifa base (no reembolsable)",

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -382,6 +382,17 @@
         "uploadComplete": "Upload concluído",
         "uploadFailed": "Falha no upload. Tente novamente."
     },
+    "videoUpload": {
+        "title": "Upload de Vídeo",
+        "description": "Selecione o arquivo de vídeo para fazer upload",
+        "dropzone": "Arraste o vídeo aqui ou clique para selecionar",
+        "browse": "Procurar Arquivos",
+        "maxSize": "Tamanho máximo compatível: {limit}",
+        "selectedFile": "{name} ({size})",
+        "removeFile": "Remover arquivo",
+        "fileRequired": "Selecione um arquivo de vídeo para continuar",
+        "autoFillTitle": "Título preenchido automaticamente do nome do arquivo: \"{title}\""
+    },
     "billingSummary": {
         "title": "Resumo de Cobrança",
         "baseFee": "Taxa base (não reembolsável)",


### PR DESCRIPTION
## Summary

Extracts the video file upload into its own wizard step (Step 1) for a clearer, more intuitive publishing flow. When the user selects "Video" as content type, they immediately see a clean drop zone before any platform selection.

## Changes

### New: VideoUploadStep (Step 1)
- Dedicated video file upload with drag-and-drop zone
- Auto-fills YouTube title from filename (minus extension)
- Only shown for video content type; skipped for posts

### Updated: PublishWizard navigation
- Steps shifted: 0->0, (new 1), 1->2, 2->3, 3->4, 4->5, 5->6, 6->7, 7->8
- ContentTypeSelect branches: video goes to Step 1, post skips to Step 2
- NetworkSelectStep now has a Back button for proper navigation
- YouTube title auto-filled from autoFillTitle when metadata is created

### Updated: ContentFormStep
- Removed video file upload section (moved to Step 1)
- Universal text label shows "Description" for video, "Text" for post
- Removed video-limit validation and unused imports

### i18n
- Added videoUpload section to en, pt-BR, es, de locales

### Types
- Added autoFillTitle: string to PublishWizardState.content

## Pre-commit checks
- Format: passed
- Lint: 0 errors (pre-existing warnings only)
- TypeScript: no errors
- Tests: 6696 passed, 9 pre-existing failures (all unrelated)
