### PR TITLE
fix: add missing OAuth env vars to production example + TikTok token validation

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -327,6 +327,40 @@ YOUTUBE_CLIENT_SECRET=your-production-google-client-secret
 YOUTUBE_REDIRECT_URI=https://your-domain.com/api/oauth/callback/youtube
 
 # ============================================================================
+# FACEBOOK OAUTH (Required for Facebook Page Linking)
+# ============================================================================
+#
+# ⚠️ NOTE: FACEBOOK_APP_ID and INSTAGRAM_APP_ID are DIFFERENT IDs.
+# FACEBOOK_APP_ID = the main Facebook App ID (from developers.facebook.com)
+# INSTAGRAM_APP_ID = the Instagram-specific App ID within that Facebook App.
+# They are NOT interchangeable.
+#
+# How to set up for production:
+# 1. Go to: https://developers.facebook.com/
+# 2. Select your app
+# 3. Go to "Settings" > "Basic" to find the App ID and App Secret
+# 4. Go to "Facebook Login" > "Settings" and add the production redirect URI
+#    to "Valid OAuth Redirect URIs":
+#    - https://www.your-domain.com/api/oauth/callback/facebook
+#    - https://your-domain.com/api/oauth/callback/facebook
+# 5. Fill in the values below
+#
+# ============================================================================
+
+# Facebook App ID (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+FACEBOOK_APP_ID=your-production-facebook-app-id
+
+# Facebook App Secret (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+FACEBOOK_APP_SECRET=your-production-facebook-app-secret
+
+# Facebook OAuth Redirect URI (production)
+# Must match what's registered in Facebook App > Facebook Login > Settings
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+FACEBOOK_REDIRECT_URI=https://your-domain.com/api/oauth/callback/facebook
+
+# ============================================================================
 # FACEBOOK BYPASS (Optional — bypass OAuth if Facebook Login is unavailable)
 # ============================================================================
 #
@@ -338,6 +372,38 @@ FACEBOOK_PAGE_ID=your-facebook-page-id
 FACEBOOK_PAGE_ACCESS_TOKEN=
 
 # ============================================================================
+# INSTAGRAM OAUTH (Required for Instagram Business Account Linking)
+# ============================================================================
+#
+# Instagram uses the same Facebook App's OAuth infrastructure.
+# The INSTAGRAM_APP_ID is the Instagram product's App ID within your
+# Facebook App (found in Facebook App > Instagram > Basic Display).
+#
+# How to set up for production:
+# 1. Go to: https://developers.facebook.com/
+# 2. Select your app
+# 3. Go to "Instagram" > "Basic Display" to find the Instagram App ID
+# 4. Go to "Facebook Login" > "Settings" and add the production redirect URI:
+#    - https://www.your-domain.com/api/oauth/callback/instagram
+#    - https://your-domain.com/api/oauth/callback/instagram
+# 5. Note: Instagram OAuth is blocked without CNPJ (Advanced Access)
+#
+# ============================================================================
+
+# Instagram App ID (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+INSTAGRAM_APP_ID=your-production-instagram-app-id
+
+# Instagram App Secret (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+INSTAGRAM_APP_SECRET=your-production-instagram-app-secret
+
+# Instagram OAuth Redirect URI (production)
+# Must be added to Facebook App > Facebook Login > Settings > Valid OAuth Redirect URIs
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+INSTAGRAM_REDIRECT_URI=https://your-domain.com/api/oauth/callback/instagram
+
+# ============================================================================
 # INSTAGRAM BYPASS (Optional — bypass OAuth if Instagram Login is unavailable)
 # ============================================================================
 #
@@ -347,6 +413,34 @@ FACEBOOK_PAGE_ACCESS_TOKEN=
 INSTAGRAM_BUSINESS_ACCOUNT_ID=your-instagram-business-account-id
 # GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
 INSTAGRAM_PAGE_ACCESS_TOKEN=
+
+# ============================================================================
+# TIKTOK OAUTH (Required for TikTok Account Linking)
+# ============================================================================
+#
+# How to set up for production:
+# 1. Go to: https://developers.tiktok.com/
+# 2. Select your app
+# 3. Go to "Apps" > your app > "App Settings"
+# 4. Add the production redirect URI to "Redirect URL" in the web platform:
+#    - https://your-domain.com/api/oauth/callback/tiktok
+# 5. Copy "Client Key" (public, not sensitive) and "Client Secret" (sensitive)
+# 6. Fill in the values below
+#
+# ============================================================================
+
+# TikTok Client Key (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+TIKTOK_CLIENT_KEY=your-production-tiktok-client-key
+
+# TikTok Client Secret (production)
+# GitHub: ❌ DO NOT COMMIT | Vercel: ✅ SENSITIVE - Production/Preview
+TIKTOK_CLIENT_SECRET=your-production-tiktok-client-secret
+
+# TikTok OAuth Redirect URI (production)
+# Must match what's registered in TikTok App Settings
+# GitHub: ❌ DO NOT COMMIT | Vercel: ⚪ NOT SENSITIVE - Production/Preview
+TIKTOK_REDIRECT_URI=https://your-domain.com/api/oauth/callback/tiktok
 
 # ============================================================================
 # JWT SECRET (Required for OAuth Registration)

--- a/src/lib/tiktok/oauth-service.ts
+++ b/src/lib/tiktok/oauth-service.ts
@@ -120,11 +120,26 @@ export class TikTokOAuthService extends BaseService {
             )
         }
 
-        this.logger.info("TikTok authorization code exchanged for token")
+        this.logger.info("TikTok authorization code exchanged for token", {
+            hasAccessToken: !!data.access_token,
+            hasRefreshToken: !!data.refresh_token,
+            expiresIn: data.expires_in,
+            hasOpenId: !!data.open_id,
+            scope: data.scope,
+        })
+
+        if (!data.access_token) {
+            throw new ServiceError(
+                "TOKEN_EXCHANGE_FAILED",
+                "TikTok returned no access_token in response",
+                400,
+                { responseData: JSON.stringify(data) }
+            )
+        }
 
         return {
             accessToken: data.access_token,
-            refreshToken: data.refresh_token,
+            refreshToken: data.refresh_token || "",
             expiresIn: data.expires_in || 86400,
             tokenType: data.token_type || "bearer",
         }
@@ -202,6 +217,13 @@ export class TikTokOAuthService extends BaseService {
 
     async getUserInfo(accessToken: string): Promise<TikTokUser | null> {
         this.assertReady()
+
+        if (!accessToken) {
+            this.logger.error(
+                "Cannot get TikTok user info: no access token provided"
+            )
+            return null
+        }
 
         const fields = [
             "open_id",


### PR DESCRIPTION

## Summary

### 1. Missing OAuth env vars in .env.production.example
Added FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, FACEBOOK_REDIRECT_URI, INSTAGRAM_APP_ID, INSTAGRAM_APP_SECRET, INSTAGRAM_REDIRECT_URI, TIKTOK_CLIENT_KEY, TIKTOK_CLIENT_SECRET, TIKTOK_REDIRECT_URI to the production example file with setup instructions.

Without these vars set in Vercel, Facebook returns PLATFORM__INVALID_APP_ID and Instagram returns redirect URI whitelist errors.

### 2. TikTok token validation + better logging
- Added null check for accessToken in getUserInfo
- Added detailed logging of token exchange response (shows hasAccessToken, hasRefreshToken, hasOpenId, scope)
- Throws explicit error if TikTok returns no access_token

## Validation
Lint 0 errors, typecheck passed.

## Risk
Level: 🔵 LOW — env docs + validation improvements only.
