### PR TITLE
feat(live): add stream key management UI for Twitch and Kick

### DIFF
--- a/src/app/[locale]/dashboard/live/page.tsx
+++ b/src/app/[locale]/dashboard/live/page.tsx
@@ -6,6 +6,7 @@
 
 "use client"
 
+import { StreamKeyCard } from "@/components/dashboard/live/stream-key-card"
 import { UnifiedChat } from "@/components/dashboard/live/unified-chat"
 import { StreamStatusCard } from "@/components/dashboard/live/stream-status-card"
 import { StreamTitleEditor } from "@/components/dashboard/live/stream-title-editor"
@@ -179,6 +180,9 @@ export default function LiveDashboardPage() {
                     />
                 </div>
             </div>
+
+            {/* Stream Key */}
+            <StreamKeyCard platform={activePlatform} />
         </div>
     )
 }

--- a/src/app/api/live/stream-key/route.test.ts
+++ b/src/app/api/live/stream-key/route.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Stream Key Endpoint Unit Tests
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Use vi.hoisted to create a mutable variable accessible in hoisted vi.mock factories
+const { mockSingleResult } = vi.hoisted(() => {
+    const store: {
+        fn: () => Promise<{
+            data: Record<string, unknown> | null
+            error: { message: string; code: string } | null
+        }>
+    } = {
+        fn: () =>
+            Promise.resolve({
+                data: {
+                    id: "net_123",
+                    user_id: "user_123",
+                    platform: "twitch",
+                    platform_user_id: "broadcaster_123",
+                    platform_username: "testuser",
+                    status: "connected",
+                    metadata: {
+                        userId: "broadcaster_123",
+                        username: "testuser",
+                    },
+                    access_token: null,
+                },
+                error: null,
+            }),
+    }
+    return {
+        mockSingleResult: store,
+    }
+})
+
+vi.mock("@supabase/supabase-js", () => ({
+    createClient: vi.fn(() => ({
+        from: vi.fn(() => ({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        eq: vi.fn(() => ({
+                            single: vi.fn(() => mockSingleResult.fn()),
+                        })),
+                        single: vi.fn(() =>
+                            Promise.resolve({ data: null, error: null })
+                        ),
+                    })),
+                    single: vi.fn(() =>
+                        Promise.resolve({ data: null, error: null })
+                    ),
+                })),
+            })),
+        })),
+    })),
+}))
+
+// Mock getServerSession
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: vi.fn(),
+}))
+
+import { getServerSession } from "@/lib/auth/get-server-session"
+
+// Mock TokenStore
+vi.mock("@/lib/token-store", () => ({
+    getTokenStore: vi.fn(),
+}))
+
+import { getTokenStore } from "@/lib/token-store"
+
+// Mock Twitch services
+vi.mock("@/lib/twitch/config", () => ({
+    getTwitchConfig: vi.fn(() => ({
+        oauth: {
+            clientId: "test-client-id",
+            clientSecret: "test-client-secret",
+            redirectUri: "http://localhost:3000/api/oauth/callback/twitch",
+            scopes: [],
+        },
+        apiBaseUrl: "https://api.twitch.tv/helix",
+        oauthAuthorizeUrl: "https://id.twitch.tv/oauth2/authorize",
+        oauthTokenUrl: "https://id.twitch.tv/oauth2/token",
+        oauthRevokeUrl: "https://id.twitch.tv/oauth2/revoke",
+        ircUrl: "irc.chat.twitch.tv",
+        ircPort: 6667,
+        eventsubWsUrl: "wss://eventsub.wss.twitch.tv",
+        rateLimit: { requestsPerMinute: 800 },
+        security: { tokenExpiryBufferMs: 300000 },
+    })),
+}))
+
+vi.mock("@/lib/twitch/oauth-service", () => ({
+    getTwitchOAuthService: vi.fn(),
+    TwitchOAuthService: vi.fn(),
+}))
+
+import { getTwitchOAuthService } from "@/lib/twitch/oauth-service"
+import { GET } from "./route"
+
+function createMockRequest(platform?: string): Request {
+    const url = platform
+        ? `http://localhost:3000/api/live/stream-key?platform=${platform}`
+        : "http://localhost:3000/api/live/stream-key"
+    return new Request(url)
+}
+
+describe("Stream Key Endpoint", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset supabase mock to return valid data by default
+        mockSingleResult.fn = () =>
+            Promise.resolve({
+                data: {
+                    id: "net_123",
+                    user_id: "user_123",
+                    platform: "twitch",
+                    platform_user_id: "broadcaster_123",
+                    platform_username: "testuser",
+                    status: "connected",
+                    metadata: {
+                        userId: "broadcaster_123",
+                        username: "testuser",
+                    },
+                    access_token: null,
+                },
+                error: null,
+            })
+    })
+
+    describe("GET /api/live/stream-key", () => {
+        it("should return 401 without auth", async () => {
+            vi.mocked(getServerSession).mockResolvedValue(null)
+
+            const response = await GET(createMockRequest("twitch"))
+            const data = await response.json()
+
+            expect(response.status).toBe(401)
+            expect(data).toMatchObject({
+                success: false,
+                error: "UNAUTHORIZED",
+            })
+        })
+
+        it("should return 400 for invalid platform", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            const response = await GET(createMockRequest("youtube"))
+            const data = await response.json()
+
+            expect(response.status).toBe(400)
+            expect(data).toMatchObject({
+                success: false,
+                error: "INVALID_PLATFORM",
+            })
+        })
+
+        it("should return 404 when platform not connected", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            // Simulate no connected platform (PGRST116 = no rows)
+            mockSingleResult.fn = () =>
+                Promise.resolve({
+                    data: null,
+                    error: {
+                        message: "no rows found",
+                        code: "PGRST116",
+                    },
+                })
+
+            const response = await GET(createMockRequest("twitch"))
+            const data = await response.json()
+
+            expect(response.status).toBe(404)
+            expect(data).toMatchObject({
+                success: false,
+                error: "PLATFORM_NOT_CONNECTED",
+            })
+        })
+
+        it("should return 500 when Twitch token not found", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            // Mock TokenStore to return no token
+            const mockGetToken = vi.fn().mockResolvedValue(null)
+            vi.mocked(getTokenStore).mockReturnValue({
+                getToken: mockGetToken,
+            } as any)
+
+            const response = await GET(createMockRequest("twitch"))
+            const data = await response.json()
+
+            expect(response.status).toBe(500)
+            expect(data).toMatchObject({
+                success: false,
+                error: "TOKEN_NOT_FOUND",
+            })
+        })
+
+        it("should return stream key for Twitch on success", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            // Mock TokenStore to return a token
+            const mockGetToken = vi
+                .fn()
+                .mockResolvedValue({ accessToken: "twitch-access-token" })
+            vi.mocked(getTokenStore).mockReturnValue({
+                getToken: mockGetToken,
+            } as any)
+
+            // Mock Twitch OAuth service to return a stream key
+            const mockGetStreamKey = vi
+                .fn()
+                .mockResolvedValue({ streamKey: "live_123456_abc123" })
+            const mockInitialize = vi.fn()
+            vi.mocked(getTwitchOAuthService).mockReturnValue({
+                initialize: mockInitialize,
+                getStreamKey: mockGetStreamKey,
+            } as any)
+
+            const response = await GET(createMockRequest("twitch"))
+            const data = await response.json()
+
+            expect(response.status).toBe(200)
+            expect(data).toMatchObject({
+                success: true,
+                key: "live_123456_abc123",
+            })
+        })
+
+        it("should return success for Kick with no key", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            // For Kick, the supabase mock should return a Kick network
+            mockSingleResult.fn = () =>
+                Promise.resolve({
+                    data: {
+                        id: "net_456",
+                        user_id: "user_123",
+                        platform: "kick",
+                        platform_user_id: "kick_user_123",
+                        platform_username: "kickuser",
+                        status: "connected",
+                        metadata: { username: "kickuser" },
+                        access_token: "kick-token",
+                    },
+                    error: null,
+                })
+
+            const response = await GET(createMockRequest("kick"))
+            const data = await response.json()
+
+            expect(response.status).toBe(200)
+            expect(data).toMatchObject({
+                success: true,
+                key: null,
+                note: expect.stringContaining("Kick"),
+            })
+        })
+
+        it("should return 500 when Twitch API fails", async () => {
+            vi.mocked(getServerSession).mockResolvedValue({
+                user: { id: "user_123" },
+            })
+
+            // Mock TokenStore to return a token
+            const mockGetToken = vi
+                .fn()
+                .mockResolvedValue({ accessToken: "twitch-access-token" })
+            vi.mocked(getTokenStore).mockReturnValue({
+                getToken: mockGetToken,
+            } as any)
+
+            // Mock Twitch OAuth service to return null (failure)
+            const mockGetStreamKey = vi.fn().mockResolvedValue(null)
+            const mockInitialize = vi.fn()
+            vi.mocked(getTwitchOAuthService).mockReturnValue({
+                initialize: mockInitialize,
+                getStreamKey: mockGetStreamKey,
+            } as any)
+
+            const response = await GET(createMockRequest("twitch"))
+            const data = await response.json()
+
+            expect(response.status).toBe(500)
+            expect(data).toMatchObject({
+                success: false,
+                error: "STREAM_KEY_UNAVAILABLE",
+            })
+        })
+    })
+})

