### PR TITLE
fix: update Facebook Graph API version from v18.0 to v22.0

### DIFF
--- a/src/__tests__/lib/oauth/oauth-manager.test.ts
+++ b/src/__tests__/lib/oauth/oauth-manager.test.ts
@@ -160,7 +160,7 @@ describe("OAuthManager", () => {
             )
 
             expect(result.authorizationUrl).toContain(
-                "https://www.facebook.com/v18.0/dialog/oauth"
+                "https://www.facebook.com/v22.0/dialog/oauth"
             )
             expect(result.authorizationUrl).toContain("display=popup")
             expect(result.authorizationUrl).toContain("client_id=")
@@ -183,6 +183,26 @@ describe("OAuthManager", () => {
         })
 
         it("should generate unique state for each call", async () => {
+            mockGenerateState
+                .mockReturnValueOnce({
+                    token: "state-1.signature1",
+                    payload: {
+                        userId: "user123",
+                        platform: "youtube",
+                        nonce: "nonce1",
+                        iat: Date.now(),
+                    },
+                })
+                .mockReturnValueOnce({
+                    token: "state-2.signature2",
+                    payload: {
+                        userId: "user123",
+                        platform: "youtube",
+                        nonce: "nonce2",
+                        iat: Date.now(),
+                    },
+                })
+
             const result1 = await manager.generateAuthorizationUrl(
                 "youtube",
                 "user123"

--- a/src/app/api/auth/oauth/callback/route.ts
+++ b/src/app/api/auth/oauth/callback/route.ts
@@ -56,7 +56,7 @@ async function exchangeCodeForToken(
         // Provider-specific token endpoints
         const tokenEndpoints: Record<string, string> = {
             google: "https://oauth2.googleapis.com/token",
-            facebook: "https://graph.facebook.com/v12.0/oauth/access_token",
+            facebook: "https://graph.facebook.com/v22.0/oauth/access_token",
             tiktok: "https://open-api.tiktok.com/oauth/access_token/",
         }
 

--- a/src/lib/oauth/oauth-manager.ts
+++ b/src/lib/oauth/oauth-manager.ts
@@ -124,8 +124,8 @@ export class OAuthManager {
                     "pages_read_engagement",
                     "pages_manage_metadata",
                 ],
-                authorizationUrl: "https://www.facebook.com/v18.0/dialog/oauth",
-                tokenUrl: "https://graph.facebook.com/v18.0/oauth/access_token",
+                authorizationUrl: "https://www.facebook.com/v22.0/dialog/oauth",
+                tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
             })
         }
 


### PR DESCRIPTION
Closes #203

## Changes
- Updated \oauth-manager.ts\: Facebook OAuth URLs from v18.0 → v22.0 (authorize + token exchange)
- Updated \callback/route.ts\: Facebook token exchange from v12.0 → v22.0 (was 10 versions behind!)
- Updated test to expect v22.0
- Fixed test mock for 'generate unique state' test to use \mockReturnValueOnce\ instead of always returning same value

## Why
oauth-manager.ts was using v18.0 for Facebook while the authorize route and all Facebook service files (posts.ts, comments.ts, live.ts, analytics.ts) use v22.0. The callback route was using v12.0 — 10 versions behind. This inconsistency could cause OAuth authorization failures.