### PR TITLE
Release v1.21.0: TikTok publishing, Instagram publishing, draft history UI, and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TikTok publishing**: Full TikTok publishing end-to-end — NetworkSelect entry, metadata types, background processor, adapter barrel export, API route validation, publish status endpoint, content adapter config. ([#197](https://github.com/GabrielToth/gabrieltoth.com/issues/197), [#198](https://github.com/GabrielToth/gabrieltoth.com/pull/198))
 - **Instagram publishing**: Full Instagram publishing support — background processor now calls real adapter instead of mock, barrel export added. ([#194](https://github.com/GabrielToth/gabrieltoth.com/issues/194), [#195](https://github.com/GabrielToth/gabrieltoth.com/pull/195))
 - **Draft management UI**: Post history with draft indicators (grayed-out cards), calendar shows gray dots for drafts and blue for scheduled/published. API-based draft CRUD replaces localStorage. ([#185](https://github.com/GabrielToth/gabrieltoth.com/issues/185), [#191](https://github.com/GabrielToth/gabrieltoth.com/pull/191))
 - **YouTube members-only visibility**: Added members-only option and scheduled publishing (publishAt) for YouTube videos. ([#180](https://github.com/GabrielToth/gabrieltoth.com/issues/180), [#186](https://github.com/GabrielToth/gabrieltoth.com/pull/186))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gabrieltoth.com",
-    "version": "1.20.0",
+    "version": "1.21.0",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## Release v1.21.0

### Added
- TikTok publishing end-to-end: NetworkSelect entry, metadata types, background processor integration, adapter barrel export, API route validation, publish status endpoint (#197, #198)
- Instagram publishing: background processor now calls real adapter instead of mock, barrel export added (#194, #195)
- Draft management UI: post history with draft indicators, calendar dots, API-based draft CRUD (#185, #191)
- YouTube members-only visibility option and scheduled publishing (publishAt) (#180, #186)

### Changed
- NetworkSelectStep shows actual linked account count per platform; 0 accounts = grayed out (#183, #189)
- Publish wizard title changed from "Publish to YouTube" to generic "Publish" in all locales (#181, #187)

### Fixed
- Step navigation bug: Next button added to VideoUploadStep when returning with existing video (#182, #193)
- Dark mode: PublishContainer title and description now have proper dark:text- color variants (#184, #190)

Closes #180, #181, #182, #183, #184, #185, #194, #197
