### PR TITLE
feat: bypass Facebook/Instagram OAuth via env var tokens

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -544,6 +544,22 @@ FACEBOOK_APP_SECRET=your-facebook-app-secret-here
 # GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Development
 FACEBOOK_REDIRECT_URI=http://localhost:3000/api/oauth/callback/facebook
 
+# Facebook Page Access Token (bypass OAuth — get from Graph API Explorer)
+# When set, all Facebook API calls use this token instead of OAuth flow.
+# Only needed if Facebook Login OAuth is unavailable (see #oauth-bypass).
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+FACEBOOK_PAGE_ID=your-facebook-page-id
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+FACEBOOK_PAGE_ACCESS_TOKEN=
+
+# Instagram Business Account Token (bypass OAuth — get from Graph API Explorer)
+# When set, all Instagram API calls use this token instead of OAuth flow.
+# Only needed if Instagram Login OAuth is unavailable (see #oauth-bypass).
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+INSTAGRAM_BUSINESS_ACCOUNT_ID=your-instagram-business-account-id
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+INSTAGRAM_PAGE_ACCESS_TOKEN=
+
 # ============================================================================
 # EMAIL SERVICE (Required for YouTube Channel Linking Notifications)
 # ============================================================================

--- a/.env.production.example
+++ b/.env.production.example
@@ -327,6 +327,28 @@ YOUTUBE_CLIENT_SECRET=your-production-google-client-secret
 YOUTUBE_REDIRECT_URI=https://your-domain.com/api/oauth/callback/youtube
 
 # ============================================================================
+# FACEBOOK BYPASS (Optional — bypass OAuth if Facebook Login is unavailable)
+# ============================================================================
+#
+# When Facebook Login OAuth is blocked (requires App Review/CNPJ), set
+# these to a Page Access Token from Graph API Explorer instead.
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+FACEBOOK_PAGE_ID=your-facebook-page-id
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+FACEBOOK_PAGE_ACCESS_TOKEN=
+
+# ============================================================================
+# INSTAGRAM BYPASS (Optional — bypass OAuth if Instagram Login is unavailable)
+# ============================================================================
+#
+# When Instagram Login OAuth is blocked (requires App Review/CNPJ), set
+# these to a Page Access Token from Graph API Explorer instead.
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+INSTAGRAM_BUSINESS_ACCOUNT_ID=your-instagram-business-account-id
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+INSTAGRAM_PAGE_ACCESS_TOKEN=
+
+# ============================================================================
 # JWT SECRET (Required for OAuth Registration)
 # ============================================================================
 # 

--- a/src/app/api/platform/instagram/analytics/route.ts
+++ b/src/app/api/platform/instagram/analytics/route.ts
@@ -53,20 +53,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         }
 
         const tokenStore = getTokenStore()
-        const storedToken = await tokenStore.getToken(userId, "instagram")
-
-        if (!storedToken) {
-            logger.warn("Instagram not linked for user", { userId })
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "INSTAGRAM_NOT_LINKED",
-                    message: "Instagram account is not linked",
-                },
-                { status: 404 }
-            )
-        }
-
         const config = getInstagramConfig()
         const oauthService = getInstagramOAuthService(config)
         await oauthService.initialize()

--- a/src/app/api/platform/instagram/comments/[id]/route.ts
+++ b/src/app/api/platform/instagram/comments/[id]/route.ts
@@ -59,19 +59,6 @@ export async function DELETE(
         }
 
         const tokenStore = getTokenStore()
-        const storedToken = await tokenStore.getToken(userId, "instagram")
-
-        if (!storedToken) {
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "INSTAGRAM_NOT_LINKED",
-                    message: "Instagram account is not linked",
-                },
-                { status: 404 }
-            )
-        }
-
         const config = getInstagramConfig()
         const oauthService = getInstagramOAuthService(config)
         await oauthService.initialize()

--- a/src/app/api/platform/instagram/comments/route.ts
+++ b/src/app/api/platform/instagram/comments/route.ts
@@ -76,19 +76,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         const before = searchParams.get("before")
 
         const tokenStore = getTokenStore()
-        const storedToken = await tokenStore.getToken(userId, "instagram")
-
-        if (!storedToken) {
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "INSTAGRAM_NOT_LINKED",
-                    message: "Instagram account is not linked",
-                },
-                { status: 404 }
-            )
-        }
-
         const config = getInstagramConfig()
         const oauthService = getInstagramOAuthService(config)
         await oauthService.initialize()
@@ -240,19 +227,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         }
 
         const tokenStore = getTokenStore()
-        const storedToken = await tokenStore.getToken(userId, "instagram")
-
-        if (!storedToken) {
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "INSTAGRAM_NOT_LINKED",
-                    message: "Instagram account is not linked",
-                },
-                { status: 404 }
-            )
-        }
-
         const config = getInstagramConfig()
         const oauthService = getInstagramOAuthService(config)
         await oauthService.initialize()

