### PR TITLE
fix: add members-only visibility and scheduled publishing support for YouTube

### DIFF
--- a/src/app/api/platform/youtube/publish/route.ts
+++ b/src/app/api/platform/youtube/publish/route.ts
@@ -172,6 +172,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             ? (privacyRaw as "public" | "unlisted" | "private")
             : "unlisted"
 
+        // Extract membersOnly flag
+        const membersOnly = formData.get("membersOnly")?.toString() === "true"
+
+        // Extract publishAt for scheduled publishing
+        const publishAt = formData.get("publishAt")?.toString().trim() || undefined
+
+        // When membersOnly is true, enforce privacyStatus as "private"
+        const effectivePrivacy: "public" | "unlisted" | "private" =
+            membersOnly ? "private" : privacyStatus
+
+        // When publishAt is provided, enforce privacyStatus as "private" (YouTube requirement)
+        const finalPrivacy: "public" | "unlisted" | "private" =
+            publishAt ? "private" : effectivePrivacy
+
         // Extract tags
         const tagsRaw = formData.get("tags")?.toString().trim() || ""
         const tags = tagsRaw
@@ -200,7 +214,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             title,
             description,
             tags,
-            privacyStatus,
+            privacyStatus: finalPrivacy,
+            membersOnly,
+            publishAt,
         })
 
         if (!result.success) {

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -301,6 +301,26 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                         "adSuitability",
                         JSON.stringify(meta.adSuitability)
                     )
