### PR TITLE
fix: show actual linked account count in NetworkSelectStep instead of hardcoded flags

### DIFF
--- a/src/components/publish/wizard/NetworkSelectStep.tsx
+++ b/src/components/publish/wizard/NetworkSelectStep.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -11,7 +12,7 @@ import {
 } from "@icons-pack/react-simple-icons"
 import { FaLinkedin } from "react-icons/fa6"
 import { useTranslations } from "next-intl"
-import { CheckCircle, Lock, XCircle, AlertCircle } from "lucide-react"
+import { CheckCircle, AlertCircle, Loader2 } from "lucide-react"
 import type { PlatformInfo, ContentType } from "./types"
 import { CONTENT_TYPE_PLATFORMS } from "./types"
 
@@ -23,14 +24,28 @@ interface NetworkSelectStepProps {
     contentType: ContentType
 }
 
-const NETWORKS: PlatformInfo[] = [
+interface SocialChannel {
+    id: string
+    platform: string
+    accountId: string
+    accountName: string
+    isConnected: boolean
+    thumbnailUrl?: string
+    connectedAt?: string
+    needsReconnect?: boolean
+    currentScopeVersion?: number
+}
+
+interface ChannelsResponse {
+    channels: SocialChannel[]
+}
+
+const BASE_NETWORKS: PlatformInfo[] = [
     {
         id: "youtube",
         labelKey: "step1.youtube",
         descKey: "step1.youtubeDesc",
         icon: <SiYoutube className="h-6 w-6 text-red-600" />,
-        implemented: true,
-        connected: true,
         features: [
             "text",
             "video",
@@ -51,8 +66,6 @@ const NETWORKS: PlatformInfo[] = [
         labelKey: "step1.facebook",
         descKey: "step1.facebookDesc",
         icon: <SiFacebook className="h-6 w-6 text-blue-600" />,
-        implemented: true,
-        connected: true,
         features: ["text", "images", "channel_selection"],
     },
     {
@@ -60,8 +73,6 @@ const NETWORKS: PlatformInfo[] = [
         labelKey: "step1.instagram",
         descKey: "step1.instagramDesc",
         icon: <SiInstagram className="h-6 w-6 text-pink-600" />,
-        implemented: false,
-        connected: false,
         features: ["text", "images", "video"],
     },
     {
@@ -69,8 +80,6 @@ const NETWORKS: PlatformInfo[] = [
         labelKey: "step1.twitter",
         descKey: "step1.twitterDesc",
         icon: <SiX className="h-6 w-6 text-gray-800 dark:text-gray-200" />,
-        implemented: false,
-        connected: false,
         features: ["text", "images"],
     },
     {
@@ -78,8 +87,6 @@ const NETWORKS: PlatformInfo[] = [
         labelKey: "step1.linkedin",
         descKey: "step1.linkedinDesc",
         icon: <FaLinkedin className="h-6 w-6 text-blue-700" />,
-        implemented: false,
-        connected: false,
         features: ["text", "images"],
     },
 ]
@@ -92,10 +99,57 @@ export default function NetworkSelectStep({
     contentType,
 }: NetworkSelectStepProps) {
     const t = useTranslations("publish")
+    const [channels, setChannels] = useState<SocialChannel[]>([])
+    const [loading, setLoading] = useState(true)
+    const [fetchError, setFetchError] = useState(false)
+
+    useEffect(() => {
+        let cancelled = false
+
+        async function fetchChannels() {
+            try {
+                const res = await fetch("/api/user/channels")
+                if (!res.ok) {
+                    throw new Error(`HTTP ${res.status}`)
+                }
+                const data: ChannelsResponse = await res.json()
+                if (!cancelled) {
+                    setChannels(data.channels || [])
+                    setLoading(false)
+                }
+            } catch {
+                if (!cancelled) {
+                    setFetchError(true)
+                    setLoading(false)
+                }
+            }
+        }
+
+        fetchChannels()
+
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    // Group channels by platform and count connected ones
+    const platformChannelCount: Record<string, number> = {}
+    for (const ch of channels) {
+        if (ch.isConnected) {
+            platformChannelCount[ch.platform] =
+                (platformChannelCount[ch.platform] || 0) + 1
+        }
+    }
+
+    // Merge channel counts into network definitions
+    const networks: PlatformInfo[] = BASE_NETWORKS.map(n => ({
+        ...n,
+        channelCount: platformChannelCount[n.id] || 0,
+    }))
 
     // Filter platforms by content type compatibility
     const compatibleIds = CONTENT_TYPE_PLATFORMS[contentType] || []
-    const filteredNetworks = NETWORKS.filter(n => compatibleIds.includes(n.id))
+    const filteredNetworks = networks.filter(n => compatibleIds.includes(n.id))
 
     const togglePlatform = (platformId: string) => {
         if (selectedPlatforms.includes(platformId)) {
@@ -105,8 +159,8 @@ export default function NetworkSelectStep({
         }
     }
 
-    const isImplemented = (id: string) => {
-        return NETWORKS.find(n => n.id === id)?.implemented ?? false
+    const isAvailable = (id: string): boolean => {
+        return platformChannelCount[id] > 0
     }
 
     return (
@@ -125,89 +179,115 @@ export default function NetworkSelectStep({
                 </div>
             </div>
 
-            <div className="grid gap-4">
-                {filteredNetworks.map(network => {
-                    const isSelected = selectedPlatforms.includes(network.id)
-                    const implemented = network.implemented
+            {/* Loading state */}
+            {loading && (
+                <div className="flex items-center justify-center py-8">
+                    <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                    <span className="ml-2 text-sm text-gray-500">
+                        {t("step2.loadingChannels")}
+                    </span>
+                </div>
+            )}
 
-                    return (
-                        <Card
-                            key={network.id}
-                            className={`relative overflow-hidden transition-all ${
-                                !implemented
-                                    ? "cursor-not-allowed opacity-60"
-                                    : isSelected
-                                      ? "border-2 border-blue-500 ring-2 ring-blue-500/20"
-                                      : "cursor-pointer border hover:border-blue-300 hover:shadow-sm dark:hover:border-blue-700"
-                            }`}
-                            onClick={() => {
-                                if (implemented) togglePlatform(network.id)
-                            }}
-                        >
-                            <div className="flex items-start gap-4 p-4">
-                                {/* Checkbox */}
-                                <div className="pt-1">
-                                    <Checkbox
-                                        checked={isSelected}
-                                        disabled={!implemented}
-                                        onCheckedChange={() =>
-                                            togglePlatform(network.id)
-                                        }
-                                    />
-                                </div>
+            {/* Error state */}
+            {fetchError && !loading && (
+                <div className="rounded-lg bg-red-50 p-4 text-sm text-red-800 dark:bg-red-950/30 dark:text-red-300">
+                    <p>{t("step2.noChannels")}</p>
+                </div>
+            )}
 
-                                {/* Icon */}
-                                <div className="flex-shrink-0 pt-1">
-                                    {network.icon}
-                                </div>
+            {/* Network cards */}
+            {!loading && (
+                <div className="grid gap-4">
+                    {filteredNetworks.map(network => {
+                        const isSelected = selectedPlatforms.includes(
+                            network.id
+                        )
+                        const available = isAvailable(network.id)
 
-                                {/* Content */}
-                                <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <h3 className="font-semibold">
-                                            {t(network.labelKey)}
-                                        </h3>
-                                        {implemented ? (
-                                            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                                                <CheckCircle className="h-3 w-3" />
-                                                {t("step1.implemented")}
-                                            </span>
-                                        ) : (
-                                            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                                <Lock className="h-3 w-3" />
-                                                {t("step1.notImplemented")}
-                                            </span>
-                                        )}
-                                    </div>
-                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                        {t(network.descKey)}
-                                    </p>
-
-                                    {/* Features / compatibility badges */}
-                                    <div className="mt-2 flex flex-wrap gap-1">
-                                        {network.features.map(feat => (
-                                            <span
-                                                key={feat}
-                                                className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                                            >
-                                                {feat_label(feat, t)}
-                                            </span>
-                                        ))}
+                        return (
+                            <Card
+                                key={network.id}
+                                className={`relative overflow-hidden transition-all ${
+                                    !available
+                                        ? "cursor-not-allowed opacity-60"
+                                        : isSelected
+                                          ? "border-2 border-blue-500 ring-2 ring-blue-500/20"
+                                          : "cursor-pointer border hover:border-blue-300 hover:shadow-sm dark:hover:border-blue-700"
+                                }`}
+                                onClick={() => {
+                                    if (available) {
+                                        togglePlatform(network.id)
+                                    }
+                                }}
+                            >
+                                <div className="flex items-start gap-4 p-4">
+                                    {/* Checkbox */}
+                                    <div className="pt-1">
+                                        <Checkbox
+                                            checked={isSelected}
+                                            disabled={!available}
+                                            onCheckedChange={() => {
+                                                if (available) {
+                                                    togglePlatform(network.id)
+                                                }
+                                            }}
+                                        />
                                     </div>
 
-                                    {/* Disconnected warning */}
-                                    {!network.connected && implemented && (
-                                        <span className="mt-2 inline-flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
-                                            <XCircle className="h-3 w-3" />
-                                            {t("step1.disconnected")}
-                                        </span>
-                                    )}
+                                    {/* Icon */}
+                                    <div className="flex-shrink-0 pt-1">
+                                        {network.icon}
+                                    </div>
+
+                                    {/* Content */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <h3 className="font-semibold">
+                                                {t(network.labelKey)}
+                                            </h3>
+                                            {/* Account count badge */}
+                                            {network.channelCount !==
+                                                undefined &&
+                                                network.channelCount > 0 && (
+                                                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                                                        <CheckCircle className="h-3 w-3" />
+                                                        {t(
+                                                            "step1.accountCount",
+                                                            {
+                                                                count: network.channelCount,
+                                                            }
+                                                        )}
+                                                    </span>
+                                                )}
+                                            {network.channelCount === 0 && (
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                                    {t("step1.noAccounts")}
+                                                </span>
+                                            )}
+                                        </div>
+                                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                            {t(network.descKey)}
+                                        </p>
+
+                                        {/* Features / compatibility badges */}
+                                        <div className="mt-2 flex flex-wrap gap-1">
+                                            {network.features.map(feat => (
+                                                <span
+                                                    key={feat}
+                                                    className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                                                >
+                                                    {feat_label(feat, t)}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
                                 </div>
-                            </div>
-                        </Card>
-                    )
-                })}
-            </div>
+                            </Card>
+                        )
+                    })}
+                </div>
+            )}
 
             {/* Navigation */}
             <div className="flex justify-between border-t pt-4 dark:border-gray-700">

--- a/src/components/publish/wizard/StorageModeStep.tsx
+++ b/src/components/publish/wizard/StorageModeStep.tsx
@@ -76,7 +76,7 @@ export default function StorageModeStep({
                                 </h3>
                                 <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
                                     <Lock className="h-3 w-3" />
-                                    {t("step1.notImplemented")}
+                                    {t("step3.notAvailable")}
                                 </span>
                             </div>
                             <p className="mt-1 text-sm text-gray-500">

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -33,8 +33,7 @@ export interface PlatformInfo {
     labelKey: string
     descKey: string
     icon: React.ReactNode
-    implemented: boolean
-    connected: boolean
+    channelCount?: number
     /** Which metadata sections this platform supports */
     features: PlatformFeature[]
 }

--- a/src/i18n/de/publish.json
+++ b/src/i18n/de/publish.json
@@ -42,9 +42,8 @@
         "twitterDesc": "Tweets mit Medien posten",
         "linkedin": "LinkedIn",
         "linkedinDesc": "Professionelle Inhalte teilen",
-        "notImplemented": "Nicht implementiert",
-        "disconnected": "Getrennt",
-        "implemented": "Implementiert",
+        "accountCount": "{count} Konto/Konten verknüpft",
+        "noAccounts": "Keine Konten verknüpft",
         "youtubeRecommended": "Wir empfehlen, mit YouTube zu beginnen, da es derzeit die einzige voll funktionsfähige Plattform ist."
     },
     "step2": {
@@ -71,7 +70,8 @@
         "cloud": "Cloud-Speicher",
         "cloudDescription": "Das Video würde vor der Veröffentlichung auf unsere Server hochgeladen werden. Diese Option wird bald verfügbar sein.",
         "cloudUnavailable": "Nicht verfügbar — Cloud-Speicher erfordert Infrastruktur-Upgrade",
-        "localSelected": "Lokal ausgewählt"
+        "localSelected": "Lokal ausgewählt",
+        "notAvailable": "Nicht verfügbar"
     },
     "step4": {
         "title": "Video-Details",

--- a/src/i18n/en/publish.json
+++ b/src/i18n/en/publish.json
@@ -42,9 +42,8 @@
         "twitterDesc": "Post tweets with media",
         "linkedin": "LinkedIn",
         "linkedinDesc": "Share professional content",
-        "notImplemented": "Not implemented",
-        "disconnected": "Disconnected",
-        "implemented": "Implemented",
+        "accountCount": "{count} linked account(s)",
+        "noAccounts": "No accounts linked",
         "youtubeRecommended": "We recommend starting with YouTube as it's the only fully functional platform at the moment."
     },
     "step2": {
@@ -71,7 +70,8 @@
         "cloud": "Cloud Storage",
         "cloudDescription": "The video would be uploaded to our servers before publishing. This option will be available soon.",
         "cloudUnavailable": "Unavailable — cloud storage requires infrastructure upgrade",
-        "localSelected": "Local selected"
+        "localSelected": "Local selected",
+        "notAvailable": "Not available"
     },
     "step4": {
         "title": "Video Details",

--- a/src/i18n/es/publish.json
+++ b/src/i18n/es/publish.json
@@ -42,9 +42,8 @@
         "twitterDesc": "Publica tweets con contenido multimedia",
         "linkedin": "LinkedIn",
         "linkedinDesc": "Comparte contenido profesional",
-        "notImplemented": "No implementado",
-        "disconnected": "Desconectado",
-        "implemented": "Implementado",
+        "accountCount": "{count} cuenta(s) vinculada(s)",
+        "noAccounts": "Ninguna cuenta vinculada",
         "youtubeRecommended": "Recomendamos empezar con YouTube, ya que es la única plataforma totalmente funcional actualmente."
     },
     "step2": {
@@ -71,7 +70,8 @@
         "cloud": "Almacenamiento en la Nube",
         "cloudDescription": "El video se enviaría a nuestros servidores antes de la publicación. Esta opción estará disponible pronto.",
         "cloudUnavailable": "No disponible — el almacenamiento en la nube requiere actualización de infraestructura",
-        "localSelected": "Local seleccionado"
+        "localSelected": "Local seleccionado",
+        "notAvailable": "No disponible"
     },
     "step4": {
         "title": "Detalles del Video",

--- a/src/i18n/pt-BR/publish.json
+++ b/src/i18n/pt-BR/publish.json
@@ -42,9 +42,8 @@
         "twitterDesc": "Poste tweets com mídia",
         "linkedin": "LinkedIn",
         "linkedinDesc": "Compartilhe conteúdo profissional",
-        "notImplemented": "Não implementado",
-        "disconnected": "Desconectado",
-        "implemented": "Implementado",
+        "accountCount": "{count} conta(s) vinculada(s)",
+        "noAccounts": "Nenhuma conta vinculada",
         "youtubeRecommended": "Recomendamos começar com YouTube, pois é a única plataforma totalmente funcional no momento."
     },
     "step2": {
@@ -71,7 +70,8 @@
         "cloud": "Armazenamento na Nuvem",
         "cloudDescription": "O vídeo seria enviado para nossos servidores antes da publicação. Esta opção estará disponível em breve.",
         "cloudUnavailable": "Indisponível no momento — armazenamento em nuvem requer atualização de infraestrutura",
-        "localSelected": "Local selecionado"
+        "localSelected": "Local selecionado",
+        "notAvailable": "Indisponível"
     },
     "step4": {
         "title": "Detalhes do Vídeo",


### PR DESCRIPTION
## Summary
Show real linked account counts in the NetworkSelectStep by fetching from \/api/user/channels\, instead of using hardcoded \implemented\/\connected\ booleans. Platforms with 0 linked accounts are grayed out and disabled.

Closes #183

## Risk Assessment
**Risk Level:** Medium (refactoring of UI component, no schema/DB changes)
**Cost:** ✅ Free (all changes local — i18n keys, component logic)

## Changes
- \src/components/publish/wizard/types.ts\: Removed \implemented\/\connected\ from \PlatformInfo\, added \channelCount?\ 
- \src/components/publish/wizard/NetworkSelectStep.tsx\: Rewrote to fetch channel data, group by platform, show account counts, disable platforms with 0 accounts
- \src/components/publish/wizard/StorageModeStep.tsx\: Replaced \step1.notImplemented\ with \step3.notAvailable\
- \src/i18n/en/publish.json\: Added \ccountCount\, \
oAccounts\, \
otAvailable\ keys; removed \implemented\, \
otImplemented\, \disconnected\
- \src/i18n/pt-BR/publish.json\: Same i18n changes
- \src/i18n/de/publish.json\: Same i18n changes
- \src/i18n/es/publish.json\: Same i18n changes

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Compilation succeeds

Closes #183

_Generated by engineering-loop | Cost-free: ✅_