### PR TITLE
fix: align CSRF cookie preference to match auth_session cookie (Issue #202)

### DIFF
--- a/src/lib/middleware/api-csrf-middleware.ts
+++ b/src/lib/middleware/api-csrf-middleware.ts
@@ -20,8 +20,8 @@ import {
  */
 function getSessionToken(request: NextRequest): string | null {
     return (
-        request.cookies.get("session")?.value ||
         request.cookies.get("auth_session")?.value ||
+        request.cookies.get("session")?.value ||
         null
     )
 }


### PR DESCRIPTION
Closes #202

## What changed
- Fixed cookie preference order in \pi-csrf-middleware.ts\ \getSessionToken()\: now prefers \uth_session\ cookie (the one actually set by login) over \session\ (legacy fallback)

## Root cause
The CSRF middleware was checking \session\ cookie FIRST and \uth_session\ second, but the application only sets \uth_session\ on login. In production, \session\ is undefined, so the fallback worked, but if any residual \session\ cookie existed from a previous version, the CSRF token would be generated with the wrong session token, causing logout to reject it with 403.