### PR TITLE
Release v1.20.0: Instagram publishing, draft history UI, YouTube members-only visibility, and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Instagram publishing**: Full Instagram publishing support — background processor now calls real adapter instead of mock, barrel export added. ([#194](https://github.com/GabrielToth/gabrieltoth.com/issues/194), [#195](https://github.com/GabrielToth/gabrieltoth.com/pull/195))
+- **Draft management UI**: Post history with draft indicators (grayed-out cards), calendar shows gray dots for drafts and blue for scheduled/published. API-based draft CRUD replaces localStorage. ([#185](https://github.com/GabrielToth/gabrieltoth.com/issues/185), [#191](https://github.com/GabrielToth/gabrieltoth.com/pull/191))
+- **YouTube members-only visibility**: Added members-only option and scheduled publishing (publishAt) for YouTube videos. ([#180](https://github.com/GabrielToth/gabrieltoth.com/issues/180), [#186](https://github.com/GabrielToth/gabrieltoth.com/pull/186))
+
+### Changed
+- **Network select**: Now shows actual linked account count per platform instead of hardcoded "implemented"/"connected" booleans. Platforms with 0 accounts appear grayed out. ([#183](https://github.com/GabrielToth/gabrieltoth.com/issues/183), [#189](https://github.com/GabrielToth/gabrieltoth.com/pull/189))
+- **Publish wizard title**: Changed from "Publish to YouTube" to generic "Publish" across all 4 locales. ([#181](https://github.com/GabrielToth/gabrieltoth.com/issues/181), [#187](https://github.com/GabrielToth/gabrieltoth.com/pull/187))
+
 ### Fixed
-- **OAuth authorize routes**: Fixed "Conectar Canais" (Connect Channels) buttons not working. Replaced `x-user-id` header check with session-cookie-based authentication using `getServerSession()`. ([#100](https://github.com/GabrielToth/gabrieltoth.com/issues/100), [#102](https://github.com/GabrielToth/gabrieltoth.com/pull/102))
-- **Database migration**: Created missing `scheduled_posts`, `scheduled_post_networks`, `publication_history`, and `scheduled_post_media` tables that were defined in schema.sql but never applied to production. Fixes GET /api/posts/ 500 error. ([#101](https://github.com/GabrielToth/gabrieltoth.com/issues/101), [#103](https://github.com/GabrielToth/gabrieltoth.com/pull/103))
+- **Step navigation bug**: Added Next button to VideoUploadStep when navigating back with existing video, fixing blocked progression. ([#182](https://github.com/GabrielToth/gabrieltoth.com/issues/182), [#193](https://github.com/GabrielToth/gabrieltoth.com/pull/193))
+- **Dark mode readability**: Added `dark:text-white` to PublishContainer title and `dark:text-gray-400` to descriptions. ([#184](https://github.com/GabrielToth/gabrieltoth.com/issues/184), [#190](https://github.com/GabrielToth/gabrieltoth.com/pull/190))
 
 ## [1.16.0] - 2026-06-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gabrieltoth.com",
-    "version": "1.15.0",
+    "version": "1.20.0",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## Release v1.20.0

### Added
- Instagram publishing: background processor now calls real adapter, barrel export added (#194, #195)
- Draft management UI: post history with draft indicators (grayed-out cards), calendar shows gray dots for drafts (#185, #191)
- YouTube members-only visibility option and scheduled publishing (publishAt) (#180, #186)

### Changed
- NetworkSelectStep shows actual linked account count per platform; 0 accounts = grayed out (#183, #189)
- Publish wizard title changed from "Publish to YouTube" to generic "Publish" in all locales (#181, #187)

### Fixed
- Step navigation bug: Next button added to VideoUploadStep when returning with existing video (#182, #193)
- Dark mode: PublishContainer title and description now have proper dark:text- color variants (#184, #190)

Closes #180, #181, #182, #183, #184, #185, #194
