### PR TITLE
fix: add dark mode text colors to PublishContainer title and description

### DIFF
--- a/src/components/publish/PublishContainer.tsx
+++ b/src/components/publish/PublishContainer.tsx
@@ -153,10 +153,10 @@ export const PublishContainer: React.FC<PublishContainerProps> = ({
             {/* Header */}
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                    <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">
+                    <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
                         {t("title")}
                     </h1>
-                    <p className="mt-1 text-xs sm:text-sm text-gray-600">
+                    <p className="mt-1 text-xs sm:text-sm text-gray-600 dark:text-gray-400">
                         {t("description")}
                     </p>
                 </div>
@@ -173,7 +173,7 @@ export const PublishContainer: React.FC<PublishContainerProps> = ({
 
             {/* Post Count */}
             {!isLoading && !error && sortedPosts.length > 0 && (
-                <div className="text-xs sm:text-sm text-gray-600">
+                <div className="text-xs sm:text-sm text-gray-600 dark:text-gray-400">
                     {t("postCount", {
                         shown: sortedPosts.length,
                         total: posts.length,

--- a/src/components/publish/wizard/PublishWizard.tsx
+++ b/src/components/publish/wizard/PublishWizard.tsx
@@ -79,10 +79,8 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
     /** Check if the wizard has any meaningful content the user might lose */
     const hasContent = (): boolean => {
         const c = wizardState.content
-        const meta =
-            wizardState.platformMetadata.youtube as
-                | YouTubeMetadata
-                | undefined
+        const meta = wizardState.platformMetadata.youtube as
+            YouTubeMetadata | undefined
 
         // Has a file uploaded
         if (c.videoFile || c.thumbnailFile || c.images.length > 0) return true
@@ -261,10 +259,8 @@ export default function PublishWizard({ onClose }: PublishWizardProps) {
                         continue
                     }
 
-                    const meta =
-                        wizardState.platformMetadata.youtube as
-                            | YouTubeMetadata
-                            | undefined
+                    const meta = wizardState.platformMetadata.youtube as
+                        YouTubeMetadata | undefined
                     if (!meta) {
                         results.push({
                             platformId: "youtube",


### PR DESCRIPTION
## Summary
Add dark mode text color classes to the PublishContainer component for the title, description, and post count elements to ensure proper visibility in dark theme.

**Risk Level:** Low
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- \src/components/publish/PublishContainer.tsx\: Added \dark:text-white\ to h1 title, \dark:text-gray-400\ to description paragraph and post count div

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Format passes

Closes #184

_Generated by engineering-loop | Cost-free: ✅_