--- a/src/app/api/live/stream-key/route.ts
+++ b/src/app/api/live/stream-key/route.ts
@@ -1,0 +1,135 @@
+/**
+ * GET /api/live/stream-key
+ * Returns stream key for the specified platform (twitch or kick)
+ * For Twitch: fetches via Helix API (requires channel:read:stream_key scope)
+ * For Kick: manual entry only (no API available)
+ * Authenticated: requires valid session
+ */
+
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { createLogger } from "@/lib/logger"
+import { getTwitchConfig } from "@/lib/twitch/config"
+import { getTwitchOAuthService } from "@/lib/twitch/oauth-service"
+import { getTokenStore } from "@/lib/token-store"
+import { createClient } from "@supabase/supabase-js"
+import { NextRequest, NextResponse } from "next/server"
+
+const logger = createLogger("StreamKeyEndpoint")
+
+interface StreamKeyResponse {
+    success: boolean
+    key: string | null
+    note?: string
+    error?: string
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return NextResponse.json(
+                { success: false, error: "UNAUTHORIZED" },
+                { status: 401 }
+            )
+        }
+
+        const userId = session.user.id
+        const { searchParams } = new URL(request.url)
+        const platform = searchParams.get("platform") || "twitch"
+
+        if (platform !== "twitch" && platform !== "kick") {
+            return NextResponse.json(
+                { success: false, error: "INVALID_PLATFORM" },
+                { status: 400 }
+            )
+        }
+
+        const supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+        )
+
+        const { data: network, error: networkError } = await supabase
+            .from("social_networks")
+            .select("*")
+            .eq("user_id", userId)
+            .eq("platform", platform)
+            .eq("status", "connected")
+            .single()
+
+        if (networkError || !network) {
+            logger.warn("No connected platform found", { userId, platform })
+            return NextResponse.json(
+                { success: false, error: "PLATFORM_NOT_CONNECTED" },
+                { status: 404 }
+            )
+        }
+
+        if (platform === "twitch") {
+            const tokenStore = getTokenStore()
+            const tokenData = await tokenStore.getToken(userId, "twitch")
+
+            if (!tokenData?.accessToken) {
+                logger.warn("No Twitch access token found", { userId })
+                return NextResponse.json(
+                    { success: false, error: "TOKEN_NOT_FOUND" },
+                    { status: 500 }
+                )
+            }
+
+            const broadcasterId =
+                network.metadata?.userId ||
+                network.platform_user_id
+
+            if (!broadcasterId) {
+                logger.warn("No Twitch broadcaster ID found", { userId })
+                return NextResponse.json(
+                    { success: false, error: "BROADCASTER_ID_NOT_FOUND" },
+                    { status: 500 }
+                )
+            }
+
+            const config = getTwitchConfig()
+            const oauthService = getTwitchOAuthService(config)
+            await oauthService.initialize()
+
+            const streamKey = await oauthService.getStreamKey(
+                tokenData.accessToken,
+                broadcasterId
+            )
+
+            if (!streamKey) {
+                return NextResponse.json(
+                    {
+                        success: false,
+                        error: "STREAM_KEY_UNAVAILABLE",
+                    },
+                    { status: 500 }
+                )
+            }
+
+            const response: StreamKeyResponse = {
+                success: true,
+                key: streamKey.streamKey,
+            }
+
+            return NextResponse.json(response)
+        }
+
+        // Kick platform — no API for stream keys
+        const response: StreamKeyResponse = {
+            success: true,
+            key: null,
+            note: "Kick does not provide stream keys via API. Add manually in settings.",
+        }
+
+        return NextResponse.json(response)
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("Stream key fetch failed", err)
+        return NextResponse.json(
+            { success: false, error: "INTERNAL_ERROR" },
+            { status: 500 }
+        )
+    }
+}

