### PR TITLE
Release v1.21.1: fix Facebook, TikTok, and Instagram OAuth authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Facebook and TikTok OAuth**: Fixed 500 error "Environment configuration is required" — added `process.env` fallback to config singletons so they work in serverless without explicit env parameter. Facebook also falls back to Instagram's app credentials. ([#200](https://github.com/GabrielToth/gabrieltoth.com/pull/200))
+
 ### Added
 - **TikTok publishing**: Full TikTok publishing end-to-end — NetworkSelect entry, metadata types, background processor, adapter barrel export, API route validation, publish status endpoint, content adapter config. ([#197](https://github.com/GabrielToth/gabrieltoth.com/issues/197), [#198](https://github.com/GabrielToth/gabrieltoth.com/pull/198))
 - **Instagram publishing**: Full Instagram publishing support — background processor now calls real adapter instead of mock, barrel export added. ([#194](https://github.com/GabrielToth/gabrieltoth.com/issues/194), [#195](https://github.com/GabrielToth/gabrieltoth.com/pull/195))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gabrieltoth.com",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## Release v1.21.1

### Fixed
- **Facebook OAuth**: Fixed 500 error — added process.env fallback to config singleton. Facebook now falls back to INSTAGRAM_APP_ID/SECRET/REDIRECT_URI when Facebook-specific vars are not set.
- **TikTok OAuth**: Fixed 500 error — added process.env fallback to config singleton so it reads TIKTOK_CLIENT_KEY/SECRET/REDIRECT_URI from serverless environment.

### Note
- **Instagram PLATFORM__INVALID_APP_ID**: The authorization URL is generated correctly but Facebook's OAuth dialog rejects the app. Verify in Meta Developer Console that:
  1. The app has Facebook Login + Instagram Graph API enabled
  2. The OAuth redirect URI is registered correctly
  3. The app is in Live mode (not Development)

Closes #200