### PR TITLE
feat: individual content fields with platform icons, fix AlertDialog close buttons

### DIFF
--- a/src/components/publish/wizard/ContentFormStep.tsx
+++ b/src/components/publish/wizard/ContentFormStep.tsx
@@ -1,14 +1,18 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Badge } from "@/components/ui/badge"
 import { useTranslations } from "next-intl"
-import { SiYoutube } from "@icons-pack/react-simple-icons"
-import { FileVideo, Image, AlertCircle, X, FileImage } from "lucide-react"
+import {
+    SiYoutube,
+    SiFacebook,
+    SiInstagram,
+    SiTiktok,
+    SiX,
+} from "@icons-pack/react-simple-icons"
+import { AlertCircle, X, FileImage } from "lucide-react"
 import { useCallback, useRef, useState } from "react"
 import type { PublishWizardState, YouTubeMetadata } from "./types"
 import { DEFAULT_YOUTUBE_METADATA } from "./types"
@@ -22,6 +26,49 @@ interface ContentFormStepProps {
 }
 
 type StepError = Record<string, string>
+
+/** Map platform ID to icon + color for field badges */
+const PLATFORM_ICONS: Record<
+    string,
+    { Icon: React.ComponentType<{ className?: string }>; color: string }
+> = {
+    youtube: { Icon: SiYoutube, color: "text-red-600" },
+    facebook: { Icon: SiFacebook, color: "text-blue-600" },
+    instagram: { Icon: SiInstagram, color: "text-pink-600" },
+    tiktok: { Icon: SiTiktok, color: "text-gray-900 dark:text-gray-100" },
+    twitter: { Icon: SiX, color: "text-gray-700 dark:text-gray-300" },
+}
+
+/**
+ * Define which platforms each field is compatible with.
+ * Fields only show if at least one compatible platform is selected.
+ */
+const FIELD_PLATFORMS: Record<string, string[]> = {
+    title: ["youtube"],
+    description: ["youtube", "facebook", "instagram"],
+    tags: ["youtube"],
+    thumbnail: ["youtube"],
+    text: ["facebook", "instagram"],
+    images: ["facebook", "instagram"],
+}
+
+/** Platform badge row — shows icons for each compatible platform */
+function PlatformBadges({ platforms }: { platforms: string[] }) {
+    return (
+        <span className="ml-2 inline-flex items-center gap-1">
+            {platforms.map(pid => {
+                const entry = PLATFORM_ICONS[pid]
+                if (!entry) return null
+                return (
+                    <entry.Icon
+                        key={pid}
+                        className={`h-3.5 w-3.5 ${entry.color}`}
+                    />
+                )
+            })}
+        </span>
+    )
+}
 
 export default function ContentFormStep({
     state,
@@ -38,12 +85,21 @@ export default function ContentFormStep({
     const isVideo = state.contentType === "video"
     const isPost = state.contentType === "post"
 
-    // Determine which platforms are selected
     const selectedPlatformIds = state.platformSelections.map(s => s.platformId)
     const hasYouTube = selectedPlatformIds.includes("youtube")
 
+    /** Get visible fields for current content type, filtered by selected platforms */
+    const visibleFields = (
+        isVideo
+            ? ["title", "description", "tags", "thumbnail"]
+            : ["text", "images"]
+    ).filter(fieldId => {
+        const compatible = FIELD_PLATFORMS[fieldId] || []
+        return compatible.some(p => selectedPlatformIds.includes(p))
+    })
+
     // YouTube metadata helper
-    const youtubeMeta =
+    const youtubeMeta: YouTubeMetadata =
         state.platformMetadata.youtube || DEFAULT_YOUTUBE_METADATA
     const setYouTubeMeta = (update: Partial<YouTubeMetadata>) => {
         onStateChange({
@@ -68,18 +124,17 @@ export default function ContentFormStep({
             errs.text = t("step4.textRequired")
         }
 
-        // YouTube: title required when YouTube is selected
-        if (hasYouTube && !youtubeMeta.title.trim()) {
-            errs.youtube_title = t("step4.titleRequired")
-        }
-        if (hasYouTube && youtubeMeta.title.length > 100) {
-            errs.youtube_title = t("step4.titleMax")
-        }
-        if (hasYouTube && youtubeMeta.description.length > 5000) {
-            errs.youtube_description = t("step4.descriptionMax")
-        }
-        // Tags limit: 500 chars total (YouTube's limit, not 30 tags)
+        // YouTube fields
         if (hasYouTube) {
+            if (!youtubeMeta.title.trim()) {
+                errs.youtube_title = t("step4.titleRequired")
+            }
+            if (youtubeMeta.title.length > 100) {
+                errs.youtube_title = t("step4.titleMax")
+            }
+            if (youtubeMeta.description.length > 5000) {
+                errs.youtube_description = t("step4.descriptionMax")
+            }
             const tagsTotalChars = youtubeMeta.tags.join(",").length
             if (tagsTotalChars > 500) {
                 errs.youtube_tags = t("step4.tagsMax")
@@ -91,9 +146,7 @@ export default function ContentFormStep({
     }
 
     const handleNext = () => {
-        if (validate()) {
-            onNext()
-        }
+        if (validate()) onNext()
     }
 
     // Thumbnail file handlers
@@ -164,28 +217,14 @@ export default function ContentFormStep({
                 </p>
             </div>
 
-            {/* ── UNIVERSAL SECTION ── */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2 text-lg">
-                        {isVideo ? (
-                            <FileVideo className="h-5 w-5" />
-                        ) : (
-                            <Image className="h-5 w-5" />
-                        )}
-                        {isVideo
-                            ? t("step4.contentVideo")
-                            : t("step4.contentPost")}
-                        <Badge variant="outline" className="ml-auto text-xs">
-                            {t("step4.allPlatforms")}
-                        </Badge>
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {/* Text — always shown */}
+            {/* ── INDIVIDUAL FIELDS WITH PLATFORM BADGES ── */}
+            <div className="space-y-6">
+                {/* Post: Text + Images */}
+                {visibleFields.includes("text") && (
                     <div className="space-y-2">
                         <Label htmlFor="universal-text">
-                            {isVideo ? t("step4.description") : t("step4.text")}
+                            {t("step4.text")}
+                            <PlatformBadges platforms={FIELD_PLATFORMS.text} />
                             {isPost && !state.content.images.length && (
                                 <span className="ml-2 text-xs text-red-500">
                                     *
@@ -204,11 +243,7 @@ export default function ContentFormStep({
                                     },
                                 })
                             }
-                            placeholder={
-                                isVideo
-                                    ? t("step4.textVideoPlaceholder")
-                                    : t("step4.textPostPlaceholder")
-                            }
+                            placeholder={t("step4.textPostPlaceholder")}
                             className="min-h-20 resize-none"
                         />
                         {errors.text && (
@@ -218,228 +253,220 @@ export default function ContentFormStep({
                             </p>
                         )}
                     </div>
+                )}
 
-                    {/* Images — only for Post content type */}
-                    {isPost && (
-                        <div className="space-y-2">
-                            <Label>{t("step4.images")}</Label>
-                            <Input
-                                type="file"
-                                multiple
-                                accept="image/*"
-                                ref={imageInputRef}
-                                onChange={handleImageUpload}
-                                className="cursor-pointer"
+                {visibleFields.includes("images") && (
+                    <div className="space-y-2">
+                        <Label>
+                            {t("step4.images")}
+                            <PlatformBadges
+                                platforms={FIELD_PLATFORMS.images}
                             />
-                            {state.content.images.length > 0 && (
-                                <div className="grid grid-cols-4 gap-2 mt-2">
-                                    {state.content.images.map((img, idx) => (
-                                        <div key={idx} className="relative">
-                                            <img
-                                                src={URL.createObjectURL(img)}
-                                                alt={`Upload ${idx + 1}`}
-                                                className="h-16 w-full rounded object-cover"
-                                            />
-                                            <button
-                                                onClick={() => removeImage(idx)}
-                                                className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white hover:bg-red-600"
-                                            >
-                                                <X className="h-3 w-3" />
-                                            </button>
-                                        </div>
-                                    ))}
-                                </div>
+                        </Label>
+                        <Input
+                            type="file"
+                            multiple
+                            accept="image/*"
+                            ref={imageInputRef}
+                            onChange={handleImageUpload}
+                            className="cursor-pointer"
+                        />
+                        {state.content.images.length > 0 && (
+                            <div className="grid grid-cols-4 gap-2 mt-2">
+                                {state.content.images.map((img, idx) => (
+                                    <div key={idx} className="relative">
+                                        <img
+                                            src={URL.createObjectURL(img)}
+                                            alt={`Upload ${idx + 1}`}
+                                            className="h-16 w-full rounded object-cover"
+                                        />
+                                        <button
+                                            onClick={() => removeImage(idx)}
+                                            className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white hover:bg-red-600"
+                                        >
+                                            <X className="h-3 w-3" />
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {/* Video: Title */}
+                {visibleFields.includes("title") && (
+                    <div className="space-y-2">
+                        <Label htmlFor="yt-title">
+                            {t("step4.title")}
+                            <PlatformBadges platforms={FIELD_PLATFORMS.title} />
+                            <span className="text-red-500">*</span>
+                        </Label>
+                        <Input
+                            id="yt-title"
+                            value={youtubeMeta.title}
+                            onChange={e =>
+                                setYouTubeMeta({
+                                    title: e.target.value.slice(0, 100),
+                                })
+                            }
+                            placeholder={t("step4.titlePlaceholder")}
+                            maxLength={100}
+                        />
+                        <div className="flex justify-between text-xs text-gray-400">
+                            <span>
+                                {youtubeMeta.title.length}/100{" "}
+                                {t("step4.titleMax")}
+                            </span>
+                            {errors.youtube_title && (
+                                <span className="text-red-500">
+                                    {errors.youtube_title}
+                                </span>
                             )}
                         </div>
-                    )}
+                    </div>
+                )}
 
-                    {/* Thumbnail — only for Video content type */}
-                    {isVideo && (
-                        <div className="space-y-2">
-                            <Label>{t("step4.thumbnail")}</Label>
-                            {!state.content.thumbnailFile ? (
-                                <div
-                                    onDragOver={e => {
-                                        e.preventDefault()
-                                        setThumbnailDragOver(true)
-                                    }}
-                                    onDragLeave={() =>
-                                        setThumbnailDragOver(false)
-                                    }
-                                    onDrop={handleThumbnailDrop}
-                                    onClick={() =>
+                {/* Video: Description */}
+                {visibleFields.includes("description") && (
+                    <div className="space-y-2">
+                        <Label htmlFor="yt-description">
+                            {t("step4.description")}
+                            <PlatformBadges
+                                platforms={FIELD_PLATFORMS.description}
+                            />
+                        </Label>
+                        <Textarea
+                            id="yt-description"
+                            value={youtubeMeta.description}
+                            onChange={e =>
+                                setYouTubeMeta({
+                                    description: e.target.value.slice(0, 5000),
+                                })
+                            }
+                            placeholder={t("step4.descriptionPlaceholder")}
+                            className="min-h-20 resize-none"
+                            maxLength={5000}
+                        />
+                        <div className="flex justify-between text-xs text-gray-400">
+                            <span>
+                                {youtubeMeta.description.length}
+                                /5000 {t("step4.descriptionMax")}
+                            </span>
+                            {errors.youtube_description && (
+                                <span className="text-red-500">
+                                    {errors.youtube_description}
+                                </span>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Video: Tags */}
+                {visibleFields.includes("tags") && (
+                    <div className="space-y-2">
+                        <Label htmlFor="yt-tags">
+                            {t("step4.tags")}
+                            <PlatformBadges platforms={FIELD_PLATFORMS.tags} />
+                        </Label>
+                        <TagInput
+                            tags={youtubeMeta.tags}
+                            onChange={handleTagsChange}
+                            placeholder={t("step4.tagsPlaceholder")}
+                            maxChars={500}
+                        />
+                        {errors.youtube_tags && (
+                            <p className="flex items-center gap-1 text-xs text-red-500">
+                                <AlertCircle className="h-3 w-3" />
+                                {errors.youtube_tags}
+                            </p>
+                        )}
+                    </div>
+                )}
+
+                {/* Video: Thumbnail */}
+                {visibleFields.includes("thumbnail") && (
+                    <div className="space-y-2">
+                        <Label>
+                            {t("step4.thumbnail")}
+                            <PlatformBadges
+                                platforms={FIELD_PLATFORMS.thumbnail}
+                            />
+                        </Label>
+                        {!state.content.thumbnailFile ? (
+                            <div
+                                onDragOver={e => {
+                                    e.preventDefault()
+                                    setThumbnailDragOver(true)
+                                }}
+                                onDragLeave={() => setThumbnailDragOver(false)}
+                                onDrop={handleThumbnailDrop}
+                                onClick={() =>
+                                    thumbnailInputRef.current?.click()
+                                }
+                                className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-4 transition-colors ${
+                                    thumbnailDragOver
+                                        ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                        : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                                }`}
+                            >
+                                <FileImage className="h-6 w-6 text-gray-400" />
+                                <p className="text-xs text-gray-600 dark:text-gray-400">
+                                    {t("step4.thumbnailHint")}
+                                </p>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={e => {
+                                        e.stopPropagation()
                                         thumbnailInputRef.current?.click()
-                                    }
-                                    className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-4 transition-colors ${
-                                        thumbnailDragOver
-                                            ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
-                                            : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
-                                    }`}
+                                    }}
                                 >
-                                    <FileImage className="h-6 w-6 text-gray-400" />
-                                    <p className="text-xs text-gray-600 dark:text-gray-400">
-                                        {t("step4.thumbnailHint")}
-                                    </p>
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={e => {
-                                            e.stopPropagation()
-                                            thumbnailInputRef.current?.click()
-                                        }}
-                                    >
-                                        {t("step4.browseImage")}
-                                    </Button>
-                                </div>
-                            ) : (
-                                <div className="relative">
-                                    <img
-                                        src={URL.createObjectURL(
-                                            state.content.thumbnailFile
-                                        )}
-                                        alt="Thumbnail preview"
-                                        className="h-32 w-full rounded-lg object-cover"
-                                    />
-                                    <button
-                                        onClick={() =>
-                                            onStateChange({
-                                                ...state,
-                                                content: {
-                                                    ...state.content,
-                                                    thumbnailFile: null,
-                                                },
-                                            })
-                                        }
-                                        className="absolute right-2 top-2 rounded-full bg-red-500 p-1 text-white hover:bg-red-600"
-                                    >
-                                        <X className="h-4 w-4" />
-                                    </button>
-                                </div>
-                            )}
-                            <input
-                                ref={thumbnailInputRef}
-                                type="file"
-                                accept="image/*"
-                                className="hidden"
-                                onChange={handleThumbnailChange}
-                            />
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
-
-            {/* ── PLATFORM-SPECIFIC SECTIONS ── */}
-
-            {/* YouTube Metadata */}
-            {hasYouTube && (
-                <>
-                    {/* Basic Info: Title, Description, Tags */}
-                    <Card className="border-l-4 border-l-red-500">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-lg">
-                                <SiYoutube className="h-5 w-5 text-red-600" />
-                                {t("step4.basicInfo")}
-                                <Badge
-                                    variant="secondary"
-                                    className="ml-auto text-xs"
-                                >
-                                    <SiYoutube className="mr-1 h-3 w-3" />
-                                    YouTube
-                                </Badge>
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="yt-title">
-                                    {t("step4.title")}
-                                    <span className="text-red-500">*</span>
-                                </Label>
-                                <Input
-                                    id="yt-title"
-                                    value={youtubeMeta.title}
-                                    onChange={e =>
-                                        setYouTubeMeta({
-                                            title: e.target.value.slice(0, 100),
+                                    {t("step4.browseImage")}
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="relative">
+                                <img
+                                    src={URL.createObjectURL(
+                                        state.content.thumbnailFile
+                                    )}
+                                    alt="Thumbnail preview"
+                                    className="h-32 w-full rounded-lg object-cover"
+                                />
+                                <button
+                                    onClick={() =>
+                                        onStateChange({
+                                            ...state,
+                                            content: {
+                                                ...state.content,
+                                                thumbnailFile: null,
+                                            },
                                         })
                                     }
-                                    placeholder={t("step4.titlePlaceholder")}
-                                    maxLength={100}
-                                />
-                                <div className="flex justify-between text-xs text-gray-400">
-                                    <span>
-                                        {youtubeMeta.title.length}/100{" "}
-                                        {t("step4.titleMax")}
-                                    </span>
-                                    {errors.youtube_title && (
-                                        <span className="text-red-500">
-                                            {errors.youtube_title}
-                                        </span>
-                                    )}
-                                </div>
+                                    className="absolute right-2 top-2 rounded-full bg-red-500 p-1 text-white hover:bg-red-600"
+                                >
+                                    <X className="h-4 w-4" />
+                                </button>
                             </div>
+                        )}
+                        <input
+                            ref={thumbnailInputRef}
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={handleThumbnailChange}
+                        />
+                    </div>
+                )}
 
-                            <div className="space-y-2">
-                                <Label htmlFor="yt-description">
-                                    {t("step4.description")}
-                                </Label>
-                                <Textarea
-                                    id="yt-description"
-                                    value={youtubeMeta.description}
-                                    onChange={e =>
-                                        setYouTubeMeta({
-                                            description: e.target.value.slice(
-                                                0,
-                                                5000
-                                            ),
-                                        })
-                                    }
-                                    placeholder={t(
-                                        "step4.descriptionPlaceholder"
-                                    )}
-                                    className="min-h-20 resize-none"
-                                    maxLength={5000}
-                                />
-                                <div className="flex justify-between text-xs text-gray-400">
-                                    <span>
-                                        {youtubeMeta.description.length}
-                                        /5000 {t("step4.descriptionMax")}
-                                    </span>
-                                    {errors.youtube_description && (
-                                        <span className="text-red-500">
-                                            {errors.youtube_description}
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
-
-                            {/* Tags — YouTube-style input */}
-                            <div className="space-y-2">
-                                <Label htmlFor="yt-tags">
-                                    {t("step4.tags")}
-                                </Label>
-                                <TagInput
-                                    tags={youtubeMeta.tags}
-                                    onChange={handleTagsChange}
-                                    placeholder={t("step4.tagsPlaceholder")}
-                                    maxChars={500}
-                                />
-                                {errors.youtube_tags && (
-                                    <p className="flex items-center gap-1 text-xs text-red-500">
-                                        <AlertCircle className="h-3 w-3" />
-                                        {errors.youtube_tags}
-                                    </p>
-                                )}
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Future: Facebook-specific section */}
-                    {/* Future: Instagram-specific section */}
-                    {/* Future: Twitter-specific section */}
-                    {/* Future: LinkedIn-specific section */}
-                </>
-            )}
+                {/* No visible fields warning */}
+                {visibleFields.length === 0 && (
+                    <p className="py-8 text-center text-sm text-gray-500">
+                        {t("step4.noCompatibleFields")}
+                    </p>
+                )}
+            </div>
 
             {/* Navigation */}
             <div className="flex justify-between border-t pt-4 dark:border-gray-700">

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -18,7 +18,6 @@ import {
     AlertDialogCancel,
     AlertDialogAction,
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { X, Save, ArrowLeft, Trash2 } from "lucide-react"
 import ContentTypeSelect from "./ContentTypeSelect"
 import NetworkSelectStep from "./NetworkSelectStep"
@@ -608,38 +607,27 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
-                        <AlertDialogCancel asChild>
-                            <Button
-                                variant="outline"
-                                onClick={handleBackToEditing}
-                                className="gap-2"
-                            >
-                                <ArrowLeft className="h-4 w-4" />
-                                {t("closeConfirm.backToEditing")}
-                            </Button>
+                        <AlertDialogCancel
+                            onClick={handleBackToEditing}
+                            className="gap-2"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                            {t("closeConfirm.backToEditing")}
                         </AlertDialogCancel>
-                        <div className="flex gap-2">
-                            <AlertDialogAction asChild>
-                                <Button
-                                    variant="secondary"
-                                    onClick={handleSaveDraftAndClose}
-                                    className="gap-2"
-                                >
-                                    <Save className="h-4 w-4" />
-                                    {t("closeConfirm.saveDraft")}
-                                </Button>
-                            </AlertDialogAction>
-                            <AlertDialogAction asChild>
-                                <Button
-                                    variant="ghost"
-                                    onClick={handleDiscardAndClose}
-                                    className="gap-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/30"
-                                >
-                                    <Trash2 className="h-4 w-4" />
-                                    {t("closeConfirm.discard")}
-                                </Button>
-                            </AlertDialogAction>
-                        </div>
+                        <AlertDialogAction
+                            onClick={handleSaveDraftAndClose}
+                            className="gap-2"
+                        >
+                            <Save className="h-4 w-4" />
+                            {t("closeConfirm.saveDraft")}
+                        </AlertDialogAction>
+                        <AlertDialogAction
+                            onClick={handleDiscardAndClose}
+                            className="gap-2 bg-red-600 hover:bg-red-700 text-white"
+                        >
+                            <Trash2 className="h-4 w-4" />
+                            {t("closeConfirm.discard")}
+                        </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -111,6 +111,7 @@
         "tagsPlaceholder": "Tags durch Kommas getrennt eingeben",
         "tagsHint": "Füge Tags hinzu, um die Auffindbarkeit deines Videos zu verbessern",
         "tagsMax": "Maximal 30 Tags, insgesamt 500 Zeichen",
+        "noCompatibleFields": "Keine Felder sind mit den ausgewählten Plattformen kompatibel",
         "audience": "Zielgruppe",
         "madeForKids": "Ist dieses Video für Kinder gemacht?",
         "madeForKidsYes": "Ja, es ist für Kinder gemacht",

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -111,6 +111,7 @@
         "tagsPlaceholder": "Enter comma-separated tags",
         "tagsHint": "Add tags to help viewers discover your video",
         "tagsMax": "Maximum 30 tags, 500 characters total",
+        "noCompatibleFields": "No fields are compatible with the selected platforms",
         "audience": "Audience",
         "madeForKids": "Is this video made for children?",
         "madeForKidsYes": "Yes, it's made for kids",

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -111,6 +111,7 @@
         "tagsPlaceholder": "Ingresa etiquetas separadas por comas",
         "tagsHint": "Añade etiquetas para ayudar al descubrimiento de tu video",
         "tagsMax": "Máximo 30 etiquetas, 500 caracteres en total",
+        "noCompatibleFields": "Ningún campo es compatible con las plataformas seleccionadas",
         "audience": "Audiencia",
         "madeForKids": "¿Este video está hecho para niños?",
         "madeForKidsYes": "Sí, está hecho para niños",

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -111,6 +111,7 @@
         "tagsPlaceholder": "Digite tags separadas por vírgula",
         "tagsHint": "Adicione tags para ajudar na descoberta do seu vídeo",
         "tagsMax": "Máximo 30 tags, 500 caracteres no total",
+        "noCompatibleFields": "Nenhum campo é compatível com as plataformas selecionadas",
         "audience": "Público",
         "madeForKids": "Este vídeo é feito para crianças?",
         "madeForKidsYes": "Sim, é feito para crianças",


### PR DESCRIPTION
## Changes

### ContentFormStep
- Removed duplicate description field (Universal + YouTube sections merged)
- Each field now shows platform icons indicating compatibility (YouTube, Facebook, Instagram, etc.)
- Fields incompatible with selected platforms are hidden automatically
- Architecture supports future platforms via FIELD_PLATFORMS map
- Added PlatformBadges component for reusable platform icon display

### PublishWizard
- Fixed AlertDialog close confirmation: X button and Back to Editing now work correctly
- Removed sChild wrapping that was breaking Radix AlertDialog button handlers

### i18n
- Added noCompatibleFields key to all 4 locales (en, pt-BR, es, de)

Closes #154