### PR TITLE
fix: make publish wizard title generic instead of YouTube-specific

### DIFF
--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -79,10 +79,8 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
     /** Check if the wizard has any meaningful content the user might lose */
     const hasContent = (): boolean => {
         const c = wizardState.content
-        const meta =
-            wizardState.platformMetadata.youtube as
-                | YouTubeMetadata
-                | undefined
+        const meta = wizardState.platformMetadata.youtube as
+            YouTubeMetadata | undefined
 
         // Has a file uploaded
         if (c.videoFile || c.thumbnailFile || c.images.length > 0) return true
@@ -261,10 +259,8 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                         continue
                     }
 
-                    const meta =
-                        wizardState.platformMetadata.youtube as
-                            | YouTubeMetadata
-                            | undefined
+                    const meta = wizardState.platformMetadata.youtube as
+                        YouTubeMetadata | undefined
                     if (!meta) {
                         results.push({
                             platformId: "youtube",

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -1,6 +1,6 @@
 {
     "wizard": {
-        "title": "Auf YouTube veröffentlichen",
+        "title": "Veröffentlichen",
         "step": "Schritt {current} von {total}",
         "next": "Weiter",
         "back": "Zurück",

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -1,6 +1,6 @@
 {
     "wizard": {
-        "title": "Publish to YouTube",
+        "title": "Publish",
         "step": "Step {current} of {total}",
         "next": "Next",
         "back": "Back",

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -1,6 +1,6 @@
 {
     "wizard": {
-        "title": "Publicar en YouTube",
+        "title": "Publicar",
         "step": "Paso {current} de {total}",
         "next": "Siguiente",
         "back": "Volver",

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -1,6 +1,6 @@
 {
     "wizard": {
-        "title": "Publicar no YouTube",
+        "title": "Publicar",
         "step": "Passo {current} de {total}",
         "next": "Próximo",
         "back": "Voltar",


### PR DESCRIPTION
## Summary
Make the publish wizard title generic (remove YouTube-specific wording) across all 4 supported locales. The wizard will now be called "Publish" / "Publicar" / "Veröffentlichen" / "Publicar" instead of referencing YouTube specifically.

Closes #181

## Risk Assessment
**Risk Level:** Low
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- `src/i18n/en/publish.json`: "Publish to YouTube" → "Publish"
- `src/i18n/pt-BR/publish.json`: "Publicar no YouTube" → "Publicar"
- `src/i18n/de/publish.json`: "Auf YouTube veröffentlichen" → "Veröffentlichen"
- `src/i18n/es/publish.json`: "Publicar en YouTube" → "Publicar"

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Build passes

Closes #181

_Generated by engineering-loop | Cost-free: ✅_
