### PR TITLE
Fix publish wizard navigation: returning to video upload step blocks progression

### DIFF
--- a/src/components/publish/wizard/VideoUploadStep.tsx
+++ b/src/components/publish/wizard/VideoUploadStep.tsx
@@ -175,11 +175,14 @@ export default function VideoUploadStep({
                 />
             </div>
 
-            {/* Navigation — only Back, auto-advances after upload */}
+            {/* Navigation — Back always shown, Next visible when video already in state */}
             <div className="flex justify-between border-t pt-4 dark:border-gray-700">
                 <Button onClick={onBack} variant="outline">
                     {t("wizard.back")}
                 </Button>
+                {videoFile && (
+                    <Button onClick={onNext}>{t("wizard.next")}</Button>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary
Fixes the publish wizard navigation bug described in #182. When a user navigates BACK to the video upload step (step 1) with a video already in state, there was no way to proceed — the step only auto-advances on new file selection.

This PR adds a conditional **Next** button that appears when \ideoFile\ already exists in state, allowing the user to proceed to the next step.

## Risk Assessment
**Risk Level:** Low — simple UI component change, no business logic, no database, no auth.
**Cost:** ✅ Free (all changes local)

## Changes
- \src/components/publish/wizard/VideoUploadStep.tsx\: Added conditional Next button in the bottom navigation section, shown when \ideoFile\ already exists in state

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Format passes

Closes #182

_Generated by engineering-loop | Cost-free: ✅_