--- a/src/components/dashboard/live/stream-key-card.tsx
+++ b/src/components/dashboard/live/stream-key-card.tsx
@@ -1,0 +1,481 @@
+/**
+ * StreamKeyCard Component
+ * Displays and manages stream keys for Twitch and Kick platforms
+ * Twitch: fetches via API (masked, toggle reveal, copy)
+ * Kick: manual entry stored in localStorage
+ */
+
+"use client"
+
+import { createLogger } from "@/lib/logger"
+import { useEffect, useState } from "react"
+
+const logger = createLogger("StreamKeyCard")
+
+interface StreamKeyCardProps {
+    platform: string
+}
+
+interface FetchState {
+    loading: boolean
+    key: string | null
+    note?: string
+    error: string | null
+}
+
+export function StreamKeyCard({ platform }: StreamKeyCardProps) {
+    const [fetchState, setFetchState] = useState<FetchState>({
+        loading: true,
+        key: null,
+        error: null,
+    })
+    const [revealed, setRevealed] = useState(false)
+    const [copied, setCopied] = useState(false)
+    const [kickKey, setKickKey] = useState("")
+    const [kickSavedKey, setKickSavedKey] = useState("")
+    const [kickSaving, setKickSaving] = useState(false)
+    const [kickSaveMessage, setKickSaveMessage] = useState<{
+        type: "success" | "error"
+        text: string
+    } | null>(null)
+
+    // Load Kick key from localStorage on mount
+    useEffect(() => {
+        if (platform === "kick") {
+            const saved = localStorage.getItem("kick_stream_key") || ""
+            setKickSavedKey(saved)
+            setKickKey(saved)
+        }
+    }, [platform])
+
+    // Fetch stream key for Twitch on mount and platform change
+    useEffect(() => {
+        if (platform !== "twitch") {
+            setFetchState({
+                loading: false,
+                key: null,
+                error: null,
+            })
+            return
+        }
+
+        let cancelled = false
+
+        async function fetchKey() {
+            setFetchState(prev => ({ ...prev, loading: true, error: null }))
+
+            try {
+                const response = await fetch(
+                    `/api/live/stream-key?platform=${platform}`
+                )
+
+                if (!response.ok) {
+                    const data = await response.json()
+                    throw new Error(data.error || "Failed to fetch stream key")
+                }
+
+                const data = await response.json()
+
+                if (!cancelled) {
+                    setFetchState({
+                        loading: false,
+                        key: data.key || null,
+                        note: data.note,
+                        error: null,
+                    })
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    logger.error("Failed to fetch stream key", {
+                        error: err instanceof Error ? err.message : String(err),
+                        platform,
+                    })
+                    setFetchState({
+                        loading: false,
+                        key: null,
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : "Unknown error",
+                    })
+                }
+            }
+        }
+
+        fetchKey()
+
+        return () => {
+            cancelled = true
+        }
+    }, [platform])
+
+    const handleCopy = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        } catch {
+            logger.warn("Failed to copy to clipboard")
+        }
+    }
+
+    const handleKickSave = () => {
+        setKickSaving(true)
+        setKickSaveMessage(null)
+
+        try {
+            if (!kickKey.trim()) {
+                // Clearing the key
+                localStorage.removeItem("kick_stream_key")
+                setKickSavedKey("")
+                setKickSaveMessage({
+                    type: "success",
+                    text: "Stream key cleared.",
+                })
+            } else {
+                localStorage.setItem("kick_stream_key", kickKey.trim())
+                setKickSavedKey(kickKey.trim())
+                setKickSaveMessage({
+                    type: "success",
+                    text: "Stream key saved to browser.",
+                })
+            }
+        } catch {
+            setKickSaveMessage({
+                type: "error",
+                text: "Failed to save. Browser storage may be unavailable.",
+            })
+        } finally {
+            setKickSaving(false)
+            setTimeout(() => setKickSaveMessage(null), 3000)
+        }
+    }
+
+    const handleRetry = () => {
+        setFetchState(prev => ({ ...prev, loading: true, error: null }))
+        // Re-trigger effect by toggling a state
+        setFetchState(prev => ({ ...prev, loading: false }))
+        // Re-fetch by re-running the effect
+        setTimeout(() => {
+            setFetchState({
+                loading: true,
+                key: null,
+                error: null,
+            })
+        }, 0)
+    }
+
+    // Loading state
+    if (fetchState.loading) {
+        return (
+            <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                    Stream Key
+                </h3>
+                <div className="flex items-center justify-center py-8">
+                    <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-gray-200 border-t-blue-500"></div>
+                    <span className="ml-2 text-sm text-gray-500">
+                        Loading stream key...
+                    </span>
+                </div>
+            </div>
+        )
+    }
+
+    // Error state
+    if (fetchState.error) {
+        return (
+            <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                    Stream Key
+                </h3>
+                <div className="rounded-md bg-red-50 p-3 text-center dark:bg-red-950/30">
+                    <p className="text-sm text-red-600 dark:text-red-400">
+                        {fetchState.error}
+                    </p>
+                    <button
+                        onClick={handleRetry}
+                        className="mt-2 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+                    >
+                        Retry
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    // Empty state
+    if (platform === "twitch" && !fetchState.key) {
+        return (
+            <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                    Stream Key
+                </h3>
+                <div className="rounded-md bg-gray-50 p-3 text-center dark:bg-gray-800">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                        No stream key available. Ensure your Twitch account has
+                        the required permissions.
+                    </p>
+                </div>
+            </div>
+        )
+    }
+
+    const displayKey =
+        platform === "twitch"
+            ? fetchState.key || ""
+            : revealed
+              ? kickSavedKey
+              : kickSavedKey
+                ? "•••••••••"
+                : ""
+
+    return (
+        <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+            <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Stream Key
+            </h3>
+
+            {platform === "twitch" && fetchState.key && (
+                <div className="space-y-4">
+                    {/* Twitch: Stream key display */}
+                    <div className="flex items-center gap-2">
+                        <code className="flex-1 rounded-md bg-gray-100 px-3 py-2 font-mono text-sm dark:bg-gray-800 dark:text-gray-200">
+                            {revealed
+                                ? fetchState.key
+                                : "••••••••••••••••••••••••••••••"}
+                        </code>
+
+                        {/* Show/Hide toggle */}
+                        <button
+                            onClick={() => setRevealed(!revealed)}
+                            className="rounded-md border border-gray-300 p-2 text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                            title={revealed ? "Hide stream key" : "Show stream key"}
+                        >
+                            {revealed ? (
+                                /* Eye-off icon */
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                >
+                                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                                    <line x1="1" y1="1" x2="23" y2="23" />
+                                </svg>
+                            ) : (
+                                /* Eye icon */
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                >
+                                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                    <circle cx="12" cy="12" r="3" />
+                                </svg>
+                            )}
+                        </button>
+
+                        {/* Copy button */}
+                        <button
+                            onClick={() => handleCopy(fetchState.key || "")}
+                            className="rounded-md border border-gray-300 p-2 text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                            title={copied ? "Copied!" : "Copy to clipboard"}
+                        >
+                            {copied ? (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5 text-green-500"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                >
+                                    <polyline points="20 6 9 17 4 12" />
+                                </svg>
+                            ) : (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                >
+                                    <rect
+                                        x="9"
+                                        y="9"
+                                        width="13"
+                                        height="13"
+                                        rx="2"
+                                        ry="2"
+                                    />
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                                </svg>
+                            )}
+                        </button>
+                    </div>
+
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {fetchState.note}
+                    </p>
+
+                    {/* Reset link */}
+                    <a
+                        href="https://dashboard.twitch.tv/settings/stream"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block text-sm text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400"
+                    >
+                        Reset on Twitch &rarr;
+                    </a>
+                </div>
+            )}
+
+            {platform === "kick" && (
+                <div className="space-y-4">
+                    {/* Kick: Manual entry */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Stream Key
+                        </label>
+                        <div className="flex items-center gap-2">
+                            {revealed && kickSavedKey ? (
+                                <span className="flex-1 rounded-md bg-gray-100 px-3 py-2 font-mono text-sm dark:bg-gray-800 dark:text-gray-200">
+                                    {kickSavedKey}
+                                </span>
+                            ) : (
+                                <input
+                                    type={revealed ? "text" : "password"}
+                                    value={kickKey}
+                                    onChange={e => setKickKey(e.target.value)}
+                                    placeholder="Enter your Kick stream key..."
+                                    className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                />
+                            )}
+
+                            {/* Show/Hide toggle */}
+                            <button
+                                onClick={() => setRevealed(!revealed)}
+                                className="rounded-md border border-gray-300 p-2 text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                                title={
+                                    revealed
+                                        ? "Hide stream key"
+                                        : "Show stream key"
+                                }
+                            >
+                                {revealed ? (
+                                    /* Eye-off icon */
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        className="h-5 w-5"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth={2}
+                                    >
+                                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                                        <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                                        <line x1="1" y1="1" x2="23" y2="23" />
+                                    </svg>
+                                ) : (
+                                    /* Eye icon */
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        className="h-5 w-5"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth={2}
+                                    >
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                        <circle cx="12" cy="12" r="3" />
+                                    </svg>
+                                )}
+                            </button>
+
+                            {/* Copy button (only when saved key exists) */}
+                            {kickSavedKey && (
+                                <button
+                                    onClick={() => handleCopy(kickSavedKey)}
+                                    className="rounded-md border border-gray-300 p-2 text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                                    title={
+                                        copied ? "Copied!" : "Copy to clipboard"
+                                    }
+                                >
+                                    {copied ? (
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            className="h-5 w-5 text-green-500"
+                                            viewBox="0 0 24 24"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            strokeWidth={2}
+                                        >
+                                            <polyline points="20 6 9 17 4 12" />
+                                        </svg>
+                                    ) : (
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            className="h-5 w-5"
+                                            viewBox="0 0 24 24"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            strokeWidth={2}
+                                        >
+                                            <rect
+                                                x="9"
+                                                y="9"
+                                                width="13"
+                                                height="13"
+                                                rx="2"
+                                                ry="2"
+                                            />
+                                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                                        </svg>
+                                    )}
+                                </button>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Save button */}
+                    <button
+                        onClick={handleKickSave}
+                        disabled={kickSaving}
+                        className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {kickSaving
+                            ? "Saving..."
+                            : kickKey.trim() !== kickSavedKey
+                              ? "Save to Browser"
+                              : "Saved"}
+                    </button>
+
+                    {kickSaveMessage && (
+                        <p
+                            className={`text-sm ${
+                                kickSaveMessage.type === "success"
+                                    ? "text-green-600"
+                                    : "text-red-600"
+                            }`}
+                        >
+                            {kickSaveMessage.text}
+                        </p>
+                    )}
+
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Kick does not provide stream keys via API. Your key is
+                        stored in your browser only (localStorage).
+                    </p>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/lib/twitch/config.ts
+++ b/src/lib/twitch/config.ts
@@ -42,6 +42,7 @@ const DEFAULT_SCOPES = [
     "user:read:email",
     "whispers:read",
     "whispers:edit",
+    "channel:read:stream_key",
 ]
 
 export function createTwitchConfig(): TwitchConfig {

--- a/src/lib/twitch/index.ts
+++ b/src/lib/twitch/index.ts
@@ -20,6 +20,7 @@ export type {
     TwitchUser,
     TwitchChannel,
     TwitchStream,
+    TwitchStreamKey,
     AuthorizationUrlResponse,
     OAuthTokenResponse,
 } from "./oauth-service"

--- a/src/lib/twitch/oauth-service.test.ts
+++ b/src/lib/twitch/oauth-service.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Twitch OAuth Service Unit Tests
+ * Tests for getStreamKey method and existing service methods
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { TwitchOAuthService } from "./oauth-service"
+import type { TwitchConfig } from "./config"
+
+// Mock global fetch
+const mockFetch = vi.fn()
+global.fetch = mockFetch as any
+
+const mockConfig: TwitchConfig = {
+    oauth: {
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        redirectUri: "http://localhost:3000/api/oauth/callback/twitch",
+        scopes: ["chat:read", "chat:edit", "channel:read:stream_key"],
+    },
+    apiBaseUrl: "https://api.twitch.tv/helix",
+    oauthAuthorizeUrl: "https://id.twitch.tv/oauth2/authorize",
+    oauthTokenUrl: "https://id.twitch.tv/oauth2/token",
+    oauthRevokeUrl: "https://id.twitch.tv/oauth2/revoke",
+    ircUrl: "irc.chat.twitch.tv",
+    ircPort: 6667,
+    eventsubWsUrl: "wss://eventsub.wss.twitch.tv",
+    rateLimit: { requestsPerMinute: 800 },
+    security: { tokenExpiryBufferMs: 300000 },
+}
+
+describe("TwitchOAuthService.getStreamKey", () => {
+    let service: TwitchOAuthService
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        service = new TwitchOAuthService(mockConfig)
+    })
+
+    it("should call GET /helix/streams/key with correct headers and broadcaster_id", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                data: [{ stream_key: "live_123456_abc123" }],
+            }),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        const callUrl = mockFetch.mock.calls[0][0]
+        expect(callUrl).toContain("/helix/streams/key")
+        expect(callUrl).toContain("broadcaster_id=broadcaster_123")
+
+        const callHeaders = mockFetch.mock.calls[0][1]?.headers
+        expect(callHeaders).toMatchObject({
+            Authorization: "Bearer test-access-token",
+            "Client-Id": "test-client-id",
+        })
+    })
+
+    it("should return TwitchStreamKey on success", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                data: [{ stream_key: "live_123456_abc123" }],
+            }),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(result).toEqual({ streamKey: "live_123456_abc123" })
+    })
+
+    it("should return null when Twitch returns 403 (missing scope)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 403,
+            json: async () => ({}),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(result).toBeNull()
+    })
+
+    it("should return null when no stream key data", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ data: [] }),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(result).toBeNull()
+    })
+
+    it("should return null on network error (non-ok response)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(result).toBeNull()
+    })
+
+    it("should return null on empty data object", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({}),
+        })
+
+        const result = await service.getStreamKey(
+            "test-access-token",
+            "broadcaster_123"
+        )
+
+        expect(result).toBeNull()
+    })
+})

