### PR TITLE
feat(chat): add YouTube, Facebook, Instagram live chat adapters

### DIFF
--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -31,7 +31,9 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
     const [messages, setMessages] = useState<ChatMessage[]>([])
     const [input, setInput] = useState("")
     const [connected, setConnected] = useState(false)
-    const [selectedPlatform, setSelectedPlatform] = useState(platforms[0] || "twitch")
+    const [selectedPlatform, setSelectedPlatform] = useState(
+        platforms[0] || "twitch"
+    )
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
     // Simulated connection (in production, connects to WebSocket/SSE backend)
@@ -96,12 +98,20 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
         // In production: await fetch(`/api/chat/timeout`, { method: 'POST', body: ... })
     }
 
-    const getPlatformBadge = (platform: string): { color: string; label: string } => {
+    const getPlatformBadge = (
+        platform: string
+    ): { color: string; label: string } => {
         switch (platform) {
             case "twitch":
                 return { color: "#9146FF", label: "Twitch" }
             case "kick":
                 return { color: "#53FC18", label: "Kick" }
+            case "youtube":
+                return { color: "#FF0000", label: "YouTube" }
+            case "facebook":
+                return { color: "#1877F2", label: "Facebook" }
+            case "instagram":
+                return { color: "#E4405F", label: "Instagram" }
             default:
                 return { color: "#6B7280", label: platform }
         }
@@ -128,7 +138,17 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                                 : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400"
                         }`}
                     >
-                        {platform === "twitch" ? "Twitch" : "Kick"}
+                        {platform === "twitch"
+                            ? "Twitch"
+                            : platform === "kick"
+                              ? "Kick"
+                              : platform === "youtube"
+                                ? "YouTube"
+                                : platform === "facebook"
+                                  ? "Facebook"
+                                  : platform === "instagram"
+                                    ? "Instagram"
+                                    : platform}
                     </button>
                 ))}
             </div>
@@ -162,7 +182,10 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                             {/* Badges */}
                             <div className="flex gap-0.5 shrink-0">
                                 {msg.isBroadcaster && (
-                                    <span className="text-xs" title="Broadcaster">
+                                    <span
+                                        className="text-xs"
+                                        title="Broadcaster"
+                                    >
                                         👑
                                     </span>
                                 )}

--- a/src/lib/chat/facebook-live-chat-adapter.test.ts
+++ b/src/lib/chat/facebook-live-chat-adapter.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for Facebook Live Chat Adapter
+ *
+ * Tests the FacebookLiveChatAdapter by mocking facebook/live.ts and
+ * facebook/comments.ts module functions.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+import { FacebookLiveChatAdapter } from "./facebook-live-chat-adapter"
+
+// Mock facebook/live.ts functions
+vi.mock("../facebook/live", () => ({
+    getLiveVideos: vi.fn(),
+    getLiveComments: vi.fn(),
+}))
+
+// Mock facebook/comments.ts functions
+vi.mock("../facebook/comments", () => ({
+    replyToComment: vi.fn(),
+}))
+
+import { getLiveVideos, getLiveComments } from "../facebook/live"
+import { replyToComment } from "../facebook/comments"
+
+describe("FacebookLiveChatAdapter", () => {
+    const roomId = "my-page-id"
+    const token = "test-facebook-token-123"
+    const liveVideoId = "live-video-456"
+
+    let adapter: FacebookLiveChatAdapter
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        adapter = new FacebookLiveChatAdapter()
+    })
+
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    const mockLiveVideo = {
+        id: liveVideoId,
+        status: "LIVE",
+        title: "Test Live Stream",
+        permalinkUrl: "https://facebook.com/watch/live-video-456",
+    }
+
+    const mockComment = (overrides = {}) => ({
+        id: "comment-1",
+        message: "Great stream!",
+        from: { name: "John Doe", id: "user-123" },
+        created_time: new Date().toISOString(),
+        ...overrides,
+    })
+
+    describe("connect", () => {
+        it("should find active live video and start polling", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+
+            expect(getLiveVideos).toHaveBeenCalledWith(token, roomId, {
+                limit: 10,
+            })
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).not.toBeNull()
+            expect(room!.platform).toBe("facebook")
+            expect(room!.isLive).toBe(true)
+        })
+
+        it("should throw error when no active live video found", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [],
+            })
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "No active Facebook Live video found for this page"
+            )
+        })
+
+        it("should skip non-live videos and find only LIVE status", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [
+                    { ...mockLiveVideo, status: "VOD" },
+                    { ...mockLiveVideo, id: "live-789", status: "LIVE" },
+                ],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+
+            // Should have connected to the LIVE video (second one)
+            const room = await adapter.getRoom(roomId)
+            expect(room).not.toBeNull()
+
+            // getLiveComments should have been called with the LIVE video ID
+            expect(getLiveComments).toHaveBeenCalledWith(token, "live-789")
+        })
+
+        it("should handle API error when fetching live videos", async () => {
+            vi.mocked(getLiveVideos).mockRejectedValueOnce(
+                new Error("Invalid page access token")
+            )
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "Invalid page access token"
+            )
+        })
+    })
+
+    describe("message delivery", () => {
+        it("should deliver comments to registered handler on connect", async () => {
+            const handler = vi.fn()
+
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            expect(handler).toHaveBeenCalled()
+            const chatMessage = handler.mock.calls[0][0]
+            expect(chatMessage.platform).toBe("facebook")
+            expect(chatMessage.content).toBe("Great stream!")
+        })
+
+        it("should deliver only unique comment IDs (deduplicate)", async () => {
+            const handler = vi.fn()
+            const comment = mockComment()
+
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            // Return same comment twice in one batch
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [comment, comment],
+            })
+
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            // Handler should only be called once for the unique ID
+            expect(handler).toHaveBeenCalledTimes(1)
+        })
+
+        it("should trigger onError when initial poll fails", async () => {
+            const errorHandler = vi.fn()
+
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockRejectedValueOnce(
+                new Error("Facebook API rate limit exceeded")
+            )
+
+            adapter.onError(errorHandler)
+            // pollCycle catches errors internally and notifies via onError,
+            // so connect() still resolves (does not throw)
+            await adapter.connect(roomId, token)
+
+            expect(errorHandler).toHaveBeenCalled()
+            expect(errorHandler.mock.calls[0][0].message).toBe(
+                "Facebook API rate limit exceeded"
+            )
+        })
+    })
+
+    describe("disconnect", () => {
+        it("should clear state and stop polling", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+            await adapter.disconnect(roomId)
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).toBeNull()
+        })
+
+        it("should not throw on disconnect from unconnected room", async () => {
+            await expect(
+                adapter.disconnect("non-existent")
+            ).resolves.not.toThrow()
+        })
+    })
+
+    describe("sendMessage", () => {
+        it("should call replyToComment with correct parameters", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+            vi.mocked(replyToComment).mockResolvedValueOnce({
+                id: "reply-123",
+            })
+
+            await adapter.connect(roomId, token)
+            const messageId = await adapter.sendMessage(
+                roomId,
+                "Hello from dashboard!"
+            )
+
+            expect(messageId).toBe("reply-123")
+            expect(replyToComment).toHaveBeenCalledWith(
+                token,
+                liveVideoId,
+                "Hello from dashboard!"
+            )
+        })
+
+        it("should throw when not connected", async () => {
+            await expect(adapter.sendMessage(roomId, "Test")).rejects.toThrow(
+                "Not connected to Facebook live chat"
+            )
+        })
+
+        it("should throw when message exceeds max length", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+            const longMessage = "x".repeat(501)
+
+            await expect(
+                adapter.sendMessage(roomId, longMessage)
+            ).rejects.toThrow("Message exceeds Facebook max length of 500")
+        })
+    })
+
+    describe("getHistory", () => {
+        it("should fetch and return comments", async () => {
+            vi.mocked(getLiveVideos).mockResolvedValueOnce({
+                data: [mockLiveVideo],
+            })
+            vi.mocked(getLiveComments)
+                .mockResolvedValueOnce({
+                    data: [mockComment()], // initial poll during connect
+                })
+                .mockResolvedValue({
+                    data: [
+                        mockComment({ id: "c1", message: "First!" }),
+                        mockComment({ id: "c2", message: "Second!" }),
+                    ], // getHistory call
+                })
+
+            await adapter.connect(roomId, token)
+            const history = await adapter.getHistory(roomId)
+
+            expect(history).toHaveLength(2)
+            expect(history[0].content).toBe("First!")
+            expect(history[1].content).toBe("Second!")
+        })
+
+        it("should return empty array when not connected", async () => {
+            const history = await adapter.getHistory(roomId)
+            expect(history).toEqual([])
+        })
+    })
+})

--- a/src/lib/chat/facebook-live-chat-adapter.ts
+++ b/src/lib/chat/facebook-live-chat-adapter.ts
@@ -1,0 +1,362 @@
+/**
+ * Facebook Live Chat Adapter
+ * HTTP polling-based chat adapter for Facebook Live using Facebook Graph API.
+ * Implements the ChatAdapter interface for multi-platform unified chat.
+ *
+ * Note: Uses HTTP polling via fetch() — works in any runtime.
+ * Reuses existing facebook/live.ts and facebook/comments.ts API functions.
+ */
+
+import { createLogger } from "../logger"
+import type {
+    ChatAdapter,
+    ChatAdapterConfig,
+    ChatMessage,
+    ChatRoom,
+    ChatUser,
+    SendMessageOptions,
+} from "./types"
+import { getLiveVideos, getLiveComments } from "../facebook/live"
+import { replyToComment } from "../facebook/comments"
+
+const logger = createLogger("FacebookLiveChatAdapter")
+
+interface FacebookMessageHandler {
+    (message: ChatMessage): void
+}
+
+interface FacebookPollingState {
+    roomId: string
+    liveVideoId: string
+    token: string
+    intervalId: ReturnType<typeof setInterval> | null
+    seenCommentIds: Set<string>
+    connected: boolean
+    pageId: string
+}
+
+export class FacebookLiveChatAdapter implements ChatAdapter {
+    readonly platform = "facebook" as const
+    readonly config: ChatAdapterConfig = {
+        platform: "facebook",
+        enabled: true,
+        maxMessageLength: 500,
+        commands: [],
+    }
+
+    private pollingStates: Map<string, FacebookPollingState> = new Map()
+    private messageHandlers: Map<string, Set<FacebookMessageHandler>> =
+        new Map()
+    private errorHandlers: Set<(error: Error) => void> = new Set()
+    private readonly POLLING_INTERVAL_MS = 5000
+
+    /**
+     * Connect to a Facebook Live chat room
+     */
+    async connect(roomId: string, token: string): Promise<void> {
+        if (this.pollingStates.has(roomId)) {
+            logger.debug("Already connected to Facebook live chat", { roomId })
+            return
+        }
+
+        try {
+            // roomId is the Facebook Page ID
+            const pageId = roomId
+
+            // Find active live video
+            const liveVideos = await getLiveVideos(token, pageId, {
+                limit: 10,
+            })
+
+            const activeVideo = liveVideos.data.find(
+                video => video.status === "LIVE"
+            )
+
+            if (!activeVideo) {
+                throw new Error(
+                    "No active Facebook Live video found for this page"
+                )
+            }
+
+            const state: FacebookPollingState = {
+                roomId,
+                liveVideoId: activeVideo.id,
+                token,
+                intervalId: null,
+                seenCommentIds: new Set(),
+                connected: true,
+                pageId,
+            }
+
+            this.pollingStates.set(roomId, state)
+
+            // Start polling
+            await this.startPolling(state)
+
+            logger.info("Connected to Facebook live chat", {
+                roomId,
+                liveVideoId: activeVideo.id,
+            })
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.error("Failed to connect to Facebook live chat", {
+                roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+            throw err
+        }
+    }
+
+    /**
+     * Disconnect from a Facebook live chat room
+     */
+    async disconnect(roomId: string): Promise<void> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to Facebook live chat", { roomId })
+            return
+        }
+
+        this.stopPolling(state)
+        this.pollingStates.delete(roomId)
+        this.messageHandlers.delete(roomId)
+        logger.info("Disconnected from Facebook live chat", { roomId })
+    }
+
+    /**
+     * Send a message to Facebook live chat (replies to the live video)
+     */
+    async sendMessage(
+        roomId: string,
+        message: string,
+        _options?: SendMessageOptions
+    ): Promise<string> {
+        const state = this.pollingStates.get(roomId)
+        if (!state || !state.connected) {
+            throw new Error(`Not connected to Facebook live chat: ${roomId}`)
+        }
+
+        if (message.length > this.config.maxMessageLength) {
+            throw new Error(
+                `Message exceeds Facebook max length of ${this.config.maxMessageLength}`
+            )
+        }
+
+        // Post a comment to the live video
+        const result = await replyToComment(
+            state.token,
+            state.liveVideoId,
+            message
+        )
+
+        const messageId =
+            result.id ||
+            `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`
+
+        logger.debug("Message sent to Facebook live chat", {
+            roomId,
+            messageId,
+            length: message.length,
+        })
+
+        return messageId
+    }
+
+    /**
+     * Get room info
+     */
+    async getRoom(roomId: string): Promise<ChatRoom | null> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) return null
+
+        return {
+            id: roomId,
+            platform: "facebook",
+            name: roomId,
+            isLive: state.connected,
+        }
+    }
+
+    /**
+     * Get message history
+     */
+    async getHistory(roomId: string, _limit?: number): Promise<ChatMessage[]> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to Facebook live chat", { roomId })
+            return []
+        }
+
+        try {
+            const comments = await getLiveComments(
+                state.token,
+                state.liveVideoId,
+                {
+                    limit: _limit || 50,
+                }
+            )
+
+            return comments.data.map(comment =>
+                this.toChatMessage(state.liveVideoId, comment)
+            )
+        } catch (error) {
+            logger.warn("Failed to fetch Facebook live chat history", {
+                roomId,
+                error: String(error),
+            })
+            return []
+        }
+    }
+
+    /**
+     * Register a message handler for a room
+     */
+    onMessage(
+        roomId: string,
+        handler: (message: ChatMessage) => void
+    ): () => void {
+        if (!this.messageHandlers.has(roomId)) {
+            this.messageHandlers.set(roomId, new Set())
+        }
+
+        this.messageHandlers.get(roomId)!.add(handler)
+
+        return () => {
+            this.messageHandlers.get(roomId)?.delete(handler)
+        }
+    }
+
+    /**
+     * Register an error handler
+     */
+    onError(handler: (error: Error) => void): () => void {
+        this.errorHandlers.add(handler)
+        return () => {
+            this.errorHandlers.delete(handler)
+        }
+    }
+
+    /**
+     * Start the polling cycle
+     */
+    private async startPolling(state: FacebookPollingState): Promise<void> {
+        // Initial fetch — awaited so the first batch of messages populates seenCommentIds
+        await this.pollCycle(state)
+
+        // Start interval
+        state.intervalId = setInterval(() => {
+            this.pollCycle(state)
+        }, this.POLLING_INTERVAL_MS)
+    }
+
+    /**
+     * Stop the polling cycle
+     */
+    private stopPolling(state: FacebookPollingState): void {
+        state.connected = false
+        if (state.intervalId !== null) {
+            clearInterval(state.intervalId)
+            state.intervalId = null
+        }
+    }
+
+    /**
+     * Execute a single poll cycle
+     */
+    private async pollCycle(state: FacebookPollingState): Promise<void> {
+        try {
+            const comments = await getLiveComments(
+                state.token,
+                state.liveVideoId
+            )
+
+            for (const comment of comments.data) {
+                if (state.seenCommentIds.has(comment.id)) continue
+                state.seenCommentIds.add(comment.id)
+
+                const chatMessage = this.toChatMessage(
+                    state.liveVideoId,
+                    comment
+                )
+                this.notifyMessageHandlers(state.roomId, chatMessage)
+            }
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.warn("Facebook live chat poll cycle error", {
+                roomId: state.roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+        }
+    }
+
+    /**
+     * Convert a Facebook comment to our ChatMessage format
+     */
+    private toChatMessage(
+        channelId: string,
+        comment: {
+            id: string
+            message: string
+            from?: { name: string; id: string }
+            created_time?: string
+        }
+    ): ChatMessage {
+        const user: ChatUser = {
+            id: comment.from?.id || "unknown",
+            username: comment.from?.name?.toLowerCase() || "unknown",
+            displayName: comment.from?.name || "Unknown",
+            platform: "facebook",
+            badges: [],
+        }
+
+        return {
+            id: `facebook-${comment.id}`,
+            channelId,
+            platform: "facebook",
+            user,
+            content: comment.message || "",
+            type: "text",
+            timestamp: comment.created_time
+                ? new Date(comment.created_time).getTime()
+                : Date.now(),
+        }
+    }
+
+    /**
+     * Notify all message handlers for a room
+     */
+    private notifyMessageHandlers(roomId: string, message: ChatMessage): void {
+        const handlers = this.messageHandlers.get(roomId)
+        if (handlers) {
+            for (const handler of handlers) {
+                try {
+                    handler(message)
+                } catch (error) {
+                    logger.error("Message handler error", {
+                        roomId,
+                        error: String(error),
+                    })
+                }
+            }
+        }
+    }
+
+    /**
+     * Notify all error handlers
+     */
+    private notifyError(error: Error): void {
+        for (const handler of this.errorHandlers) {
+            try {
+                handler(error)
+            } catch (handlerError) {
+                logger.error("Error handler failed", {
+                    error: String(handlerError),
+                })
+            }
+        }
+    }
+}

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -5,6 +5,9 @@
 
 export { TwitchChatAdapter } from "./twitch-adapter"
 export { KickChatAdapter } from "./kick-adapter"
+export { YouTubeLiveChatAdapter } from "./youtube-live-chat-adapter"
+export { FacebookLiveChatAdapter } from "./facebook-live-chat-adapter"
+export { InstagramLiveChatAdapter } from "./instagram-live-chat-adapter"
 export type {
     ChatAdapter,
     ChatAdapterConfig,

--- a/src/lib/chat/instagram-live-chat-adapter.test.ts
+++ b/src/lib/chat/instagram-live-chat-adapter.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for Instagram Live Chat Adapter
+ *
+ * Tests the InstagramLiveChatAdapter by mocking instagram/comments.ts
+ * module functions and global.fetch for the media lookup.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+import { InstagramLiveChatAdapter } from "./instagram-live-chat-adapter"
+
+// Mock instagram/comments.ts functions
+vi.mock("../instagram/comments", () => ({
+    getComments: vi.fn(),
+    replyToComment: vi.fn(),
+}))
+
+import { getComments, replyToComment } from "../instagram/comments"
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe("InstagramLiveChatAdapter", () => {
+    const roomId = "ig-user-123"
+    const token = "test-instagram-token-456"
+    const mediaId = "media-789"
+
+    let adapter: InstagramLiveChatAdapter
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.clearAllMocks()
+        mockFetch.mockReset()
+        adapter = new InstagramLiveChatAdapter()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    const mockMediaResponse = (overrides = {}) => ({
+        data: [
+            {
+                id: mediaId,
+                media_type: "LIVE",
+                media_product_type: "LIVE",
+                permalink: "https://instagram.com/p/live-123",
+            },
+        ],
+        ...overrides,
+    })
+
+    const mockComment = (overrides = {}) => ({
+        id: "comment-1",
+        text: "Awesome live!",
+        timestamp: new Date().toISOString(),
+        username: "jane_doe",
+        ...overrides,
+    })
+
+    describe("connect", () => {
+        it("should find LIVE media and start polling", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+            expect(mockFetch.mock.calls[0][0]).toContain(
+                `/v25.0/${roomId}/media`
+            )
+            expect(mockFetch.mock.calls[0][0]).toContain("media_type")
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).not.toBeNull()
+            expect(room!.platform).toBe("instagram")
+            expect(room!.isLive).toBe(true)
+        })
+
+        it("should throw error when no LIVE media found", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [] }),
+            })
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "No active Instagram Live media found for this account"
+            )
+        })
+
+        it("should throw error when media API fails", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                json: async () => ({
+                    error: { message: "Invalid Instagram token" },
+                }),
+            })
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "Invalid Instagram token"
+            )
+        })
+
+        it("should handle media API network error", async () => {
+            mockFetch.mockRejectedValueOnce(new Error("Network failure"))
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "Network failure"
+            )
+        })
+    })
+
+    describe("polling", () => {
+        it("should deliver new comments via onMessage", async () => {
+            const handler = vi.fn()
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments).mockResolvedValueOnce({
+                data: [mockComment()], // initial poll
+            })
+
+            // Register handler before connect to catch initial poll
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            expect(handler).toHaveBeenCalled()
+            const chatMessage = handler.mock.calls[0][0]
+            expect(chatMessage.platform).toBe("instagram")
+            expect(chatMessage.content).toBe("Awesome live!")
+        })
+
+        it("should not re-emit duplicate comment IDs", async () => {
+            const handler = vi.fn()
+            const comment = mockComment()
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments)
+                .mockResolvedValueOnce({
+                    data: [comment], // initial poll
+                })
+                .mockResolvedValueOnce({
+                    data: [comment], // second poll — same comment
+                })
+
+            // Register handler before connect to catch initial poll
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            // Initial poll delivered 1 message
+            expect(handler).toHaveBeenCalledTimes(1)
+
+            // Second poll — same comment should not trigger handler
+            await vi.advanceTimersByTimeAsync(5000)
+            expect(handler).toHaveBeenCalledTimes(1)
+        })
+
+        it("should propagate API error during poll to error handler", async () => {
+            const errorHandler = vi.fn()
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments)
+                .mockResolvedValueOnce({
+                    data: [mockComment()],
+                })
+                .mockRejectedValueOnce(
+                    new Error("Instagram API rate limit exceeded")
+                )
+
+            await adapter.connect(roomId, token)
+            adapter.onError(errorHandler)
+
+            await vi.advanceTimersByTimeAsync(5000)
+            await vi.advanceTimersByTimeAsync(5000)
+
+            expect(errorHandler).toHaveBeenCalled()
+            expect(errorHandler.mock.calls[0][0].message).toBe(
+                "Instagram API rate limit exceeded"
+            )
+        })
+    })
+
+    describe("disconnect", () => {
+        it("should stop polling and clear state", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+            await adapter.disconnect(roomId)
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).toBeNull()
+        })
+
+        it("should not throw when disconnecting from unconnected room", async () => {
+            await expect(
+                adapter.disconnect("non-existent")
+            ).resolves.not.toThrow()
+        })
+    })
+
+    describe("sendMessage", () => {
+        it("should call replyToComment with correct parameters", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+            vi.mocked(replyToComment).mockResolvedValueOnce({
+                id: "reply-123",
+            })
+
+            await adapter.connect(roomId, token)
+            const messageId = await adapter.sendMessage(
+                roomId,
+                "Love the stream!"
+            )
+
+            expect(messageId).toBe("reply-123")
+            expect(replyToComment).toHaveBeenCalledWith(
+                token,
+                roomId,
+                mediaId,
+                "Love the stream!"
+            )
+        })
+
+        it("should throw when not connected", async () => {
+            await expect(adapter.sendMessage(roomId, "Test")).rejects.toThrow(
+                "Not connected to Instagram live chat"
+            )
+        })
+
+        it("should throw when message exceeds max length", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments).mockResolvedValueOnce({
+                data: [mockComment()],
+            })
+
+            await adapter.connect(roomId, token)
+            const longMessage = "x".repeat(501)
+
+            await expect(
+                adapter.sendMessage(roomId, longMessage)
+            ).rejects.toThrow("Message exceeds Instagram max length of 500")
+        })
+    })
+
+    describe("getHistory", () => {
+        it("should fetch and return comments", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockMediaResponse(),
+            })
+            vi.mocked(getComments)
+                .mockResolvedValueOnce({
+                    data: [mockComment()], // initial poll during connect
+                })
+                .mockResolvedValueOnce({
+                    data: [
+                        mockComment({ id: "c1", text: "First!" }),
+                        mockComment({ id: "c2", text: "Second!" }),
+                    ], // getHistory call
+                })
+
+            await adapter.connect(roomId, token)
+            const history = await adapter.getHistory(roomId)
+
+            expect(history).toHaveLength(2)
+            expect(history[0].content).toBe("First!")
+            expect(history[1].content).toBe("Second!")
+        })
+
+        it("should return empty array when not connected", async () => {
+            const history = await adapter.getHistory(roomId)
+            expect(history).toEqual([])
+        })
+    })
+})

--- a/src/lib/chat/instagram-live-chat-adapter.ts
+++ b/src/lib/chat/instagram-live-chat-adapter.ts
@@ -1,0 +1,400 @@
+/**
+ * Instagram Live Chat Adapter
+ * HTTP polling-based chat adapter for Instagram Live using Instagram Graph API.
+ * Implements the ChatAdapter interface for multi-platform unified chat.
+ *
+ * Note: Uses HTTP polling via fetch() — works in any runtime.
+ * Reuses existing instagram/comments.ts API functions.
+ */
+
+import { createLogger } from "../logger"
+import type {
+    ChatAdapter,
+    ChatAdapterConfig,
+    ChatMessage,
+    ChatRoom,
+    ChatUser,
+    SendMessageOptions,
+} from "./types"
+import { getComments, replyToComment } from "../instagram/comments"
+
+const logger = createLogger("InstagramLiveChatAdapter")
+
+interface InstagramMessageHandler {
+    (message: ChatMessage): void
+}
+
+interface InstagramPollingState {
+    roomId: string
+    mediaId: string
+    igUserId: string
+    token: string
+    intervalId: ReturnType<typeof setInterval> | null
+    seenCommentIds: Set<string>
+    connected: boolean
+}
+
+const GRAPH_API_BASE = "https://graph.facebook.com"
+const API_VERSION = "v25.0"
+
+export class InstagramLiveChatAdapter implements ChatAdapter {
+    readonly platform = "instagram" as const
+    readonly config: ChatAdapterConfig = {
+        platform: "instagram",
+        enabled: true,
+        maxMessageLength: 500,
+        commands: [],
+    }
+
+    private pollingStates: Map<string, InstagramPollingState> = new Map()
+    private messageHandlers: Map<string, Set<InstagramMessageHandler>> =
+        new Map()
+    private errorHandlers: Set<(error: Error) => void> = new Set()
+    private readonly POLLING_INTERVAL_MS = 5000
+
+    /**
+     * Connect to an Instagram Live chat room
+     */
+    async connect(roomId: string, token: string): Promise<void> {
+        if (this.pollingStates.has(roomId)) {
+            logger.debug("Already connected to Instagram live chat", {
+                roomId,
+            })
+            return
+        }
+
+        try {
+            // roomId is the Instagram Business Account ID
+            const igUserId = roomId
+
+            // Find active LIVE media
+            const mediaId = await this.findLiveMedia(token, igUserId)
+
+            if (!mediaId) {
+                throw new Error(
+                    "No active Instagram Live media found for this account"
+                )
+            }
+
+            const state: InstagramPollingState = {
+                roomId,
+                mediaId,
+                igUserId,
+                token,
+                intervalId: null,
+                seenCommentIds: new Set(),
+                connected: true,
+            }
+
+            this.pollingStates.set(roomId, state)
+
+            // Start polling
+            await this.startPolling(state)
+
+            logger.info("Connected to Instagram live chat", {
+                roomId,
+                mediaId,
+            })
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.error("Failed to connect to Instagram live chat", {
+                roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+            throw err
+        }
+    }
+
+    /**
+     * Disconnect from an Instagram live chat room
+     */
+    async disconnect(roomId: string): Promise<void> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to Instagram live chat", { roomId })
+            return
+        }
+
+        this.stopPolling(state)
+        this.pollingStates.delete(roomId)
+        this.messageHandlers.delete(roomId)
+        logger.info("Disconnected from Instagram live chat", { roomId })
+    }
+
+    /**
+     * Send a message to Instagram live chat (replies to the live media)
+     */
+    async sendMessage(
+        roomId: string,
+        message: string,
+        _options?: SendMessageOptions
+    ): Promise<string> {
+        const state = this.pollingStates.get(roomId)
+        if (!state || !state.connected) {
+            throw new Error(`Not connected to Instagram live chat: ${roomId}`)
+        }
+
+        if (message.length > this.config.maxMessageLength) {
+            throw new Error(
+                `Message exceeds Instagram max length of ${this.config.maxMessageLength}`
+            )
+        }
+
+        // Reply to the live media (post a comment)
+        const result = await replyToComment(
+            state.token,
+            state.igUserId,
+            state.mediaId,
+            message
+        )
+
+        const messageId =
+            result.id ||
+            `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`
+
+        logger.debug("Message sent to Instagram live chat", {
+            roomId,
+            messageId,
+            length: message.length,
+        })
+
+        return messageId
+    }
+
+    /**
+     * Get room info
+     */
+    async getRoom(roomId: string): Promise<ChatRoom | null> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) return null
+
+        return {
+            id: roomId,
+            platform: "instagram",
+            name: roomId,
+            isLive: state.connected,
+        }
+    }
+
+    /**
+     * Get message history
+     */
+    async getHistory(roomId: string, _limit?: number): Promise<ChatMessage[]> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to Instagram live chat", { roomId })
+            return []
+        }
+
+        try {
+            const comments = await getComments(
+                state.token,
+                state.igUserId,
+                state.mediaId,
+                { limit: _limit || 50 }
+            )
+
+            return comments.data.map(comment =>
+                this.toChatMessage(state.mediaId, comment)
+            )
+        } catch (error) {
+            logger.warn("Failed to fetch Instagram live chat history", {
+                roomId,
+                error: String(error),
+            })
+            return []
+        }
+    }
+
+    /**
+     * Register a message handler for a room
+     */
+    onMessage(
+        roomId: string,
+        handler: (message: ChatMessage) => void
+    ): () => void {
+        if (!this.messageHandlers.has(roomId)) {
+            this.messageHandlers.set(roomId, new Set())
+        }
+
+        this.messageHandlers.get(roomId)!.add(handler)
+
+        return () => {
+            this.messageHandlers.get(roomId)?.delete(handler)
+        }
+    }
+
+    /**
+     * Register an error handler
+     */
+    onError(handler: (error: Error) => void): () => void {
+        this.errorHandlers.add(handler)
+        return () => {
+            this.errorHandlers.delete(handler)
+        }
+    }
+
+    /**
+     * Find active LIVE media for the Instagram account
+     */
+    private async findLiveMedia(
+        token: string,
+        igUserId: string
+    ): Promise<string | null> {
+        const params = new URLSearchParams({
+            access_token: token,
+            fields: "media_type,media_product_type,permalink",
+        })
+
+        const url = `${GRAPH_API_BASE}/${API_VERSION}/${igUserId}/media?${params.toString()}`
+
+        const response = await fetch(url)
+
+        if (!response.ok) {
+            const error = await response.json()
+            throw new Error(
+                error.error?.message || "Failed to fetch Instagram media"
+            )
+        }
+
+        const data = await response.json()
+
+        if (!data.data || data.data.length === 0) {
+            return null
+        }
+
+        // Find the first LIVE media item
+        const liveMedia = data.data.find(
+            (item: {
+                media_type?: string
+                media_product_type?: string
+                id: string
+            }) =>
+                item.media_type === "LIVE" || item.media_product_type === "LIVE"
+        )
+
+        return liveMedia?.id || null
+    }
+
+    /**
+     * Start the polling cycle
+     */
+    private async startPolling(state: InstagramPollingState): Promise<void> {
+        // Initial fetch — awaited so the first batch of messages populates seenCommentIds
+        await this.pollCycle(state)
+
+        // Start interval
+        state.intervalId = setInterval(() => {
+            this.pollCycle(state)
+        }, this.POLLING_INTERVAL_MS)
+    }
+
+    /**
+     * Stop the polling cycle
+     */
+    private stopPolling(state: InstagramPollingState): void {
+        state.connected = false
+        if (state.intervalId !== null) {
+            clearInterval(state.intervalId)
+            state.intervalId = null
+        }
+    }
+
+    /**
+     * Execute a single poll cycle
+     */
+    private async pollCycle(state: InstagramPollingState): Promise<void> {
+        try {
+            const comments = await getComments(
+                state.token,
+                state.igUserId,
+                state.mediaId
+            )
+
+            for (const comment of comments.data) {
+                if (state.seenCommentIds.has(comment.id)) continue
+                state.seenCommentIds.add(comment.id)
+
+                const chatMessage = this.toChatMessage(state.mediaId, comment)
+                this.notifyMessageHandlers(state.roomId, chatMessage)
+            }
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.warn("Instagram live chat poll cycle error", {
+                roomId: state.roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+        }
+    }
+
+    /**
+     * Convert an Instagram comment to our ChatMessage format
+     */
+    private toChatMessage(
+        channelId: string,
+        comment: {
+            id: string
+            text: string
+            timestamp?: string
+            username?: string
+        }
+    ): ChatMessage {
+        const user: ChatUser = {
+            id: comment.id,
+            username: comment.username?.toLowerCase() || "unknown",
+            displayName: comment.username || "Unknown",
+            platform: "instagram",
+            badges: [],
+        }
+
+        return {
+            id: `instagram-${comment.id}`,
+            channelId,
+            platform: "instagram",
+            user,
+            content: comment.text || "",
+            type: "text",
+            timestamp: comment.timestamp
+                ? new Date(comment.timestamp).getTime()
+                : Date.now(),
+        }
+    }
+
+    /**
+     * Notify all message handlers for a room
+     */
+    private notifyMessageHandlers(roomId: string, message: ChatMessage): void {
+        const handlers = this.messageHandlers.get(roomId)
+        if (handlers) {
+            for (const handler of handlers) {
+                try {
+                    handler(message)
+                } catch (error) {
+                    logger.error("Message handler error", {
+                        roomId,
+                        error: String(error),
+                    })
+                }
+            }
+        }
+    }
+
+    /**
+     * Notify all error handlers
+     */
+    private notifyError(error: Error): void {
+        for (const handler of this.errorHandlers) {
+            try {
+                handler(error)
+            } catch (handlerError) {
+                logger.error("Error handler failed", {
+                    error: String(handlerError),
+                })
+            }
+        }
+    }
+}

--- a/src/lib/chat/youtube-live-chat-adapter.test.ts
+++ b/src/lib/chat/youtube-live-chat-adapter.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Tests for YouTube Live Chat Adapter
+ *
+ * Tests the YouTubeLiveChatAdapter by mocking global.fetch.
+ * Coverage: connect, disconnect, sendMessage, getHistory, polling, error handling.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+import { YouTubeLiveChatAdapter } from "./youtube-live-chat-adapter"
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe("YouTubeLiveChatAdapter", () => {
+    const roomId = "my-channel"
+    const token = "test-youtube-token-123"
+    const liveChatId = "Cg0KCnRlc3RfbGl2ZV9jDFgBKJgB"
+
+    let adapter: YouTubeLiveChatAdapter
+
+    beforeEach(() => {
+        mockFetch.mockReset()
+        vi.useFakeTimers()
+        adapter = new YouTubeLiveChatAdapter()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    const mockLiveBroadcastsResponse = (overrides = {}) => ({
+        items: [
+            {
+                id: "broadcast-1",
+                snippet: {
+                    liveChatId,
+                    title: "Test Stream",
+                    actualStartTime: new Date().toISOString(),
+                },
+                status: {
+                    lifeCycleStatus: "live",
+                    privacyStatus: "public",
+                },
+            },
+        ],
+        pollingIntervalMillis: 5000,
+        ...overrides,
+    })
+
+    const mockLiveChatMessagesResponse = (messages: any[] = []) => ({
+        items: messages,
+        nextPageToken: messages.length > 0 ? "next-page-token" : undefined,
+        pollingIntervalMillis: 5000,
+    })
+
+    const makeMessage = (overrides = {}) => ({
+        id: "msg-1",
+        snippet: {
+            type: "textMessageEvent",
+            publishedAt: new Date().toISOString(),
+            displayMessage: "Hello from YouTube!",
+            textMessageDetails: {
+                messageText: "Hello from YouTube!",
+            },
+            authorChannelId: "channel-123",
+        },
+        authorDetails: {
+            channelId: "channel-123",
+            displayName: "TestUser",
+            profileImageUrl: "https://example.com/avatar.png",
+            isChatModerator: false,
+            isChatOwner: false,
+            isChatSponsor: false,
+            isVerified: false,
+        },
+        ...overrides,
+    })
+
+    describe("connect", () => {
+        it("should find active broadcast and start polling", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () =>
+                        mockLiveChatMessagesResponse([makeMessage()]),
+                })
+
+            await adapter.connect(roomId, token)
+
+            // Should have called liveBroadcasts endpoint
+            expect(mockFetch).toHaveBeenCalledTimes(2)
+            expect(mockFetch.mock.calls[0][0]).toContain(
+                "/youtube/v3/liveBroadcasts"
+            )
+            expect(mockFetch.mock.calls[0][0]).toContain("mine=true")
+
+            // Should have called liveChat/messages
+            expect(mockFetch.mock.calls[1][0]).toContain(
+                "/youtube/v3/liveChat/messages"
+            )
+            expect(mockFetch.mock.calls[1][0]).toContain(
+                `liveChatId=${liveChatId}`
+            )
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).not.toBeNull()
+            expect(room!.platform).toBe("youtube")
+            expect(room!.isLive).toBe(true)
+        })
+
+        it("should throw error when no active broadcast found", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ items: [] }),
+            })
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "No active YouTube live broadcast found for this channel"
+            )
+        })
+
+        it("should throw error when broadcasts API fails", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => "Invalid credentials",
+            })
+
+            await expect(adapter.connect(roomId, token)).rejects.toThrow(
+                "Failed to fetch YouTube live broadcasts"
+            )
+        })
+    })
+
+    describe("polling", () => {
+        it("should receive messages and notify handlers", async () => {
+            const handler = vi.fn()
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () =>
+                        mockLiveChatMessagesResponse([makeMessage()]),
+                })
+
+            // Register handler before connect to catch the initial poll
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            expect(handler).toHaveBeenCalled()
+            const chatMessage = handler.mock.calls[0][0]
+            expect(chatMessage.platform).toBe("youtube")
+            expect(chatMessage.content).toBe("Hello from YouTube!")
+        })
+
+        it("should not re-emit duplicate messages", async () => {
+            const handler = vi.fn()
+            const message = makeMessage()
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                // Initial poll (now awaited inside connect)
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([message]),
+                })
+                // Second poll
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([message]),
+                })
+
+            // Register handler before connect to catch the initial poll
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            // Initial poll should have delivered 1 message
+            expect(handler).toHaveBeenCalledTimes(1)
+
+            // Second poll — same messages should not trigger handler
+            await vi.advanceTimersByTimeAsync(5000)
+            expect(handler).toHaveBeenCalledTimes(1)
+        })
+
+        it("should handle empty poll response without crashing", async () => {
+            const handler = vi.fn()
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                // Initial poll (awaited inside connect)
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+                // Timer poll
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+
+            // Register handler before connect
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            expect(handler).not.toHaveBeenCalled()
+
+            await vi.advanceTimersByTimeAsync(5000)
+            expect(handler).not.toHaveBeenCalled()
+        })
+
+        it("should trigger onError when API returns error during poll", async () => {
+            const errorHandler = vi.fn()
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                // Initial poll (awaited inside connect)
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+                // Timer poll — error
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 429,
+                    text: async () => "Rate limit exceeded",
+                })
+
+            // Register handler before connect
+            adapter.onError(errorHandler)
+            await adapter.connect(roomId, token)
+
+            await vi.advanceTimersByTimeAsync(5000)
+            await vi.advanceTimersByTimeAsync(5000)
+
+            expect(errorHandler).toHaveBeenCalled()
+            expect(errorHandler.mock.calls[0][0].message).toContain(
+                "Failed to fetch YouTube live chat messages"
+            )
+        })
+    })
+
+    describe("disconnect", () => {
+        it("should stop polling and clear state", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+
+            await adapter.connect(roomId, token)
+            await adapter.disconnect(roomId)
+
+            const room = await adapter.getRoom(roomId)
+            expect(room).toBeNull()
+        })
+
+        it("should not throw when disconnecting from unconnected room", async () => {
+            await expect(
+                adapter.disconnect("non-existent-room")
+            ).resolves.not.toThrow()
+        })
+    })
+
+    describe("sendMessage", () => {
+        it("should post message to YouTube API", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({ id: "sent-msg-1" }),
+                })
+
+            await adapter.connect(roomId, token)
+            const messageId = await adapter.sendMessage(roomId, "Test message")
+
+            expect(messageId).toBeTruthy()
+            expect(mockFetch.mock.calls[2][0]).toContain(
+                "/youtube/v3/liveChat/messages?part=snippet"
+            )
+            expect(mockFetch.mock.calls[2][1].method).toBe("POST")
+
+            const body = JSON.parse(mockFetch.mock.calls[2][1].body)
+            expect(body.snippet.liveChatId).toBe(liveChatId)
+            expect(body.snippet.textMessageDetails.messageText).toBe(
+                "Test message"
+            )
+        })
+
+        it("should throw when not connected", async () => {
+            await expect(adapter.sendMessage(roomId, "Hello")).rejects.toThrow(
+                "Not connected to YouTube live chat"
+            )
+        })
+
+        it("should throw when message exceeds max length", async () => {
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveChatMessagesResponse([]),
+                })
+
+            await adapter.connect(roomId, token)
+            const longMessage = "x".repeat(201)
+
+            await expect(
+                adapter.sendMessage(roomId, longMessage)
+            ).rejects.toThrow("Message exceeds YouTube max length of 200")
+        })
+    })
+
+    describe("getHistory", () => {
+        it("should return messages from fetch", async () => {
+            const msg1 = makeMessage({
+                id: "msg-1",
+                snippet: {
+                    ...makeMessage().snippet,
+                    displayMessage: "First message",
+                    textMessageDetails: { messageText: "First message" },
+                },
+            })
+            const msg2 = makeMessage({
+                id: "msg-2",
+                snippet: {
+                    ...makeMessage().snippet,
+                    displayMessage: "Second message",
+                    textMessageDetails: { messageText: "Second message" },
+                },
+            })
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () =>
+                        mockLiveChatMessagesResponse([msg1, msg2]),
+                })
+                // Second call for getHistory
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () =>
+                        mockLiveChatMessagesResponse([msg1, msg2]),
+                })
+
+            await adapter.connect(roomId, token)
+
+            // Clear seen IDs so getHistory returns messages
+            const history = await adapter.getHistory(roomId)
+
+            expect(history).toHaveLength(2)
+            expect(history[0].content).toBe("First message")
+            expect(history[1].content).toBe("Second message")
+        })
+
+        it("should return empty array when not connected", async () => {
+            const history = await adapter.getHistory(roomId)
+            expect(history).toEqual([])
+        })
+    })
+
+    describe("message types", () => {
+        it("should map superChatEvent to announcement type", async () => {
+            const handler = vi.fn()
+
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => mockLiveBroadcastsResponse(),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () =>
+                        mockLiveChatMessagesResponse([
+                            makeMessage({
+                                snippet: {
+                                    ...makeMessage().snippet,
+                                    type: "superChatEvent",
+                                },
+                            }),
+                        ]),
+                })
+
+            // Register handler before connect to catch the initial poll
+            adapter.onMessage(roomId, handler)
+            await adapter.connect(roomId, token)
+
+            expect(handler.mock.calls[0][0].type).toBe("announcement")
+        })
+    })
+})

--- a/src/lib/chat/youtube-live-chat-adapter.ts
+++ b/src/lib/chat/youtube-live-chat-adapter.ts
@@ -1,0 +1,569 @@
+/**
+ * YouTube Live Chat Adapter
+ * HTTP polling-based chat adapter for YouTube Live using YouTube Data API v3.
+ * Implements the ChatAdapter interface for multi-platform unified chat.
+ *
+ * Note: Uses HTTP polling via fetch() — works in any runtime (Node.js, browser, edge).
+ * Requires OAuth scope: youtube.readonly and/or youtube.
+ */
+
+import { createLogger } from "../logger"
+import type {
+    ChatAdapter,
+    ChatAdapterConfig,
+    ChatMessage,
+    ChatRoom,
+    ChatUser,
+    SendMessageOptions,
+} from "./types"
+
+const logger = createLogger("YouTubeLiveChatAdapter")
+
+const YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+interface YouTubeMessageHandler {
+    (message: ChatMessage): void
+}
+
+interface YouTubePollingState {
+    roomId: string
+    liveChatId: string
+    token: string
+    pollingIntervalMs: number
+    nextPageToken?: string
+    intervalId: ReturnType<typeof setInterval> | null
+    seenMessageIds: Set<string>
+    connected: boolean
+}
+
+interface YouTubeLiveBroadcast {
+    id: string
+    snippet: {
+        liveChatId: string
+        title: string
+        actualStartTime?: string
+    }
+    status: {
+        lifeCycleStatus: string
+        privacyStatus: string
+    }
+}
+
+interface YouTubeLiveChatMessage {
+    id: string
+    snippet: {
+        type: string
+        publishedAt: string
+        displayMessage: string
+        textMessageDetails?: {
+            messageText: string
+        }
+        authorChannelId: string
+    }
+    authorDetails: {
+        channelId: string
+        displayName: string
+        profileImageUrl: string
+        isChatModerator: boolean
+        isChatOwner: boolean
+        isChatSponsor: boolean
+        isVerified: boolean
+    }
+}
+
+export class YouTubeLiveChatAdapter implements ChatAdapter {
+    readonly platform = "youtube" as const
+    readonly config: ChatAdapterConfig = {
+        platform: "youtube",
+        enabled: true,
+        maxMessageLength: 200,
+        commands: [],
+    }
+
+    private pollingStates: Map<string, YouTubePollingState> = new Map()
+    private messageHandlers: Map<string, Set<YouTubeMessageHandler>> = new Map()
+    private errorHandlers: Set<(error: Error) => void> = new Set()
+    private readonly DEFAULT_POLLING_INTERVAL_MS = 5000
+
+    /**
+     * Connect to a YouTube Live chat room
+     */
+    async connect(roomId: string, token: string): Promise<void> {
+        if (this.pollingStates.has(roomId)) {
+            logger.debug("Already connected to YouTube live chat", { roomId })
+            return
+        }
+
+        try {
+            // Step 1: Find the active live broadcast to get the liveChatId
+            const liveChatId = await this.findLiveChatId(token)
+
+            if (!liveChatId) {
+                throw new Error(
+                    "No active YouTube live broadcast found for this channel"
+                )
+            }
+
+            // Step 2: Start polling
+            const state: YouTubePollingState = {
+                roomId,
+                liveChatId,
+                token,
+                pollingIntervalMs: this.DEFAULT_POLLING_INTERVAL_MS,
+                intervalId: null,
+                seenMessageIds: new Set(),
+                connected: true,
+            }
+
+            this.pollingStates.set(roomId, state)
+
+            // Start the polling cycle
+            await this.startPolling(state)
+
+            logger.info("Connected to YouTube live chat", {
+                roomId,
+                liveChatId,
+            })
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.error("Failed to connect to YouTube live chat", {
+                roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+            throw err
+        }
+    }
+
+    /**
+     * Disconnect from a YouTube live chat room
+     */
+    async disconnect(roomId: string): Promise<void> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to YouTube live chat", { roomId })
+            return
+        }
+
+        this.stopPolling(state)
+        this.pollingStates.delete(roomId)
+        this.messageHandlers.delete(roomId)
+        logger.info("Disconnected from YouTube live chat", { roomId })
+    }
+
+    /**
+     * Send a message to YouTube live chat
+     */
+    async sendMessage(
+        roomId: string,
+        message: string,
+        _options?: SendMessageOptions
+    ): Promise<string> {
+        const state = this.pollingStates.get(roomId)
+        if (!state || !state.connected) {
+            throw new Error(`Not connected to YouTube live chat: ${roomId}`)
+        }
+
+        if (message.length > this.config.maxMessageLength) {
+            throw new Error(
+                `Message exceeds YouTube max length of ${this.config.maxMessageLength}`
+            )
+        }
+
+        const messageId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`
+
+        const url = `${YOUTUBE_API_BASE}/liveChat/messages?part=snippet`
+
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${state.token}`,
+            },
+            body: JSON.stringify({
+                snippet: {
+                    liveChatId: state.liveChatId,
+                    type: "textMessageEvent",
+                    textMessageDetails: {
+                        messageText: message,
+                    },
+                },
+            }),
+        })
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to send YouTube live chat message: ${response.status} ${errorBody}`
+            )
+        }
+
+        logger.debug("Message sent to YouTube live chat", {
+            roomId,
+            messageId,
+            length: message.length,
+        })
+
+        return messageId
+    }
+
+    /**
+     * Get room info
+     */
+    async getRoom(roomId: string): Promise<ChatRoom | null> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) return null
+
+        return {
+            id: roomId,
+            platform: "youtube",
+            name: roomId,
+            isLive: state.connected,
+        }
+    }
+
+    /**
+     * Get message history
+     */
+    async getHistory(roomId: string, limit?: number): Promise<ChatMessage[]> {
+        const state = this.pollingStates.get(roomId)
+        if (!state) {
+            logger.debug("Not connected to YouTube live chat", { roomId })
+            return []
+        }
+
+        try {
+            const messages = await this.fetchLiveChatMessages(
+                state.liveChatId,
+                state.token,
+                undefined,
+                limit
+            )
+            return messages.map(msg =>
+                this.toChatMessage(state.liveChatId, msg)
+            )
+        } catch (error) {
+            logger.warn("Failed to fetch YouTube live chat history", {
+                roomId,
+                error: String(error),
+            })
+            return []
+        }
+    }
+
+    /**
+     * Register a message handler for a room
+     */
+    onMessage(
+        roomId: string,
+        handler: (message: ChatMessage) => void
+    ): () => void {
+        if (!this.messageHandlers.has(roomId)) {
+            this.messageHandlers.set(roomId, new Set())
+        }
+
+        this.messageHandlers.get(roomId)!.add(handler)
+
+        return () => {
+            this.messageHandlers.get(roomId)?.delete(handler)
+        }
+    }
+
+    /**
+     * Register an error handler
+     */
+    onError(handler: (error: Error) => void): () => void {
+        this.errorHandlers.add(handler)
+        return () => {
+            this.errorHandlers.delete(handler)
+        }
+    }
+
+    /**
+     * Find the active live broadcast's liveChatId
+     */
+    private async findLiveChatId(token: string): Promise<string | null> {
+        const url = `${YOUTUBE_API_BASE}/liveBroadcasts?part=snippet,status&mine=true`
+
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to fetch YouTube live broadcasts: ${response.status} ${errorBody}`
+            )
+        }
+
+        const data = await response.json()
+
+        if (!data.items || data.items.length === 0) {
+            return null
+        }
+
+        // Find the first active live broadcast
+        const activeBroadcast = data.items.find(
+            (item: YouTubeLiveBroadcast) =>
+                item.status?.lifeCycleStatus === "live"
+        )
+
+        if (!activeBroadcast || !activeBroadcast.snippet?.liveChatId) {
+            return null
+        }
+
+        // Use the pollingIntervalMillis from API if available
+        if (data.pollingIntervalMillis) {
+            const state = this.pollingStates.get(
+                Array.from(this.pollingStates.keys()).pop() || ""
+            )
+            if (state) {
+                state.pollingIntervalMs = Math.max(
+                    data.pollingIntervalMillis,
+                    2000
+                )
+            }
+        }
+
+        return activeBroadcast.snippet.liveChatId
+    }
+
+    /**
+     * Fetch live chat messages from the YouTube API
+     */
+    private async fetchLiveChatMessages(
+        liveChatId: string,
+        token: string,
+        pageToken?: string,
+        maxResults?: number
+    ): Promise<YouTubeLiveChatMessage[]> {
+        const params = new URLSearchParams({
+            liveChatId,
+            part: "snippet,authorDetails",
+        })
+
+        if (pageToken) {
+            params.set("pageToken", pageToken)
+        }
+        if (maxResults) {
+            params.set("maxResults", String(Math.min(maxResults, 200)))
+        }
+
+        const url = `${YOUTUBE_API_BASE}/liveChat/messages?${params.toString()}`
+
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to fetch YouTube live chat messages: ${response.status} ${errorBody}`
+            )
+        }
+
+        const data = await response.json()
+
+        // Update polling interval from API response
+        if (data.pollingIntervalMillis) {
+            this.updatePollingInterval(liveChatId, data.pollingIntervalMillis)
+        }
+
+        // Update nextPageToken
+        if (data.nextPageToken) {
+            this.updateNextPageToken(liveChatId, data.nextPageToken)
+        }
+
+        return data.items || []
+    }
+
+    /**
+     * Start the polling cycle for a room
+     */
+    private async startPolling(state: YouTubePollingState): Promise<void> {
+        // Do an initial fetch to get history — awaited so seenMessageIds is populated
+        await this.pollCycle(state)
+
+        // Start interval
+        state.intervalId = setInterval(() => {
+            this.pollCycle(state)
+        }, state.pollingIntervalMs)
+    }
+
+    /**
+     * Stop the polling cycle
+     */
+    private stopPolling(state: YouTubePollingState): void {
+        state.connected = false
+        if (state.intervalId !== null) {
+            clearInterval(state.intervalId)
+            state.intervalId = null
+        }
+    }
+
+    /**
+     * Execute a single poll cycle
+     */
+    private async pollCycle(state: YouTubePollingState): Promise<void> {
+        try {
+            const messages = await this.fetchLiveChatMessages(
+                state.liveChatId,
+                state.token,
+                state.nextPageToken
+            )
+
+            for (const msg of messages) {
+                if (state.seenMessageIds.has(msg.id)) continue
+                state.seenMessageIds.add(msg.id)
+
+                const chatMessage = this.toChatMessage(state.liveChatId, msg)
+                this.notifyMessageHandlers(state.roomId, chatMessage)
+            }
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error))
+            logger.warn("YouTube live chat poll cycle error", {
+                roomId: state.roomId,
+                error: err.message,
+            })
+            this.notifyError(err)
+        }
+    }
+
+    /**
+     * Convert a YouTube live chat message to our ChatMessage format
+     */
+    private toChatMessage(
+        channelId: string,
+        msg: YouTubeLiveChatMessage
+    ): ChatMessage {
+        const user: ChatUser = {
+            id: msg.authorDetails?.channelId || "unknown",
+            username:
+                msg.authorDetails?.displayName?.toLowerCase() || "unknown",
+            displayName: msg.authorDetails?.displayName || "Unknown",
+            platform: "youtube",
+            badges: [],
+            isBroadcaster: msg.authorDetails?.isChatOwner || false,
+            isModerator: msg.authorDetails?.isChatModerator || false,
+            isSubscriber: msg.authorDetails?.isChatSponsor || false,
+        }
+
+        const content =
+            msg.snippet?.textMessageDetails?.messageText ||
+            msg.snippet?.displayMessage ||
+            ""
+
+        let messageType: "text" | "system" | "announcement" | "subscription" =
+            "text"
+
+        switch (msg.snippet?.type) {
+            case "chatEndedEvent":
+                messageType = "system"
+                break
+            case "newSponsorEvent":
+                messageType = "subscription"
+                break
+            case "memberMilestoneEvent":
+                messageType = "subscription"
+                break
+            case "superChatEvent":
+            case "superStickerEvent":
+                messageType = "announcement"
+                break
+            default:
+                messageType = "text"
+        }
+
+        return {
+            id: `youtube-${msg.id}`,
+            channelId,
+            platform: "youtube",
+            user,
+            content,
+            type: messageType,
+            timestamp: msg.snippet?.publishedAt
+                ? new Date(msg.snippet.publishedAt).getTime()
+                : Date.now(),
+        }
+    }
+
+    /**
+     * Update the polling interval for a live chat
+     */
+    private updatePollingInterval(
+        liveChatId: string,
+        pollingIntervalMs: number
+    ): void {
+        const clampedInterval = Math.max(pollingIntervalMs, 2000)
+
+        for (const state of this.pollingStates.values()) {
+            if (state.liveChatId === liveChatId) {
+                state.pollingIntervalMs = clampedInterval
+
+                // Restart interval with new timing
+                if (state.intervalId !== null) {
+                    clearInterval(state.intervalId)
+                    state.intervalId = setInterval(() => {
+                        this.pollCycle(state)
+                    }, clampedInterval)
+                }
+                break
+            }
+        }
+    }
+
+    /**
+     * Update the next page token for a live chat
+     */
+    private updateNextPageToken(
+        liveChatId: string,
+        nextPageToken: string
+    ): void {
+        for (const state of this.pollingStates.values()) {
+            if (state.liveChatId === liveChatId) {
+                state.nextPageToken = nextPageToken
+                break
+            }
+        }
+    }
+
+    /**
+     * Notify all message handlers for a room
+     */
+    private notifyMessageHandlers(roomId: string, message: ChatMessage): void {
+        const handlers = this.messageHandlers.get(roomId)
+        if (handlers) {
+            for (const handler of handlers) {
+                try {
+                    handler(message)
+                } catch (error) {
+                    logger.error("Message handler error", {
+                        roomId,
+                        error: String(error),
+                    })
+                }
+            }
+        }
+    }
+
+    /**
+     * Notify all error handlers
+     */
+    private notifyError(error: Error): void {
+        for (const handler of this.errorHandlers) {
+            try {
+                handler(error)
+            } catch (handlerError) {
+                logger.error("Error handler failed", {
+                    error: String(handlerError),
+                })
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add YouTube, Facebook, and Instagram live chat adapters as HTTP-polling implementations of the ChatAdapter interface, referenced in issue #228.

**YouTube Live Chat**: Uses YouTube Data API v3 — finds active live broadcast via \/liveBroadcasts?mine=true\, extracts \liveChatId\, then polls \/liveChat/messages\ with the \pollingIntervalMillis\ from API response.

**Facebook Live Chat**: Uses Facebook Graph API — finds active live video via \getLiveVideos()\ with filter \status=LIVE\, then polls comments via \getLiveComments()\ on the live video ID. Uses existing \acebook/live.ts\ functions.

**Instagram Live Chat**: Uses Instagram Graph API — finds LIVE media via \/{igUserId}/media\ filtered by \media_type=LIVE\, then polls comments via \instagram/comments.ts\ \getComments()\.

All adapters follow the same \ChatAdapter\ interface pattern as the existing Twitch (IRC) and Kick (WebSocket) adapters. All are HTTP polling-based, work in any runtime (Node.js, browser, edge), and include seen-ID deduplication to avoid re-emitting messages.

## Risk Assessment

**Risk Level:** MEDIUM
**Cost:** ✅ Free (all changes local/local tools, uses existing OAuth tokens for all three platforms)

## Changes

- **\src/lib/chat/youtube-live-chat-adapter.ts\** — New file: YouTube live chat adapter (\~570 lines)
- **\src/lib/chat/facebook-live-chat-adapter.ts\** — New file: Facebook live chat adapter (\~362 lines)
- **\src/lib/chat/instagram-live-chat-adapter.ts\** — New file: Instagram live chat adapter (\~400 lines)
- **\src/lib/chat/index.ts\** — Added barrel exports for all three new adapters
- **\src/components/dashboard/live/unified-chat.tsx\** — Added platform badge colors (YouTube #FF0000, Facebook #1877F2, Instagram #E4405F) and button labels
- **\src/lib/chat/youtube-live-chat-adapter.test.ts\** — 15 test cases
- **\src/lib/chat/facebook-live-chat-adapter.test.ts\** — 13 test cases
- **\src/lib/chat/instagram-live-chat-adapter.test.ts\** — 15 test cases

## Testing

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (43/43)
- [x] Build passes (type-check)

Closes #228

_Generated by engineering-loop | Cost-free: ✅_