--- a/src/app/api/platform/instagram/publish/route.ts
+++ b/src/app/api/platform/instagram/publish/route.ts
@@ -53,20 +53,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         }
 
         const tokenStore = getTokenStore()
-        const storedToken = await tokenStore.getToken(userId, "instagram")
-
-        if (!storedToken) {
-            logger.warn("Instagram not linked for user", { userId })
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "INSTAGRAM_NOT_LINKED",
-                    message: "Instagram account is not linked",
-                },
-                { status: 404 }
-            )
-        }
-
         let body: Record<string, unknown>
         try {
             body = await request.json()

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -49,6 +49,14 @@ export interface EnvironmentConfig {
     // Facebook Webhook (Meta verification handshake)
     FACEBOOK_WEBHOOK_VERIFY_TOKEN: string
 
+    // Facebook Page Access Token (bypass OAuth — from Graph API Explorer)
+    FACEBOOK_PAGE_ID: string
+    FACEBOOK_PAGE_ACCESS_TOKEN: string
+
+    // Instagram Business Account Token (bypass OAuth — from Graph API Explorer)
+    INSTAGRAM_BUSINESS_ACCOUNT_ID: string
+    INSTAGRAM_PAGE_ACCESS_TOKEN: string
+
     // Email via Supabase Auth (configured in Supabase Dashboard SMTP)
     EMAIL_FROM: string
 
@@ -106,6 +114,13 @@ function parseConfig(): EnvironmentConfig {
         FACEBOOK_REDIRECT_URI: process.env.FACEBOOK_REDIRECT_URI ?? "",
         FACEBOOK_WEBHOOK_VERIFY_TOKEN:
             process.env.FACEBOOK_WEBHOOK_VERIFY_TOKEN ?? "",
+        FACEBOOK_PAGE_ID: process.env.FACEBOOK_PAGE_ID ?? "",
+        FACEBOOK_PAGE_ACCESS_TOKEN:
+            process.env.FACEBOOK_PAGE_ACCESS_TOKEN ?? "",
+        INSTAGRAM_BUSINESS_ACCOUNT_ID:
+            process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ?? "",
+        INSTAGRAM_PAGE_ACCESS_TOKEN:
+            process.env.INSTAGRAM_PAGE_ACCESS_TOKEN ?? "",
         EMAIL_FROM: process.env.EMAIL_FROM ?? "noreply@gabrieltoth.com",
         RESEND_API_KEY: process.env.RESEND_API_KEY ?? "",
         RESEND_FROM_EMAIL:

--- a/src/lib/facebook/config.ts
+++ b/src/lib/facebook/config.ts
@@ -134,6 +134,13 @@ export function getFacebookConfig(env?: EnvironmentConfig): FacebookConfig {
             FACEBOOK_REDIRECT_URI: process.env.FACEBOOK_REDIRECT_URI ?? "",
             FACEBOOK_WEBHOOK_VERIFY_TOKEN:
                 process.env.FACEBOOK_WEBHOOK_VERIFY_TOKEN ?? "",
+            FACEBOOK_PAGE_ID: process.env.FACEBOOK_PAGE_ID ?? "",
+            FACEBOOK_PAGE_ACCESS_TOKEN:
+                process.env.FACEBOOK_PAGE_ACCESS_TOKEN ?? "",
+            INSTAGRAM_BUSINESS_ACCOUNT_ID:
+                process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ?? "",
+            INSTAGRAM_PAGE_ACCESS_TOKEN:
+                process.env.INSTAGRAM_PAGE_ACCESS_TOKEN ?? "",
             EMAIL_FROM: process.env.EMAIL_FROM ?? "noreply@gabrieltoth.com",
             RESEND_API_KEY: process.env.RESEND_API_KEY ?? "",
             RESEND_FROM_EMAIL:

--- a/src/lib/facebook/get-valid-token.ts
+++ b/src/lib/facebook/get-valid-token.ts
@@ -11,6 +11,11 @@ export async function getValidFacebookToken(
         oauthService?: FacebookOAuthService
     }
 ): Promise<string | null> {
+    const envToken = process.env.FACEBOOK_PAGE_ACCESS_TOKEN
+    if (envToken) {
+        return envToken
+    }
+
     const tokenStore = options?.tokenStore ?? getTokenStore()
 
     const stored = await tokenStore.getToken(userId, "facebook")

--- a/src/lib/facebook/oauth-service.ts
+++ b/src/lib/facebook/oauth-service.ts
@@ -319,6 +319,12 @@ export class FacebookOAuthService extends BaseService {
         pageId: string,
         userAccessToken: string
     ): Promise<string | null> {
+        const envToken = process.env.FACEBOOK_PAGE_ACCESS_TOKEN
+        const envPageId = process.env.FACEBOOK_PAGE_ID
+        if (envToken && envPageId && envPageId === pageId) {
+            return envToken
+        }
+
         this.assertReady()
 
         try {

--- a/src/lib/instagram/config.ts
+++ b/src/lib/instagram/config.ts
@@ -130,6 +130,13 @@ export function getInstagramConfig(env?: EnvironmentConfig): InstagramConfig {
             FACEBOOK_REDIRECT_URI: process.env.FACEBOOK_REDIRECT_URI ?? "",
             FACEBOOK_WEBHOOK_VERIFY_TOKEN:
                 process.env.FACEBOOK_WEBHOOK_VERIFY_TOKEN ?? "",
+            FACEBOOK_PAGE_ID: process.env.FACEBOOK_PAGE_ID ?? "",
+            FACEBOOK_PAGE_ACCESS_TOKEN:
+                process.env.FACEBOOK_PAGE_ACCESS_TOKEN ?? "",
+            INSTAGRAM_BUSINESS_ACCOUNT_ID:
+                process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ?? "",
+            INSTAGRAM_PAGE_ACCESS_TOKEN:
+                process.env.INSTAGRAM_PAGE_ACCESS_TOKEN ?? "",
             EMAIL_FROM: process.env.EMAIL_FROM ?? "noreply@gabrieltoth.com",
             RESEND_API_KEY: process.env.RESEND_API_KEY ?? "",
             RESEND_FROM_EMAIL:

--- a/src/lib/instagram/get-valid-token.ts
+++ b/src/lib/instagram/get-valid-token.ts
@@ -24,6 +24,11 @@ export async function getValidInstagramToken(
         oauthService?: InstagramOAuthService
     }
 ): Promise<string | null> {
+    const envToken = process.env.INSTAGRAM_PAGE_ACCESS_TOKEN
+    if (envToken) {
+        return envToken
+    }
+
     const tokenStore = options?.tokenStore ?? getTokenStore()
 
     const stored = await tokenStore.getToken(userId, "instagram")

--- a/src/lib/tiktok/config.ts
+++ b/src/lib/tiktok/config.ts
@@ -123,6 +123,13 @@ export function getTikTokConfig(env?: EnvironmentConfig): TikTokConfig {
             FACEBOOK_REDIRECT_URI: process.env.FACEBOOK_REDIRECT_URI ?? "",
             FACEBOOK_WEBHOOK_VERIFY_TOKEN:
                 process.env.FACEBOOK_WEBHOOK_VERIFY_TOKEN ?? "",
+            FACEBOOK_PAGE_ID: process.env.FACEBOOK_PAGE_ID ?? "",
+            FACEBOOK_PAGE_ACCESS_TOKEN:
+                process.env.FACEBOOK_PAGE_ACCESS_TOKEN ?? "",
+            INSTAGRAM_BUSINESS_ACCOUNT_ID:
+                process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ?? "",
+            INSTAGRAM_PAGE_ACCESS_TOKEN:
+                process.env.INSTAGRAM_PAGE_ACCESS_TOKEN ?? "",
             EMAIL_FROM: process.env.EMAIL_FROM ?? "noreply@gabrieltoth.com",
             RESEND_API_KEY: process.env.RESEND_API_KEY ?? "",
             RESEND_FROM_EMAIL:

--- a/src/lib/youtube/config.test.ts
+++ b/src/lib/youtube/config.test.ts
@@ -47,6 +47,10 @@ function createValidEnv(): EnvironmentConfig {
         FACEBOOK_REDIRECT_URI:
             "http://localhost:3000/api/oauth/callback/facebook",
         FACEBOOK_WEBHOOK_VERIFY_TOKEN: "test-verify-token",
+        FACEBOOK_PAGE_ID: "",
+        FACEBOOK_PAGE_ACCESS_TOKEN: "",
+        INSTAGRAM_BUSINESS_ACCOUNT_ID: "",
+        INSTAGRAM_PAGE_ACCESS_TOKEN: "",
         TOKEN_ENCRYPTION_KEY: "a".repeat(64), // 64 character hex string
     }
 }


### PR DESCRIPTION

## Summary

Bypass Facebook and Instagram OAuth flows using manual Page Access Tokens from Graph API Explorer, since Meta requires CNPJ for app review (permanently blocked).

## Changes

### Env vars added
- \FACEBOOK_PAGE_ID\, \FACEBOOK_PAGE_ACCESS_TOKEN\
- \INSTAGRAM_BUSINESS_ACCOUNT_ID\, \INSTAGRAM_PAGE_ACCESS_TOKEN\

### Token resolution (fallback order)
- **Facebook**: env var first, then DB token
- **Instagram**: env var first, then DB token
- **OAuthService.getPageAccessToken**: returns env token when pageId matches

### Instagram route fix
- Removed premature \	okenStore.getToken\ early-return from 5 route files that bypassed the \getValidInstagramToken\ logic entirely

### Env examples
- Updated \.env.local.example\ / \.env.production.example\ with correct sensitivity tags

## Validation
- Format, lint (0 errors), typecheck (0 errors), all tests passing

## Cost Declaration
Zero-cost. All free tiers and local development.

## Risk
Level: 🟡 HIGH — bypassing OAuth with manual tokens is a workaround, not a proper solution. Draft recommended for review.