--- a/src/lib/twitch/oauth-service.ts
+++ b/src/lib/twitch/oauth-service.ts
@@ -35,6 +35,10 @@ export interface TwitchChannel {
     contentClassificationLabels: string[]
 }
 
+export interface TwitchStreamKey {
+    streamKey: string
+}
+
 export interface TwitchStream {
     id: string
     userId: string
@@ -311,6 +315,51 @@ export class TwitchOAuthService {
             thumbnailUrl: stream.thumbnail_url,
             tagIds: stream.tag_ids || [],
             isMature: stream.is_mature,
+        }
+    }
+
+    /**
+     * Get stream key from Twitch
+     * Requires channel:read:stream_key scope
+     */
+    async getStreamKey(
+        accessToken: string,
+        broadcasterId: string
+    ): Promise<TwitchStreamKey | null> {
+        const params = new URLSearchParams({
+            broadcaster_id: broadcasterId,
+        })
+
+        const response = await fetch(
+            `${this.config.apiBaseUrl}/streams/key?${params.toString()}`,
+            {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    "Client-Id": this.config.oauth.clientId,
+                },
+            }
+        )
+
+        if (response.status === 403) {
+            logger.warn("Missing scope: channel:read:stream_key", {
+                status: response.status,
+                broadcasterId,
+            })
+            return null
+        }
+
+        if (!response.ok) {
+            logger.error("Failed to get Twitch stream key", {
+                status: response.status,
+            })
+            return null
+        }
+
+        const data = await response.json()
+        if (!data.data || data.data.length === 0) return null
+
+        return {
+            streamKey: data.data[0].stream_key,
         }
     }
 