+                    formData.append(
+                        "membersOnly",
+                        meta.membersOnly ? "true" : "false"
+                    )
+
+                    // Compute publishAt from scheduledDate + scheduledTime
+                    if (meta.scheduledDate && meta.scheduledTime) {
+                        const scheduledDateTime = new Date(meta.scheduledDate)
+                        const [hours, minutes] = meta.scheduledTime
+                            .split(":")
+                            .map(Number)
+                        if (!isNaN(hours) && !isNaN(minutes)) {
+                            scheduledDateTime.setHours(hours, minutes, 0, 0)
+                            formData.append(
+                                "publishAt",
+                                scheduledDateTime.toISOString()
+                            )
+                        }
+                    }
+
                     if (meta.linkedVideoStart) {
                         formData.append(
                             "linkedVideoStart",

--- a/src/components/publish/wizard/VisibilityStep.tsx
+++ b/src/components/publish/wizard/VisibilityStep.tsx
@@ -384,6 +384,29 @@ export default function VisibilityStep({
                         </Select>
                     </div>
 
+                    {/* Members-only toggle */}
+                    <div className="space-y-3 border-t pt-3 dark:border-gray-700">
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="checkbox"
+                                id="membersOnly"
+                                checked={youtubeMeta.membersOnly}
+                                onChange={e =>
+                                    setYouTubeMeta({
+                                        membersOnly: e.target.checked,
+                                    })
+                                }
+                                className="h-4 w-4 rounded border-gray-300"
+                            />
+                            <Label htmlFor="membersOnly" className="cursor-pointer">
+                                {t("step6.membersOnly")}
+                            </Label>
+                        </div>
+                        <p className="text-xs text-gray-400 ml-6">
+                            {t("step6.membersOnlyHint")}
+                        </p>
+                    </div>
+
                     {/* Schedule type */}
                     <div className="space-y-3 border-t pt-3 dark:border-gray-700">
                         <div className="flex gap-4">

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -120,6 +120,8 @@ export interface YouTubeMetadata {
     linkedVideoStart: string
     linkedVideoEnd: string
     privacyStatus: "public" | "unlisted" | "private"
+    membersOnly: boolean
+    publishAt: string | null // ISO 8601 string for scheduled publish
     scheduledDate: Date | null
     scheduledTime: string
 }
@@ -203,6 +205,8 @@ export const DEFAULT_YOUTUBE_METADATA: YouTubeMetadata = {
     linkedVideoStart: "",
     linkedVideoEnd: "",
     privacyStatus: "unlisted",
+    membersOnly: false,
+    publishAt: null,
     scheduledDate: null,
     scheduledTime: "",
 }

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -222,6 +222,8 @@
         "scheduleDate": "Veröffentlichungsdatum",
         "scheduleTime": "Uhrzeit",
         "scheduleHint": "Wenn du planst und gehst, wird der Upload verarbeitet, wenn du zurückkommst",
+        "membersOnly": "Nur-Mitglieder-Video (als privat hochladen, Mitglieder-Sichtbarkeit im YouTube Studio aktivieren)",
+        "membersOnlyHint": "Nur-Mitglieder-Videos werden als privat hochgeladen. Gehe nach dem Hochladen ins YouTube Studio, um die Sichtbarkeit auf Nur-Mitglieder umzustellen.",
         "scheduleNow": "Jetzt veröffentlichen",
         "scheduleLater": "Für später planen",
         "scheduleWarning": "Wenn du planst und den Browser schließt, wird das Video hochgeladen, wenn du zurückkommst und eingeloggt bist. Die Verarbeitung erfolgt lokal."

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -222,6 +222,8 @@
         "scheduleDate": "Publish Date",
         "scheduleTime": "Publish Time",
         "scheduleHint": "If you schedule and leave, the upload will process when you return",
+        "membersOnly": "Members-only video (upload as private, set members-only in YouTube Studio)",
+        "membersOnlyHint": "Members-only videos are uploaded as private. After uploading, go to YouTube Studio to enable the members-only visibility setting.",
         "scheduleNow": "Publish now",
         "scheduleLater": "Schedule for later",
         "scheduleWarning": "If you schedule and close the browser, the video will be uploaded when you return and are logged in. Processing is local."

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -222,6 +222,8 @@
         "scheduleDate": "Fecha de Publicación",
         "scheduleTime": "Hora",
         "scheduleHint": "Si programas y cierras sesión, la subida se procesará cuando vuelvas",
+        "membersOnly": "Video solo para miembros (subir como privado, configurar en YouTube Studio)",
+        "membersOnlyHint": "Los videos solo para miembros se suben como privados. Después de subir, ve a YouTube Studio para activar la visibilidad solo para miembros.",
         "scheduleNow": "Publicar ahora",
         "scheduleLater": "Programar para después",
         "scheduleWarning": "Si programas y cierras el navegador, el video se subirá cuando regreses e inicies sesión. El procesamiento es local."

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -222,6 +222,8 @@
         "scheduleDate": "Data de Publicação",
         "scheduleTime": "Horário",
         "scheduleHint": "Se você programar e sair, o upload será processado quando você voltar",
+        "membersOnly": "Vídeo exclusivo para membros (enviar como privado, definir como exclusivo no YouTube Studio)",
+        "membersOnlyHint": "Vídeos exclusivos para membros são enviados como privados. Após o envio, vá ao YouTube Studio para ativar a visibilidade exclusiva para membros.",
         "scheduleNow": "Publicar agora",
         "scheduleLater": "Agendar para depois",
         "scheduleWarning": "Se você agendar e fechar o navegador, o vídeo será enviado quando você retornar e estiver logado. O processamento é local."

--- a/src/lib/posting/adapters/youtube.ts
+++ b/src/lib/posting/adapters/youtube.ts
@@ -10,6 +10,8 @@ export interface YouTubePostConfig {
     description: string
     tags?: string[]
     privacyStatus: "public" | "unlisted" | "private"
+    membersOnly?: boolean
+    publishAt?: string // ISO 8601 date for scheduled publishing
     categoryId?: string
     madeForKids?: boolean
 }
@@ -48,6 +50,16 @@ export async function uploadVideo(
 
         const youtube = google.youtube({ version: "v3", auth })
 
+        // Determine effective privacy status
+        // When membersOnly is true or publishAt is set, YouTube requires "private"
+        let effectivePrivacy = config.privacyStatus
+        if (config.membersOnly) {
+            effectivePrivacy = "private"
+        }
+        if (config.publishAt) {
+            effectivePrivacy = "private"
+        }
+
         const res = await youtube.videos.insert({
             part: ["snippet", "status"],
             notifySubscribers: false,
@@ -59,7 +71,8 @@ export async function uploadVideo(
                     categoryId: config.categoryId || "22",
                 },
                 status: {
-                    privacyStatus: config.privacyStatus,
+                    privacyStatus: effectivePrivacy,
+                    publishAt: config.publishAt,
                     madeForKids: config.madeForKids ?? false,
                     selfDeclaredMadeForKids: config.madeForKids ?? false,
                 },
@@ -106,6 +119,7 @@ export async function postToYouTube(
  * Queue-compatible publish method.
  * Matches the interface expected by PublicationQueue.
  * YouTube only supports video uploads - use uploadVideo for actual publishing.
+ * This function is kept for interface compatibility and provides guidance.
  */
 export async function publish(config: {
     content: string
@@ -115,7 +129,7 @@ export async function publish(config: {
 }): Promise<{ id?: string; url?: string; success: boolean; error?: string }> {
     return {
         success: false,
-        error: "YouTube scheduled publishing is not supported. YouTube requires a video file for publishing, which cannot be provided via scheduled posts.",
+        error: "YouTube only supports video uploads via the video upload wizard. Please use the upload endpoint with a video file to publish to YouTube.",
     }
 }
 


### PR DESCRIPTION
## Summary

Adds members-only / member-first visibility option and fixes scheduled publishing for YouTube when publishing from the wizard.

Closes #180

## Changes

### types.ts
- Added `membersOnly: boolean` to `YouTubeMetadata` interface
- Added `publishAt: string | null` to `YouTubeMetadata` for ISO 8601 scheduled publish date
- Updated `DEFAULT_YOUTUBE_METADATA` with defaults for both fields

### VisibilityStep.tsx
- Added members-only checkbox in the Privacy & Scheduling card
- Added guidance text explaining members-only videos are uploaded as private
- Users can enable members-only visibility when uploading

### PublishWizard.tsx
- Computes `publishAt` ISO string from `scheduledDate` + `scheduledTime`
- Appends `membersOnly` and `publishAt` to FormData when publishing to YouTube

### YouTube API Route (route.ts)
- Accepts `membersOnly` and `publishAt` from form data
- Enforces `privacyStatus: "private"` when membersOnly or publishAt is set (YouTube API requirement)
- Passes both fields to `uploadVideo`

### YouTube Adapter (youtube.ts)
- Added `membersOnly` and `publishAt` to `YouTubePostConfig`
- Passes `publishAt` as `status.publishAt` in API request body for scheduled publishing
- Enforces private status when membersOnly or publishAt is set
- Fixed `publish()` error message to provide helpful guidance instead of incorrect error

### i18n
- Added `step6.membersOnly` and `step6.membersOnlyHint` in all 4 locales (en, pt-BR, de, es)

## Risk Assessment

**Risk Level:** Medium (feature enhancement for existing YouTube publish flow)
**Cost:** Free (all changes local, YouTube Data API is free with quota)

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (2 pre-existing failures in unrelated tests)
- [x] Build passes

Closes #180

_Generated by engineering-loop | Cost-free: ✅_
