### PR TITLE
fix: implement Instagram publishing - background processor, barrel export, wizard metadata

### DIFF
--- a/src/lib/posting/index.ts
+++ b/src/lib/posting/index.ts
@@ -18,3 +18,9 @@ export {
     type ConflictDetectionResult,
     type ConflictType,
 } from "./conflict-detector"
+
+export { postToInstagram } from "./adapters/instagram"
+export type {
+    InstagramPostConfig,
+    InstagramPostResult,
+} from "./adapters/instagram"

--- a/src/lib/queue/background-processor.ts
+++ b/src/lib/queue/background-processor.ts
@@ -147,6 +147,7 @@ export class BackgroundProcessor {
             network: string
             success: boolean
             externalId?: string
+            error?: string | null
         }> = []
         for (const network of publication.networks) {
             try {
@@ -168,6 +169,38 @@ export class BackgroundProcessor {
                         network: network.platform,
                         success: result.success,
                         externalId: result.postId,
+                    })
+                } else if (network.platform === "instagram") {
+                    const { postToInstagram } =
+                        await import("@/lib/posting/adapters/instagram")
+                    const { getNetworkManager } = await import("@/lib/networks")
+
+                    const networkManager = getNetworkManager()
+                    const igNetwork = await networkManager.getNetwork(
+                        publication.userId,
+                        "instagram"
+                    )
+
+                    if (!igNetwork) {
+                        results.push({
+                            network: network.platform,
+                            success: false,
+                            error: "Instagram account is not linked",
+                        })
+                        continue
+                    }
+
+                    const result = await postToInstagram({
+                        userId: publication.userId,
+                        accountId: igNetwork.platformUserId,
+                        caption: publication.content,
+                    })
+
+                    results.push({
+                        network: network.platform,
+                        success: result.success,
+                        externalId: result.postId,
+                        error: result.error || undefined,
                     })
                 } else {
                     results.push({


### PR DESCRIPTION
## Summary

Instagram publishing was 80% implemented but had 5 gaps. This PR fixes the remaining gaps:

### Gap 1: Background processor mocked Instagram
**File:** \src/lib/queue/background-processor.ts\
Added proper Instagram handler that calls the real \postToInstagram\ adapter instead of returning mock success. The handler:
- Dynamically imports the Instagram adapter and NetworkManager
- Looks up the user's linked Instagram Business Account via \NetworkManager.getNetwork\
- Calls \postToInstagram\ with the user ID, account ID, and caption
- Returns proper success/failure results

### Gap 2: Posting barrel export
**File:** \src/lib/posting/index.ts\
Added exports for \postToInstagram\, \InstagramPostConfig\, and \InstagramPostResult\ from the Instagram adapter.

### Gap 3 & 4: Already handled
- Wizard types (types.ts): Instagram already listed in \CONTENT_TYPE_PLATFORMS\, \PLATFORM_VIDEO_LIMITS\, and \PLATFORM_EXCLUSIVE_FEATURES\
- API routes (\posts/route.ts\): Instagram already in \VALID_PLATFORMS\
- No changes needed for these

### Gap 5: Production env var
Noted — no changes to \.env.production\ (has actual production values)

## Risk Assessment
**Risk Level:** Medium
**Cost:** ✅ Free (all changes local, no external API calls in the fix itself)

## Changes
- \src/lib/queue/background-processor.ts\ — Added Instagram handler in \publishToNetworks\ (33 lines)
- \src/lib/posting/index.ts\ — Added Instagram adapter exports (6 lines)

## Testing
- [x] Type check passes (\	sc --noEmit\)
- [x] Lint passes (\eslint\)
- [x] Tests pass (\itest --run\) — 6747 passed, 1 pre-existing test failure (unrelated)
- [x] Build passes

Closes #194

_Generated by engineering-loop | Cost-free: ✅_