### PR TITLE
feat(publish): connect PublishWizard to Facebook text-post API

### DIFF
--- a/src/components/publish/wizard/NetworkSelectStep.tsx
+++ b/src/components/publish/wizard/NetworkSelectStep.tsx
@@ -51,8 +51,8 @@ const NETWORKS: PlatformInfo[] = [
         labelKey: "step1.facebook",
         descKey: "step1.facebookDesc",
         icon: <SiFacebook className="h-6 w-6 text-blue-600" />,
-        implemented: false,
-        connected: false,
+        implemented: true,
+        connected: true,
         features: ["text", "images", "channel_selection"],
     },
     {

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -371,6 +371,83 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                                 : "Unknown error",
                     })
                 }
+            } else if (platformId === "facebook") {
+                // Post text to Facebook page feed
+                setWizardState(prev => ({
+                    ...prev,
+                    processing: {
+                        status: "uploading",
+                        platformId: "facebook",
+                        progress: 0,
+                        speed: "0 KB/s",
+                    },
+                }))
+
+                try {
+                    const pageId = sel.channelIds[0]
+                    if (!pageId) {
+                        results.push({
+                            platformId: "facebook",
+                            success: false,
+                            error: "No Facebook page selected",
+                        })
+                        continue
+                    }
+
+                    const message = wizardState.content.text
+                    if (!message.trim()) {
+                        results.push({
+                            platformId: "facebook",
+                            success: false,
+                            error: "No message content",
+                        })
+                        continue
+                    }
+
+                    setWizardState(prev => ({
+                        ...prev,
+                        processing: {
+                            status: "publishing",
+                            platformId: "facebook",
+                        },
+                    }))
+
+                    const res = await fetch("/api/platform/facebook/publish", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({
+                            pageId,
+                            message,
+                        }),
+                    })
+
+                    if (!res.ok) {
+                        const data = await res.json()
+                        throw new Error(
+                            data.message ||
+                                data.error ||
+                                "Failed to publish to Facebook"
+                        )
+                    }
+
+                    const result = await res.json()
+                    results.push({
+                        platformId: "facebook",
+                        success: true,
+                        url: result.url,
+                    })
+                } catch (err) {
+                    results.push({
+                        platformId: "facebook",
+                        success: false,
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : "Unknown error",
+                    })
+                }
             } else {
                 // Future: handle other platforms and post type
                 results.push({


### PR DESCRIPTION
## Summary
Connect PublishWizard to the existing Facebook text-post publishing API.

- **NetworkSelectStep.tsx**: Flip `implemented: false` → `true` and `connected: false` → `true` for Facebook, making it selectable in the wizard
- **PublishWizard.tsx**: Add Facebook text-post branch in `handlePublish()` that calls `POST /api/platform/facebook/publish` with `{pageId, message}`, following the same pattern as YouTube posting

## Risk Assessment
**Risk Level:** MEDIUM
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- `src/components/publish/wizard/NetworkSelectStep.tsx` — Enable Facebook as implemented and connected
- `src/components/publish/wizard/PublishWizard.tsx` — Add Facebook text-post publishing branch with validation, API call, and error handling

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Build passes

Closes #163

_Generated by engineering-loop | Cost-free: ✅_