### PR DESCRIPTION
## Summary
Add stream key management UI for Twitch and Kick streaming platforms, referenced in issue #230.

- **Twitch**: Add 'channel:read:stream_key' OAuth scope to config, implement getStreamKey() in TwitchOAuthService (GET /helix/streams/key), create API endpoint GET /api/live/stream-key
- **Kick**: Manual entry via UI, stored in localStorage (no API available)
- **New StreamKeyCard component** with masked display, show/hide toggle (eye icon), copy to clipboard button
- **Kick mode**: text field for manual entry with localStorage persistence, plus copy/reveal features
- **Reset link**: external link to Twitch Creator Dashboard (Twitch has no reset API)

## Risk Assessment
**Risk Level:** MEDIUM
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- src/lib/twitch/config.ts - add channel:read:stream_key scope
- src/lib/twitch/oauth-service.ts - add getStreamKey() method + TwitchStreamKey type
- src/lib/twitch/index.ts - export TwitchStreamKey type
- src/app/api/live/stream-key/route.ts - new API endpoint
- src/components/dashboard/live/stream-key-card.tsx - new component
- src/app/[locale]/dashboard/live/page.tsx - integrate StreamKeyCard
- src/lib/twitch/oauth-service.test.ts - 6 tests for getStreamKey
- src/app/api/live/stream-key/route.test.ts - 7 tests for API route

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (13 new tests)
- [x] Build passes

Closes #230

_Generated by engineering-loop | Cost-free: ✅_