### PR TITLE
test(live-streaming): add 139 tests for Twitch/Kick OAuth, chat adapters, and live dashboard UI

### DIFF
--- a/src/__tests__/app/dashboard/live/page.test.tsx
+++ b/src/__tests__/app/dashboard/live/page.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Integration tests for Live Dashboard Page
+ * Covers data fetching, loading/error/success states
+ */
+
+import LiveDashboardPage from "@/app/[locale]/dashboard/live/page"
+import { render, screen, waitFor } from "@testing-library/react"
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const mockLiveData = {
+    success: true,
+    data: [
+        {
+            platform: "twitch",
+            username: "ogabrieltoth",
+            displayName: "GabrielToth",
+            profileImageUrl: null,
+            isLive: true,
+            viewerCount: 42,
+            title: "Streaming live!",
+            gameName: "Just Chatting",
+            startedAt: new Date(Date.now() - 3600000).toISOString(),
+        },
+    ],
+}
+
+describe("LiveDashboardPage", () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it("shows loading state initially", () => {
+        // Don't resolve the fetch yet — keep loading indefinitely
+        vi.spyOn(globalThis, "fetch").mockReturnValue(
+            new Promise(() => {}) as Promise<Response>
+        )
+
+        render(<LiveDashboardPage />)
+
+        // Should show a loading spinner with translation text
+        expect(
+            screen.getByText("Loading stream status...")
+        ).toBeInTheDocument()
+    })
+
+    it("fetches live status from /api/live/status on mount", async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue({
+                ok: true,
+                json: async () => mockLiveData,
+            } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            expect(fetchSpy).toHaveBeenCalledWith("/api/live/status")
+        })
+    })
+
+    it("shows error state with retry button on fetch failure", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: false,
+            status: 500,
+        } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/Failed to load stream data/)
+            ).toBeInTheDocument()
+        })
+
+        // Should have a retry button
+        const retryButton = screen.getByRole("button", { name: /Retry/i })
+        expect(retryButton).toBeInTheDocument()
+    })
+
+    it("shows error message on network failure", async () => {
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            new Error("Network error")
+        )
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            // Error text is "Failed to load stream data: Network error"
+            expect(screen.getByText(/Network error/)).toBeInTheDocument()
+        })
+    })
+
+    it("shows StreamStatusCard for each platform", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockLiveData,
+        } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            expect(screen.getByText("GabrielToth")).toBeInTheDocument()
+            expect(screen.getByText("LIVE")).toBeInTheDocument()
+            expect(screen.getByText("Streaming live!")).toBeInTheDocument()
+        })
+    })
+
+    it("shows StreamTitleEditor for active platform", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockLiveData,
+        } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            expect(
+                screen.getByPlaceholderText("Enter stream title...")
+            ).toBeInTheDocument()
+            expect(
+                screen.getByDisplayValue("Streaming live!")
+            ).toBeInTheDocument()
+        })
+    })
+
+    it("shows UnifiedChat component", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockLiveData,
+        } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            // UnifiedChat welcome message
+            expect(
+                screen.getByText("Chat connected. Waiting for messages...")
+            ).toBeInTheDocument()
+            // Input placeholder confirms UnifiedChat rendered
+            expect(
+                screen.getByPlaceholderText("Send message to twitch...")
+            ).toBeInTheDocument()
+        })
+    })
+
+    it("shows empty state when no platforms are connected", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true, data: [] }),
+        } as Response)
+
+        render(<LiveDashboardPage />)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/No live platforms connected/)
+            ).toBeInTheDocument()
+        })
+    })
+})

--- a/src/__tests__/components/dashboard/live/stream-status-card.test.tsx
+++ b/src/__tests__/components/dashboard/live/stream-status-card.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for StreamStatusCard Component
+ * Covers rendering platform info, LIVE badge, viewer count, uptime, title
+ */
+
+import { StreamStatusCard } from "@/components/dashboard/live/stream-status-card"
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+
+// Mock Date.now for predictable uptime
+const MOCK_NOW = 1700000000000 // Some fixed timestamp
+
+describe("StreamStatusCard", () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(MOCK_NOW)
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    const defaultProps = {
+        platform: "twitch",
+        username: "testuser",
+        displayName: "TestUser",
+        isLive: true,
+        viewerCount: 42,
+        title: "My Awesome Stream",
+        gameName: "Just Chatting",
+        startedAt: new Date(MOCK_NOW - 3600000).toISOString(), // 1 hour ago
+    }
+
+    it("renders platform name and display name", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("TestUser")).toBeInTheDocument()
+        expect(screen.getByText("twitch")).toBeInTheDocument()
+    })
+
+    it("shows LIVE badge when isLive is true", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("LIVE")).toBeInTheDocument()
+    })
+
+    it("hides LIVE badge when isLive is false", () => {
+        render(<StreamStatusCard {...defaultProps} isLive={false} />)
+
+        expect(screen.queryByText("LIVE")).not.toBeInTheDocument()
+    })
+
+    it("shows viewer count and uptime when live", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("42")).toBeInTheDocument()
+        expect(screen.getByText("1h 0m")).toBeInTheDocument()
+    })
+
+    it("shows dashes for viewer count and uptime when not live", () => {
+        render(
+            <StreamStatusCard
+                {...defaultProps}
+                isLive={false}
+                viewerCount={0}
+                startedAt={null}
+            />
+        )
+
+        // Find all dash indicators — there should be two (viewers + uptime)
+        const dashes = screen.getAllByText("—")
+        expect(dashes.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it("shows stream title", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("My Awesome Stream")).toBeInTheDocument()
+    })
+
+    it("renders game name", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("Just Chatting")).toBeInTheDocument()
+    })
+
+    it("renders platform initial letter in circle", () => {
+        render(<StreamStatusCard {...defaultProps} />)
+
+        expect(screen.getByText("T")).toBeInTheDocument()
+    })
+
+    it("renders K for Kick platform", () => {
+        render(
+            <StreamStatusCard
+                {...defaultProps}
+                platform="kick"
+                displayName="KickStreamer"
+            />
+        )
+
+        expect(screen.getByText("K")).toBeInTheDocument()
+    })
+
+    it("shows game name as dash when no game", () => {
+        render(<StreamStatusCard {...defaultProps} gameName="" />)
+
+        const gameLabel = screen.getByText("Game")
+        expect(gameLabel).toBeInTheDocument()
+    })
+
+    it("does not render title section when title is empty", () => {
+        render(<StreamStatusCard {...defaultProps} title="" />)
+
+        // The title should not appear as a paragraph
+        expect(screen.queryByText("My Awesome Stream")).not.toBeInTheDocument()
+    })
+
+    it("calculates uptime correctly", () => {
+        const twoHoursAgo = new Date(MOCK_NOW - 2 * 3600000).toISOString()
+        render(<StreamStatusCard {...defaultProps} startedAt={twoHoursAgo} />)
+
+        expect(screen.getByText("2h 0m")).toBeInTheDocument()
+    })
+})

--- a/src/__tests__/components/dashboard/live/stream-title-editor.test.tsx
+++ b/src/__tests__/components/dashboard/live/stream-title-editor.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for StreamTitleEditor Component
+ * Covers rendering, input changes, save behavior, success/error messages
+ */
+
+import { StreamTitleEditor } from "@/components/dashboard/live/stream-title-editor"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+describe("StreamTitleEditor", () => {
+    const defaultProps = {
+        platform: "twitch",
+        currentTitle: "My Current Title",
+        currentGame: "Just Chatting",
+        onUpdate: vi.fn(),
+    }
+
+    beforeEach(() => {
+        vi.useRealTimers()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it("renders title input and game input", () => {
+        render(<StreamTitleEditor {...defaultProps} />)
+
+        const titleInput = screen.getByPlaceholderText("Enter stream title...")
+        expect(titleInput).toBeInTheDocument()
+        expect(titleInput).toHaveValue("My Current Title")
+
+        const gameInput = screen.getByPlaceholderText("Enter game or category...")
+        expect(gameInput).toBeInTheDocument()
+        expect(gameInput).toHaveValue("Just Chatting")
+    })
+
+    it("displays current values in inputs", () => {
+        render(<StreamTitleEditor {...defaultProps} />)
+
+        expect(screen.getByDisplayValue("My Current Title")).toBeInTheDocument()
+        expect(screen.getByDisplayValue("Just Chatting")).toBeInTheDocument()
+    })
+
+    it("typing updates input value", () => {
+        render(<StreamTitleEditor {...defaultProps} />)
+
+        const titleInput = screen.getByPlaceholderText("Enter stream title...")
+        fireEvent.change(titleInput, {
+            target: { value: "New Stream Title" },
+        })
+
+        expect(titleInput).toHaveValue("New Stream Title")
+    })
+
+    it("save button calls POST /api/live/update with correct data", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true }),
+        } as Response)
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const titleInput = screen.getByPlaceholderText("Enter stream title...")
+        fireEvent.change(titleInput, {
+            target: { value: "Updated Title" },
+        })
+
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        await waitFor(() => {
+            expect(fetchSpy).toHaveBeenCalledWith("/api/live/update", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    platform: "twitch",
+                    title: "Updated Title",
+                    game_id: "Just Chatting",
+                }),
+            })
+        })
+    })
+
+    it("shows success message when save succeeds", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true }),
+        } as Response)
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        await waitFor(() => {
+            expect(screen.getByText("Stream updated!")).toBeInTheDocument()
+        })
+        expect(screen.getByText("Stream updated!")).toHaveClass("text-green-600")
+    })
+
+    it("shows error message on API error response", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                success: false,
+                error: "Rate limited",
+            }),
+        } as Response)
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        await waitFor(() => {
+            expect(screen.getByText("Rate limited")).toBeInTheDocument()
+        })
+    })
+
+    it("shows error message on network failure", async () => {
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            new Error("Network error")
+        )
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        await waitFor(() => {
+            expect(screen.getByText("Network error")).toBeInTheDocument()
+        })
+    })
+
+    it("shows saving state while request is in progress", async () => {
+        let resolvePromise: (value: unknown) => void
+        const fetchPromise = new Promise(resolve => {
+            resolvePromise = resolve
+        })
+
+        vi.spyOn(globalThis, "fetch").mockReturnValue(
+            fetchPromise as Promise<Response>
+        )
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        expect(screen.getByText("Saving...")).toBeInTheDocument()
+        expect(saveButton).toBeDisabled()
+
+        resolvePromise!({
+            ok: true,
+            json: async () => ({ success: true }),
+        } as Response)
+
+        await waitFor(() => {
+            expect(screen.getByText("Update Stream")).toBeInTheDocument()
+        })
+    })
+
+    it("auto-dismisses message after 3 seconds", async () => {
+        vi.useFakeTimers()
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true }),
+        } as Response)
+
+        render(<StreamTitleEditor {...defaultProps} />)
+        const saveButton = screen.getByText("Update Stream")
+        fireEvent.click(saveButton)
+
+        // Wait for the fetch to resolve and state to update
+        await vi.waitFor(() => {
+            expect(screen.getByText("Stream updated!")).toBeInTheDocument()
+        })
+
+        // Advance past 3 seconds: flush the setTimeout callback
+        act(() => {
+            vi.advanceTimersByTime(3000)
+        })
+
+        // After React processes the state update, message should be gone
+        expect(screen.queryByText("Stream updated!")).not.toBeInTheDocument()
+
+        vi.useRealTimers()
+    })
+})

--- a/src/__tests__/components/dashboard/live/unified-chat.test.tsx
+++ b/src/__tests__/components/dashboard/live/unified-chat.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for UnifiedChat Component
+ * Covers platform tabs, messages, input, connection indicator
+ */
+
+import { UnifiedChat } from "@/components/dashboard/live/unified-chat"
+import { fireEvent, render, screen } from "@testing-library/react"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+describe("UnifiedChat", () => {
+    const defaultProps = {
+        platforms: ["twitch", "kick"],
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    it("renders platform tabs (Twitch/Kick)", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        expect(screen.getByText("Twitch")).toBeInTheDocument()
+        expect(screen.getByText("Kick")).toBeInTheDocument()
+    })
+
+    it("platform selector switches visible platform", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const kickButton = screen.getByText("Kick")
+        fireEvent.click(kickButton)
+
+        // After clicking Kick, the input placeholder should reference Kick
+        expect(
+            screen.getByPlaceholderText("Send message to kick...")
+        ).toBeInTheDocument()
+    })
+
+    it("shows connection indicator as connected", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        // After the useEffect runs, it should show connected
+        expect(screen.getByText("Connected")).toBeInTheDocument()
+    })
+
+    it("renders welcome message initially", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        expect(
+            screen.getByText("Chat connected. Waiting for messages...")
+        ).toBeInTheDocument()
+    })
+
+    it("input field accepts text", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const input = screen.getByPlaceholderText(
+            "Send message to twitch..."
+        ) as HTMLInputElement
+        fireEvent.change(input, { target: { value: "Hello chat!" } })
+
+        expect(input.value).toBe("Hello chat!")
+    })
+
+    it("send button triggers message addition", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const input = screen.getByPlaceholderText("Send message to twitch...")
+        fireEvent.change(input, { target: { value: "Test message" } })
+
+        const sendButton = screen.getByText("Send")
+        fireEvent.click(sendButton)
+
+        // After sending, the message should appear in the chat
+        expect(screen.getByText("Test message")).toBeInTheDocument()
+        // The input should be cleared
+        expect(input).toHaveValue("")
+    })
+
+    it("does not send empty messages", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const sendButton = screen.getByText("Send")
+        expect(sendButton).toBeDisabled()
+
+        const input = screen.getByPlaceholderText(
+            "Send message to twitch..."
+        ) as HTMLInputElement
+        fireEvent.change(input, { target: { value: "" } })
+        expect(input.value).toBe("")
+    })
+
+    it("shows broadcaster badge for broadcaster messages", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        // When the user sends a message, it should have broadcaster badge
+        const input = screen.getByPlaceholderText("Send message to twitch...")
+        fireEvent.change(input, { target: { value: "Broadcaster msg" } })
+
+        const sendButton = screen.getByText("Send")
+        fireEvent.click(sendButton)
+
+        // The broadcaster crown emoji should be present
+        expect(screen.getByText("Broadcaster msg")).toBeInTheDocument()
+    })
+
+    it("renders quick command buttons", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        expect(screen.getByText("/timeout")).toBeInTheDocument()
+        expect(screen.getByText("/ban")).toBeInTheDocument()
+        expect(screen.getByText("/me")).toBeInTheDocument()
+    })
+
+    it("clicking quick command sets text in input", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const timeoutBtn = screen.getByText("/timeout")
+        fireEvent.click(timeoutBtn)
+
+        const input = screen.getByPlaceholderText(
+            "Send message to twitch..."
+        ) as HTMLInputElement
+        expect(input.value).toBe("/timeout ")
+    })
+
+    it("handles Enter key to send message", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const input = screen.getByPlaceholderText("Send message to twitch...")
+        fireEvent.change(input, { target: { value: "Enter message" } })
+        fireEvent.keyDown(input, { key: "Enter", shiftKey: false })
+
+        expect(screen.getByText("Enter message")).toBeInTheDocument()
+    })
+
+    it("does not send on Shift+Enter", () => {
+        render(<UnifiedChat {...defaultProps} />)
+
+        const input = screen.getByPlaceholderText("Send message to twitch...")
+        fireEvent.change(input, { target: { value: "Shift+Enter test" } })
+        fireEvent.keyDown(input, { key: "Enter", shiftKey: true })
+
+        // The message should not appear
+        expect(screen.queryByText("Shift+Enter test")).not.toBeInTheDocument()
+    })
+})

--- a/src/__tests__/lib/chat/kick-adapter.test.ts
+++ b/src/__tests__/lib/chat/kick-adapter.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for Kick Chat Adapter
+ * Covers WebSocket connection, message handling, disconnect, reconnection with backoff
+ */
+
+import { KickChatAdapter } from "@/lib/chat/kick-adapter"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Track all WebSocket instances
+const wsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+    static OPEN = 1
+    readyState = MockWebSocket.OPEN
+    onopen: (() => void) | null = null
+    onmessage: ((event: { data: string }) => void) | null = null
+    onerror: ((event: Event) => void) | null = null
+    onclose: (() => void) | null = null
+    send = vi.fn()
+    close = vi.fn()
+    url: string
+
+    constructor(url: string) {
+        this.url = url
+        wsInstances.push(this)
+
+        // Simulate connection opening asynchronously
+        setTimeout(() => {
+            if (this.onopen) this.onopen()
+        }, 0)
+    }
+
+    /** Simulate receiving a WebSocket message */
+    simulateMessage(data: Record<string, unknown>): void {
+        if (this.onmessage) {
+            this.onmessage({ data: JSON.stringify(data) })
+        }
+    }
+
+    /** Simulate WebSocket close */
+    simulateClose(): void {
+        if (this.onclose) this.onclose()
+    }
+
+    /** Simulate WebSocket error */
+    simulateError(): void {
+        if (this.onerror) {
+            this.onerror(new Event("error"))
+        }
+    }
+}
+
+describe("KickChatAdapter", () => {
+    let adapter: KickChatAdapter
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        wsInstances.length = 0
+        ;(globalThis as any).WebSocket = MockWebSocket as any
+        adapter = new KickChatAdapter()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+        delete (globalThis as any).WebSocket
+    })
+
+    /** Connect and resolve all async operations */
+    async function connectAndWait(
+        channel = "kickchannel",
+        token = "test-token"
+    ): Promise<void> {
+        const connectPromise = adapter.connect(channel, token)
+        // Flush the setTimeout(0) that calls onopen
+        await vi.advanceTimersByTimeAsync(10)
+        await connectPromise
+    }
+
+    /** Get the last created WebSocket instance */
+    function getWs(): MockWebSocket {
+        const ws = wsInstances[wsInstances.length - 1]
+        if (!ws) throw new Error("No WebSocket instance created")
+        return ws
+    }
+
+    describe("connect", () => {
+        it("connects and sends join message", async () => {
+            await connectAndWait()
+
+            expect(wsInstances).toHaveLength(1)
+            const ws = getWs()
+            expect(ws.url).toContain("wss://ws.kick.com")
+            expect(ws.url).toContain("token=test-token")
+            expect(ws.send).toHaveBeenCalledWith(
+                JSON.stringify({
+                    event: "join",
+                    data: { channel: "kickchannel" },
+                })
+            )
+        })
+
+        it("does not reconnect if already connected", async () => {
+            await connectAndWait()
+            const initialCount = wsInstances.length
+
+            await adapter.connect("kickchannel", "test-token")
+
+            expect(wsInstances.length).toBe(initialCount)
+        })
+
+        it("rejects on connection timeout", async () => {
+            // Create a WebSocket that never opens
+            class TimeoutWs {
+                static OPEN = 1
+                readyState = 0
+                onopen: (() => void) | null = null
+                onmessage: ((event: { data: string }) => void) | null = null
+                onerror: ((event: Event) => void) | null = null
+                onclose: (() => void) | null = null
+                send = vi.fn()
+                close = vi.fn()
+                constructor(public url: string) {
+                    wsInstances.push(this as any)
+                    // Intentionally do NOT call onopen
+                }
+            }
+            ;(globalThis as any).WebSocket = TimeoutWs as any
+            wsInstances.length = 0
+
+            const connectPromise = adapter.connect(
+                "timeoutchannel",
+                "test-token"
+            )
+            vi.advanceTimersByTime(11000)
+
+            await expect(connectPromise).rejects.toThrow(
+                "Kick WebSocket connection timeout"
+            )
+        })
+    })
+
+    describe("onMessage", () => {
+        it("receives chat message events", async () => {
+            await connectAndWait()
+            const handler = vi.fn()
+            adapter.onMessage("kickchannel", handler)
+
+            getWs().simulateMessage({
+                event: "message",
+                data: {
+                    id: "msg_1",
+                    user_id: "user_1",
+                    sender: { username: "KickUser" },
+                    content: "Hello from Kick!",
+                    created_at: Date.now(),
+                    is_broadcaster: true,
+                },
+            })
+
+            expect(handler).toHaveBeenCalledTimes(1)
+            const msg = handler.mock.calls[0][0]
+            expect(msg.platform).toBe("kick")
+            expect(msg.content).toBe("Hello from Kick!")
+            expect(msg.user.username).toBe("KickUser")
+            expect(msg.user.isBroadcaster).toBe(true)
+        })
+
+        it("receives system events (join, leave, subscription)", async () => {
+            await connectAndWait()
+            const handler = vi.fn()
+            adapter.onMessage("kickchannel", handler)
+
+            // Simulate user_joined
+            getWs().simulateMessage({
+                event: "user_joined",
+                data: { username: "NewUser" },
+            })
+
+            expect(handler).toHaveBeenCalledTimes(1)
+            expect(handler.mock.calls[0][0].content).toContain("joined")
+            expect(handler.mock.calls[0][0].type).toBe("system")
+
+            // Simulate subscription
+            getWs().simulateMessage({
+                event: "subscription",
+                data: { username: "SubUser" },
+            })
+
+            expect(handler).toHaveBeenCalledTimes(2)
+            expect(handler.mock.calls[1][0].content).toContain("subscribed")
+        })
+    })
+
+    describe("sendMessage", () => {
+        it("sends message via WebSocket", async () => {
+            await connectAndWait()
+
+            const msgId = await adapter.sendMessage(
+                "kickchannel",
+                "Hello Kick!"
+            )
+
+            expect(msgId).toBeTruthy()
+            expect(getWs().send).toHaveBeenCalledWith(
+                expect.stringContaining("send_message")
+            )
+            expect(getWs().send).toHaveBeenCalledWith(
+                expect.stringContaining("Hello Kick!")
+            )
+        })
+
+        it("throws if not connected", async () => {
+            await expect(
+                adapter.sendMessage("unknown", "test")
+            ).rejects.toThrow("Not connected to Kick room: unknown")
+        })
+    })
+
+    describe("getRoom", () => {
+        it("returns room info when connected", async () => {
+            await connectAndWait()
+
+            const room = await adapter.getRoom("kickchannel")
+
+            expect(room).not.toBeNull()
+            expect(room!.id).toBe("kickchannel")
+            expect(room!.platform).toBe("kick")
+            expect(room!.isLive).toBe(true)
+        })
+
+        it("returns null when not connected", async () => {
+            const room = await adapter.getRoom("unknown")
+            expect(room).toBeNull()
+        })
+    })
+
+    describe("getHistory", () => {
+        it("returns empty array (not yet implemented)", async () => {
+            const history = await adapter.getHistory("kickchannel", 50)
+            expect(history).toEqual([])
+        })
+    })
+
+    describe("disconnect", () => {
+        it("disconnects and cleans up", async () => {
+            await connectAndWait()
+            getWs().send.mockClear()
+
+            await adapter.disconnect("kickchannel")
+
+            expect(getWs().send).toHaveBeenCalledWith(
+                expect.stringContaining("leave")
+            )
+            expect(getWs().close).toHaveBeenCalled()
+        })
+    })
+
+    describe("reconnection", () => {
+        it("reconnects on close with exponential backoff", async () => {
+            await connectAndWait()
+            const initialWsCount = wsInstances.length
+
+            // Simulate WebSocket close
+            getWs().simulateClose()
+
+            // Advance past the initial reconnect delay (3s)
+            vi.advanceTimersByTime(3100)
+            await vi.advanceTimersByTimeAsync(10)
+
+            // Should have created a new WebSocket connection
+            expect(wsInstances.length).toBeGreaterThanOrEqual(
+                initialWsCount + 1
+            )
+        })
+    })
+
+    describe("onError", () => {
+        it("notifies error handler on WebSocket error", async () => {
+            const errorHandler = vi.fn()
+            adapter.onError(errorHandler)
+
+            const connectPromise = adapter.connect("err-channel", "test-token")
+            await vi.advanceTimersByTimeAsync(10)
+
+            // The WebSocket error will cause both a rejection and error handler call
+            // Note: behavior depends on the mock, so we just check handler was called
+            getWs().simulateError()
+            await vi.advanceTimersByTimeAsync(10)
+
+            try {
+                await connectPromise
+            } catch {
+                // Expected to reject
+            }
+            expect(errorHandler).toHaveBeenCalled()
+        })
+    })
+})

--- a/src/__tests__/lib/chat/twitch-adapter.test.ts
+++ b/src/__tests__/lib/chat/twitch-adapter.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for Twitch Chat Adapter
+ * Covers IRC connection, message handling, disconnect, reconnection
+ */
+
+import { TwitchChatAdapter } from "@/lib/chat/twitch-adapter"
+import { EventEmitter } from "events"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Track socket instances
+const socketInstances: any[] = []
+
+class MockSocket extends EventEmitter {
+    connect = vi.fn((_port: number, _host: string, cb?: () => void) => {
+        if (cb) setTimeout(cb, 0)
+    })
+    write = vi.fn()
+    destroy = vi.fn()
+    end = vi.fn()
+    setTimeout = vi.fn()
+    removeListener = vi.fn()
+
+    constructor() {
+        super()
+        socketInstances.push(this)
+    }
+}
+
+vi.mock("net", () => ({
+    Socket: MockSocket,
+}))
+
+describe("TwitchChatAdapter", () => {
+    let adapter: TwitchChatAdapter
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        socketInstances.length = 0
+        adapter = new TwitchChatAdapter()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    /** Get the last created socket */
+    function getSocket(): MockSocket {
+        return socketInstances[socketInstances.length - 1]
+    }
+
+    /** Connect and simulate IRC welcome to resolve */
+    async function connectAndWait(channel = "testchannel"): Promise<void> {
+        const connectPromise = adapter.connect(channel, "test-token")
+
+        // Allow microtasks to process (the dynamic import)
+        await vi.advanceTimersByTimeAsync(10)
+
+        // Simulate IRC welcome message to complete the connection
+        const socket = getSocket()
+        if (socket) {
+            socket.emit(
+                "data",
+                Buffer.from(
+                    ":tmi.twitch.tv :Welcome, GLHF! Welcome to Twitch IRC\r\n"
+                )
+            )
+        }
+
+        await vi.advanceTimersByTimeAsync(100)
+        await connectPromise
+    }
+
+    describe("connect", () => {
+        it("connects and sends IRC PASS/NICK/JOIN", async () => {
+            await connectAndWait()
+
+            const socket = getSocket()
+            expect(socket).toBeDefined()
+            expect(socket.write).toHaveBeenCalledWith(
+                "PASS oauth:test-token\r\n"
+            )
+            expect(socket.write).toHaveBeenCalledWith("NICK testchannel\r\n")
+            expect(socket.write).toHaveBeenCalledWith(
+                "CAP REQ :twitch.tv/tags\r\n"
+            )
+            expect(socket.write).toHaveBeenCalledWith(
+                "CAP REQ :twitch.tv/commands\r\n"
+            )
+
+            // After welcome, it should JOIN
+            const joinCall = socket.write.mock.calls.find((call: string[]) =>
+                call[0]?.includes("JOIN #")
+            )
+            expect(joinCall).toBeTruthy()
+            expect(joinCall[0]).toBe("JOIN #testchannel\r\n")
+        })
+
+        it("does not reconnect if already connected", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+            socket.write.mockClear()
+
+            await adapter.connect("testchannel", "oauth:test-token")
+            expect(socket.write).not.toHaveBeenCalled()
+        })
+
+        it("rejects on connection timeout", async () => {
+            const connectPromise = adapter.connect(
+                "timeoutchannel",
+                "token"
+            )
+
+            // Advance past the 10s timeout
+            await vi.advanceTimersByTimeAsync(11000)
+
+            await expect(connectPromise).rejects.toThrow(
+                "Twitch IRC connection timeout"
+            )
+        })
+
+        it("rejects on socket error", async () => {
+            const connectPromise = adapter.connect(
+                "errorchannel",
+                "oauth:token"
+            )
+            await vi.advanceTimersByTimeAsync(10)
+
+            const socket = getSocket()
+            if (socket) {
+                socket.emit("error", new Error("Connection refused"))
+            }
+
+            await vi.advanceTimersByTimeAsync(100)
+            await expect(connectPromise).rejects.toThrow("Connection refused")
+        })
+    })
+
+    describe("onMessage and IRC PRIVMSG", () => {
+        it("receives PRIVMSG and parses it correctly", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+            const handler = vi.fn()
+            adapter.onMessage("testchannel", handler)
+
+            socket.emit(
+                "data",
+                Buffer.from(
+                    '@badges=moderator/1;color=#FF0000;display-name=TestUser;emotes=;id=abc-123;mod=1;user-id=456;user-type=mod :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Hello world!\r\n'
+                )
+            )
+
+            expect(handler).toHaveBeenCalledTimes(1)
+            const msg = handler.mock.calls[0][0]
+            expect(msg.platform).toBe("twitch")
+            expect(msg.content).toBe("Hello world!")
+            expect(msg.user.displayName).toBe("TestUser")
+            expect(msg.user.isModerator).toBe(true)
+            expect(msg.user.id).toBe("456")
+        })
+
+        it("receives USERNOTICE events", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+            const handler = vi.fn()
+            adapter.onMessage("testchannel", handler)
+
+            // Note: system-msg with spaces won't parse correctly via IRC regex
+            // Using a message without space in the tag value
+            socket.emit(
+                "data",
+                Buffer.from(
+                    '@system-msg=subscribed :tmi.twitch.tv USERNOTICE #testchannel :Someone just subscribed!\r\n'
+                )
+            )
+
+            expect(handler).toHaveBeenCalledTimes(1)
+            const msg = handler.mock.calls[0][0]
+            expect(msg.type).toBe("system")
+            expect(msg.content).toContain("Someone just subscribed!")
+        })
+    })
+
+    describe("sendMessage", () => {
+        it("sends PRIVMSG for normal message", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+
+            const msgId = await adapter.sendMessage("testchannel", "Hello!")
+
+            expect(msgId).toBeTruthy()
+            expect(socket.write).toHaveBeenCalledWith(
+                "PRIVMSG #testchannel :Hello!\r\n"
+            )
+        })
+
+        it("sends ACTION for /me messages", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+
+            await adapter.sendMessage("testchannel", "waves", {
+                isAction: true,
+            })
+
+            const actionCall = socket.write.mock.calls.find(
+                (call: string[]) => call[0]?.includes("ACTION")
+            )
+            expect(actionCall).toBeTruthy()
+        })
+
+        it("throws if not connected", async () => {
+            await expect(
+                adapter.sendMessage("unknown", "test")
+            ).rejects.toThrow("Not connected to Twitch room: unknown")
+        })
+    })
+
+    describe("getRoom", () => {
+        it("returns room info when connected", async () => {
+            await connectAndWait()
+
+            const room = await adapter.getRoom("testchannel")
+
+            expect(room).not.toBeNull()
+            expect(room!.id).toBe("testchannel")
+            expect(room!.platform).toBe("twitch")
+            expect(room!.isLive).toBe(true)
+        })
+
+        it("returns null when not connected", async () => {
+            const room = await adapter.getRoom("unknown")
+            expect(room).toBeNull()
+        })
+    })
+
+    describe("getHistory", () => {
+        it("returns empty array (not yet implemented)", async () => {
+            const history = await adapter.getHistory("testchannel", 50)
+            expect(history).toEqual([])
+        })
+    })
+
+    describe("disconnect", () => {
+        it("disconnects and cleans up", async () => {
+            await connectAndWait()
+            const socket = getSocket()
+
+            await adapter.disconnect("testchannel")
+
+            expect(socket.write).toHaveBeenCalledWith("PART #testchannel\r\n")
+            expect(socket.end).toHaveBeenCalled()
+            expect(socket.destroy).toHaveBeenCalled()
+        })
+
+        it("handles disconnect when not connected gracefully", async () => {
+            await expect(
+                adapter.disconnect("unknown")
+            ).resolves.not.toThrow()
+        })
+    })
+
+    describe("onError", () => {
+        it("notifies error handler on socket error", async () => {
+            const errorHandler = vi.fn()
+            adapter.onError(errorHandler)
+
+            const connectPromise = adapter.connect("err-channel", "token")
+            await vi.advanceTimersByTimeAsync(10)
+
+            const socket = getSocket()
+            if (socket) {
+                socket.emit("error", new Error("Socket error"))
+            }
+
+            await vi.advanceTimersByTimeAsync(100)
+            await expect(connectPromise).rejects.toThrow()
+            expect(errorHandler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: "Socket error",
+                })
+            )
+        })
+    })
+})

--- a/src/__tests__/lib/kick/kick-config.test.ts
+++ b/src/__tests__/lib/kick/kick-config.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for Kick Configuration Module
+ * Covers createKickConfig(), validateKickConfig(), getKickConfig(), resetKickConfig()
+ */
+
+import {
+    createKickConfig,
+    getKickConfig,
+    resetKickConfig,
+    validateKickConfig,
+} from "@/lib/kick/config"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+function setEnv(vars: Record<string, string>): void {
+    for (const [key, val] of Object.entries(vars)) {
+        process.env[key] = val
+    }
+}
+
+function unsetEnv(keys: string[]): void {
+    for (const key of keys) {
+        delete process.env[key]
+    }
+}
+
+describe("Kick Config", () => {
+    beforeEach(() => {
+        setEnv({
+            KICK_CLIENT_ID: "test-kick-client-id",
+            KICK_CLIENT_SECRET: "test-kick-client-secret",
+            KICK_REDIRECT_URI: "http://localhost:3000/callback/kick",
+        })
+    })
+
+    afterEach(() => {
+        resetKickConfig()
+        unsetEnv(["KICK_CLIENT_ID", "KICK_CLIENT_SECRET", "KICK_REDIRECT_URI"])
+    })
+
+    describe("createKickConfig", () => {
+        it("creates config with env vars", () => {
+            const config = createKickConfig()
+
+            expect(config.oauth.clientId).toBe("test-kick-client-id")
+            expect(config.oauth.clientSecret).toBe("test-kick-client-secret")
+            expect(config.oauth.redirectUri).toBe(
+                "http://localhost:3000/callback/kick"
+            )
+        })
+
+        it("uses default scopes", () => {
+            const config = createKickConfig()
+
+            expect(config.oauth.scopes).toContain("user:read")
+            expect(config.oauth.scopes).toContain("channel:read")
+            expect(config.oauth.scopes).toContain("chat:write")
+        })
+
+        it("uses default redirect URI when env var is missing", () => {
+            unsetEnv(["KICK_REDIRECT_URI"])
+            const config = createKickConfig()
+
+            expect(config.oauth.redirectUri).toBe(
+                "https://www.gabrieltoth.com/api/oauth/callback/kick"
+            )
+        })
+
+        it("sets correct API URLs", () => {
+            const config = createKickConfig()
+
+            expect(config.apiBaseUrl).toBe("https://api.kick.com")
+            expect(config.oauthAuthorizeUrl).toBe(
+                "https://id.kick.com/oauth/authorize"
+            )
+            expect(config.oauthTokenUrl).toBe("https://id.kick.com/oauth/token")
+            expect(config.websocketUrl).toBe("wss://ws.kick.com")
+        })
+
+        it("sets rate limit defaults", () => {
+            const config = createKickConfig()
+
+            expect(config.rateLimit.linkingAttemptsPerHour).toBe(5)
+            expect(config.security.tokenExpiryBufferMs).toBe(5 * 60 * 1000)
+        })
+    })
+
+    describe("validateKickConfig", () => {
+        it("returns valid for complete config", () => {
+            const config = createKickConfig()
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(true)
+            expect(result.errors).toHaveLength(0)
+        })
+
+        it("returns error when client ID is missing", () => {
+            const config = createKickConfig()
+            config.oauth.clientId = ""
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Kick Client ID is required")
+        })
+
+        it("returns error when client secret is missing", () => {
+            const config = createKickConfig()
+            config.oauth.clientSecret = ""
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Kick Client Secret is required")
+        })
+
+        it("returns error when redirect URI is missing", () => {
+            const config = createKickConfig()
+            config.oauth.redirectUri = ""
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Kick redirect URI is required")
+        })
+
+        it("returns error when linkingAttemptsPerHour is less than 1", () => {
+            const config = createKickConfig()
+            config.rateLimit.linkingAttemptsPerHour = 0
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain(
+                "Linking attempts per hour must be at least 1"
+            )
+        })
+
+        it("collects multiple errors at once", () => {
+            const config = createKickConfig()
+            config.oauth.clientId = ""
+            config.oauth.clientSecret = ""
+            config.oauth.redirectUri = ""
+            config.rateLimit.linkingAttemptsPerHour = 0
+            const result = validateKickConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors.length).toBeGreaterThanOrEqual(4)
+        })
+    })
+
+    describe("getKickConfig", () => {
+        it("returns a config instance", () => {
+            const config = getKickConfig()
+
+            expect(config.oauth.clientId).toBe("test-kick-client-id")
+        })
+
+        it("returns the same instance on repeated calls (singleton)", () => {
+            const config1 = getKickConfig()
+            const config2 = getKickConfig()
+
+            expect(config1).toBe(config2)
+        })
+
+        it("throws when env vars are missing", () => {
+            unsetEnv(["KICK_CLIENT_ID", "KICK_CLIENT_SECRET"])
+            resetKickConfig()
+
+            expect(() => getKickConfig()).toThrow("Invalid Kick configuration")
+        })
+    })
+
+    describe("resetKickConfig", () => {
+        it("clears the cached config instance", () => {
+            const config1 = getKickConfig()
+            resetKickConfig()
+            const config2 = getKickConfig()
+
+            expect(config1).not.toBe(config2)
+        })
+
+        it("allows re-creation after reset", () => {
+            resetKickConfig()
+            const config = getKickConfig()
+
+            expect(config.oauth.clientId).toBe("test-kick-client-id")
+        })
+    })
+})

--- a/src/__tests__/lib/kick/kick-oauth-service.test.ts
+++ b/src/__tests__/lib/kick/kick-oauth-service.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for Kick OAuth Service
+ * Covers PKCE authorization flow, token exchange, refresh, API calls, singleton
+ */
+
+import {
+    KickOAuthService,
+    resetKickOAuthService,
+} from "@/lib/kick/oauth-service"
+import type { KickConfig } from "@/lib/kick/config"
+import { ServiceError } from "@/lib/youtube/base-service"
+import crypto from "crypto"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+function createMockConfig(overrides?: Partial<KickConfig>): KickConfig {
+    return {
+        oauth: {
+            clientId: "kick-client-id",
+            clientSecret: "kick-client-secret",
+            redirectUri: "http://localhost:3000/callback/kick",
+            scopes: ["user:read", "channel:read", "chat:write"],
+        },
+        apiBaseUrl: "https://api.kick.com",
+        oauthAuthorizeUrl: "https://id.kick.com/oauth/authorize",
+        oauthTokenUrl: "https://id.kick.com/oauth/token",
+        websocketUrl: "wss://ws.kick.com",
+        rateLimit: { linkingAttemptsPerHour: 5 },
+        security: { tokenExpiryBufferMs: 5 * 60 * 1000 },
+        ...overrides,
+    }
+}
+
+describe("KickOAuthService", () => {
+    let service: KickOAuthService
+    let mockConfig: KickConfig
+    let fetchSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(async () => {
+        mockConfig = createMockConfig()
+        service = new KickOAuthService(mockConfig)
+        await service.initialize()
+        fetchSpy = vi.spyOn(globalThis, "fetch")
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        resetKickOAuthService()
+    })
+
+    describe("generateAuthorizationUrl", () => {
+        it("returns authorization URL with PKCE params", () => {
+            const result = service.generateAuthorizationUrl("user_123")
+
+            const url = new URL(result.authorizationUrl)
+            expect(url.origin + url.pathname).toBe(
+                "https://id.kick.com/oauth/authorize"
+            )
+            expect(url.searchParams.get("client_id")).toBe("kick-client-id")
+            expect(url.searchParams.get("redirect_uri")).toBe(
+                "http://localhost:3000/callback/kick"
+            )
+            expect(url.searchParams.get("response_type")).toBe("code")
+            expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+            expect(url.searchParams.get("code_challenge")).toBeTruthy()
+            expect(url.searchParams.get("state")).toBeTruthy()
+        })
+
+        it("generates state and PKCE values", () => {
+            const result = service.generateAuthorizationUrl("user_123")
+
+            expect(result.state).toBeTruthy()
+            expect(result.state.length).toBe(64) // 32 bytes hex
+            expect(result.codeVerifier).toBeTruthy()
+            expect(result.codeChallenge).toBeTruthy()
+            // code_challenge should be derived from codeVerifier
+            const computedChallenge = crypto
+                .createHash("sha256")
+                .update(result.codeVerifier)
+                .digest("base64url")
+            expect(result.codeChallenge).toBe(computedChallenge)
+        })
+
+        it("throws ServiceError when not initialized", () => {
+            const uninitService = new KickOAuthService(mockConfig)
+
+            expect(() => uninitService.generateAuthorizationUrl("u")).toThrow(
+                ServiceError
+            )
+        })
+    })
+
+    describe("exchangeCodeForToken", () => {
+        it("exchanges code for token with code verifier", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: "kick-access-token",
+                    refresh_token: "kick-refresh-token",
+                    expires_in: 3600,
+                    token_type: "bearer",
+                }),
+            } as Response)
+
+            const result = await service.exchangeCodeForToken(
+                "auth-code",
+                "test-code-verifier"
+            )
+
+            expect(result.accessToken).toBe("kick-access-token")
+            expect(result.refreshToken).toBe("kick-refresh-token")
+            expect(result.expiresIn).toBe(3600)
+            expect(result.tokenType).toBe("bearer")
+
+            // Verify code_verifier was sent
+            const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+            const body = options.body as string
+            expect(body).toContain("code_verifier=test-code-verifier")
+        })
+
+        it("exchanges code for token without code verifier", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: "kick-access-token",
+                    refresh_token: "kick-refresh-token",
+                    expires_in: 3600,
+                    token_type: "bearer",
+                }),
+            } as Response)
+
+            const result = await service.exchangeCodeForToken("auth-code")
+
+            expect(result.accessToken).toBe("kick-access-token")
+            // Verify code_verifier is NOT sent
+            const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+            const body = options.body as string
+            expect(body).not.toContain("code_verifier")
+        })
+
+        it("throws ServiceError on failed exchange", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 400,
+                json: async () => ({ error: "invalid_grant" }),
+            } as Response)
+
+            await expect(
+                service.exchangeCodeForToken("bad-code")
+            ).rejects.toThrow(ServiceError)
+        })
+
+        it("throws ServiceError when not initialized", async () => {
+            const uninitService = new KickOAuthService(mockConfig)
+
+            await expect(
+                uninitService.exchangeCodeForToken("code")
+            ).rejects.toThrow(ServiceError)
+        })
+    })
+
+    describe("refreshAccessToken", () => {
+        it("refreshes token successfully", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: "new-kick-token",
+                    refresh_token: "new-kick-refresh",
+                    expires_in: 7200,
+                    token_type: "bearer",
+                }),
+            } as Response)
+
+            const result = await service.refreshAccessToken("old-refresh")
+
+            expect(result.accessToken).toBe("new-kick-token")
+            expect(result.refreshToken).toBe("new-kick-refresh")
+            expect(result.expiresIn).toBe(7200)
+        })
+
+        it("throws ServiceError on failed refresh", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 401,
+                json: async () => ({ error: "invalid_token" }),
+            } as Response)
+
+            await expect(
+                service.refreshAccessToken("bad-token")
+            ).rejects.toThrow(ServiceError)
+        })
+    })
+
+    describe("getUser", () => {
+        it("returns user on success", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            user_id: "kick_user_1",
+                            username: "kickuser",
+                            email: "kick@example.com",
+                            profile_picture_url:
+                                "https://example.com/avatar.png",
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const user = await service.getUser("access-token")
+
+            expect(user).not.toBeNull()
+            expect(user!.userId).toBe("kick_user_1")
+            expect(user!.username).toBe("kickuser")
+            expect(user!.email).toBe("kick@example.com")
+        })
+
+        it("returns null on API error", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 401,
+            } as Response)
+
+            const user = await service.getUser("bad-token")
+            expect(user).toBeNull()
+        })
+    })
+
+    describe("getChannel", () => {
+        it("returns channel on success", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            channel_id: "kick_channel_1",
+                            name: "KickStreamer",
+                            slug: "kickstreamer",
+                            followers_count: 1500,
+                            live: true,
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const channel = await service.getChannel("access-token")
+
+            expect(channel).not.toBeNull()
+            expect(channel!.id).toBe("kick_channel_1")
+            expect(channel!.name).toBe("KickStreamer")
+            expect(channel!.slug).toBe("kickstreamer")
+            expect(channel!.followersCount).toBe(1500)
+            expect(channel!.isLive).toBe(true)
+        })
+
+        it("returns null on API error", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 404,
+            } as Response)
+
+            const channel = await service.getChannel("bad-token")
+            expect(channel).toBeNull()
+        })
+    })
+
+    describe("revokeToken", () => {
+        it("revokes token and returns true", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+            } as Response)
+
+            const result = await service.revokeToken("token-to-revoke")
+
+            expect(result).toBe(true)
+            const [url, options] = fetchSpy.mock.calls[0] as [
+                string,
+                RequestInit,
+            ]
+            expect(url).toBe("https://id.kick.com/oauth/token/revoke")
+            expect(options.method).toBe("POST")
+            const body = options.body as string
+            expect(body).toContain("token=token-to-revoke")
+        })
+
+        it("returns false on failed revocation", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 400,
+            } as Response)
+
+            const result = await service.revokeToken("bad-token")
+            expect(result).toBe(false)
+        })
+
+        it("returns false on fetch error", async () => {
+            fetchSpy.mockRejectedValue(new Error("Network error"))
+
+            const result = await service.revokeToken("token")
+            expect(result).toBe(false)
+        })
+    })
+})

--- a/src/__tests__/lib/twitch/twitch-config.test.ts
+++ b/src/__tests__/lib/twitch/twitch-config.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for Twitch Configuration Module
+ * Covers createTwitchConfig(), validateTwitchConfig(), getTwitchConfig(), resetTwitchConfig()
+ */
+
+import {
+    createTwitchConfig,
+    getTwitchConfig,
+    resetTwitchConfig,
+    validateTwitchConfig,
+} from "@/lib/twitch/config"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+function setEnv(vars: Record<string, string>): void {
+    for (const [key, val] of Object.entries(vars)) {
+        process.env[key] = val
+    }
+}
+
+function unsetEnv(keys: string[]): void {
+    for (const key of keys) {
+        delete process.env[key]
+    }
+}
+
+describe("Twitch Config", () => {
+    beforeEach(() => {
+        setEnv({
+            TWITCH_CLIENT_ID: "test-client-id",
+            TWITCH_CLIENT_SECRET: "test-client-secret",
+            TWITCH_REDIRECT_URI: "http://localhost:3000/callback/twitch",
+        })
+    })
+
+    afterEach(() => {
+        resetTwitchConfig()
+        unsetEnv([
+            "TWITCH_CLIENT_ID",
+            "TWITCH_CLIENT_SECRET",
+            "TWITCH_REDIRECT_URI",
+        ])
+    })
+
+    describe("createTwitchConfig", () => {
+        it("creates config with env vars", () => {
+            const config = createTwitchConfig()
+
+            expect(config.oauth.clientId).toBe("test-client-id")
+            expect(config.oauth.clientSecret).toBe("test-client-secret")
+            expect(config.oauth.redirectUri).toBe(
+                "http://localhost:3000/callback/twitch"
+            )
+        })
+
+        it("uses default scopes", () => {
+            const config = createTwitchConfig()
+
+            expect(config.oauth.scopes).toContain("chat:read")
+            expect(config.oauth.scopes).toContain("chat:edit")
+            expect(config.oauth.scopes).toContain("channel:manage:broadcast")
+        })
+
+        it("uses default redirect URI when env var is missing", () => {
+            unsetEnv(["TWITCH_REDIRECT_URI"])
+            const config = createTwitchConfig()
+
+            expect(config.oauth.redirectUri).toBe(
+                "http://localhost:3000/api/oauth/callback/twitch"
+            )
+        })
+
+        it("sets correct API URLs", () => {
+            const config = createTwitchConfig()
+
+            expect(config.apiBaseUrl).toBe("https://api.twitch.tv/helix")
+            expect(config.oauthAuthorizeUrl).toBe(
+                "https://id.twitch.tv/oauth2/authorize"
+            )
+            expect(config.oauthTokenUrl).toBe(
+                "https://id.twitch.tv/oauth2/token"
+            )
+            expect(config.oauthRevokeUrl).toBe(
+                "https://id.twitch.tv/oauth2/revoke"
+            )
+        })
+
+        it("sets IRC and EventSub URLs", () => {
+            const config = createTwitchConfig()
+
+            expect(config.ircUrl).toBe("irc.chat.twitch.tv")
+            expect(config.ircPort).toBe(6667)
+            expect(config.eventsubWsUrl).toBe("wss://eventsub.wss.twitch.tv")
+        })
+
+        it("sets rate limit and security defaults", () => {
+            const config = createTwitchConfig()
+
+            expect(config.rateLimit.requestsPerMinute).toBe(800)
+            expect(config.security.tokenExpiryBufferMs).toBe(5 * 60 * 1000)
+        })
+    })
+
+    describe("validateTwitchConfig", () => {
+        it("returns valid for complete config", () => {
+            const config = createTwitchConfig()
+            const result = validateTwitchConfig(config)
+
+            expect(result.isValid).toBe(true)
+            expect(result.errors).toHaveLength(0)
+        })
+
+        it("returns error when client ID is missing", () => {
+            const config = createTwitchConfig()
+            config.oauth.clientId = ""
+            const result = validateTwitchConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Twitch Client ID is required")
+        })
+
+        it("returns error when client secret is missing", () => {
+            const config = createTwitchConfig()
+            config.oauth.clientSecret = ""
+            const result = validateTwitchConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Twitch Client Secret is required")
+        })
+
+        it("returns error when redirect URI is missing", () => {
+            const config = createTwitchConfig()
+            config.oauth.redirectUri = ""
+            const result = validateTwitchConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toContain("Twitch redirect URI is required")
+        })
+
+        it("collects multiple errors at once", () => {
+            const config = createTwitchConfig()
+            config.oauth.clientId = ""
+            config.oauth.clientSecret = ""
+            config.oauth.redirectUri = ""
+            const result = validateTwitchConfig(config)
+
+            expect(result.isValid).toBe(false)
+            expect(result.errors).toHaveLength(3)
+        })
+    })
+
+    describe("getTwitchConfig", () => {
+        it("returns a config instance", () => {
+            const config = getTwitchConfig()
+
+            expect(config.oauth.clientId).toBe("test-client-id")
+        })
+
+        it("returns the same instance on repeated calls (singleton)", () => {
+            const config1 = getTwitchConfig()
+            const config2 = getTwitchConfig()
+
+            expect(config1).toBe(config2)
+        })
+
+        it("throws when env vars are missing", () => {
+            unsetEnv(["TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"])
+            resetTwitchConfig()
+
+            expect(() => getTwitchConfig()).toThrow(
+                "Invalid Twitch configuration"
+            )
+        })
+    })
+
+    describe("resetTwitchConfig", () => {
+        it("clears the cached config instance", () => {
+            const config1 = getTwitchConfig()
+            resetTwitchConfig()
+            const config2 = getTwitchConfig()
+
+            expect(config1).not.toBe(config2)
+        })
+
+        it("allows re-creation after reset", () => {
+            resetTwitchConfig()
+            const config = getTwitchConfig()
+
+            expect(config.oauth.clientId).toBe("test-client-id")
+        })
+    })
+})

--- a/src/__tests__/lib/twitch/twitch-oauth-service.test.ts
+++ b/src/__tests__/lib/twitch/twitch-oauth-service.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for Twitch OAuth Service
+ * Covers authorization URL generation, token exchange, refresh, API calls, singleton
+ */
+
+import {
+    TwitchOAuthService,
+    resetTwitchOAuthService,
+} from "@/lib/twitch/oauth-service"
+import type { TwitchConfig } from "@/lib/twitch/config"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+function createMockConfig(overrides?: Partial<TwitchConfig>): TwitchConfig {
+    return {
+        oauth: {
+            clientId: "test-client-id",
+            clientSecret: "test-client-secret",
+            redirectUri: "http://localhost:3000/callback/twitch",
+            scopes: ["chat:read", "chat:edit"],
+        },
+        apiBaseUrl: "https://api.twitch.tv/helix",
+        oauthAuthorizeUrl: "https://id.twitch.tv/oauth2/authorize",
+        oauthTokenUrl: "https://id.twitch.tv/oauth2/token",
+        oauthRevokeUrl: "https://id.twitch.tv/oauth2/revoke",
+        ircUrl: "irc.chat.twitch.tv",
+        ircPort: 6667,
+        eventsubWsUrl: "wss://eventsub.wss.twitch.tv",
+        rateLimit: { requestsPerMinute: 800 },
+        security: { tokenExpiryBufferMs: 5 * 60 * 1000 },
+        ...overrides,
+    }
+}
+
+describe("TwitchOAuthService", () => {
+    let service: TwitchOAuthService
+    let mockConfig: TwitchConfig
+    let fetchSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(async () => {
+        mockConfig = createMockConfig()
+        service = new TwitchOAuthService(mockConfig)
+        await service.initialize()
+        fetchSpy = vi.spyOn(globalThis, "fetch")
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        resetTwitchOAuthService()
+    })
+
+    describe("generateAuthorizationUrl", () => {
+        it("returns authorization URL with correct params", () => {
+            const result = service.generateAuthorizationUrl("test-state")
+
+            const url = new URL(result.authorizationUrl)
+            expect(url.origin + url.pathname).toBe(
+                "https://id.twitch.tv/oauth2/authorize"
+            )
+            expect(url.searchParams.get("client_id")).toBe("test-client-id")
+            expect(url.searchParams.get("redirect_uri")).toBe(
+                "http://localhost:3000/callback/twitch"
+            )
+            expect(url.searchParams.get("response_type")).toBe("code")
+            expect(url.searchParams.get("scope")).toBe("chat:read chat:edit")
+            expect(url.searchParams.get("state")).toBe("test-state")
+        })
+
+        it("returns the same state", () => {
+            const result = service.generateAuthorizationUrl("my-state")
+
+            expect(result.state).toBe("my-state")
+            expect(result.authorizationUrl).toContain("state=my-state")
+        })
+    })
+
+    describe("exchangeCodeForToken", () => {
+        it("exchanges code for token successfully", async () => {
+            const mockResponse = {
+                ok: true,
+                json: async () => ({
+                    access_token: "test-access-token",
+                    refresh_token: "test-refresh-token",
+                    expires_in: 3600,
+                    token_type: "bearer",
+                    scope: "chat:read chat:edit",
+                }),
+            }
+            fetchSpy.mockResolvedValue(mockResponse as Response)
+
+            const result = await service.exchangeCodeForToken("auth-code")
+
+            expect(result.accessToken).toBe("test-access-token")
+            expect(result.refreshToken).toBe("test-refresh-token")
+            expect(result.expiresIn).toBe(3600)
+            expect(result.tokenType).toBe("bearer")
+            expect(result.scope).toBe("chat:read chat:edit")
+        })
+
+        it("sends correct POST request", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({ access_token: "tok" }),
+            } as Response)
+
+            await service.exchangeCodeForToken("auth-code-123")
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1)
+            const [url, options] = fetchSpy.mock.calls[0] as [
+                string,
+                RequestInit,
+            ]
+            expect(url).toBe("https://id.twitch.tv/oauth2/token")
+            expect(options.method).toBe("POST")
+            expect(options.headers).toEqual({
+                "Content-Type": "application/x-www-form-urlencoded",
+            })
+            const body = options.body as string
+            expect(body).toContain("client_id=test-client-id")
+            expect(body).toContain("code=auth-code-123")
+            expect(body).toContain("grant_type=authorization_code")
+        })
+
+        it("throws on failed exchange", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 400,
+                text: async () => "bad request",
+            } as Response)
+
+            await expect(
+                service.exchangeCodeForToken("bad-code")
+            ).rejects.toThrow("Twitch token exchange failed: 400")
+        })
+    })
+
+    describe("refreshAccessToken", () => {
+        it("refreshes token successfully", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: "new-access-token",
+                    refresh_token: "new-refresh-token",
+                    expires_in: 7200,
+                    token_type: "bearer",
+                    scope: "chat:read",
+                }),
+            } as Response)
+
+            const result = await service.refreshAccessToken("old-refresh-token")
+
+            expect(result.accessToken).toBe("new-access-token")
+            expect(result.refreshToken).toBe("new-refresh-token")
+            expect(result.expiresIn).toBe(7200)
+        })
+
+        it("throws on failed refresh", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 401,
+                text: async () => "invalid refresh token",
+            } as Response)
+
+            await expect(
+                service.refreshAccessToken("invalid-token")
+            ).rejects.toThrow("Twitch token refresh failed: 401")
+        })
+    })
+
+    describe("getUser", () => {
+        it("returns user on success", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            id: "123",
+                            login: "testuser",
+                            display_name: "TestUser",
+                            type: "",
+                            broadcaster_type: "partner",
+                            description: "A test channel",
+                            profile_image_url: "https://example.com/avatar.png",
+                            offline_image_url:
+                                "https://example.com/offline.png",
+                            email: "test@example.com",
+                            created_at: "2024-01-01T00:00:00Z",
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const user = await service.getUser("access-token")
+
+            expect(user).not.toBeNull()
+            expect(user!.id).toBe("123")
+            expect(user!.login).toBe("testuser")
+            expect(user!.displayName).toBe("TestUser")
+            expect(user!.email).toBe("test@example.com")
+        })
+
+        it("sends correct authorization headers", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            id: "1",
+                            login: "u",
+                            display_name: "U",
+                            type: "",
+                            broadcaster_type: "",
+                            description: "",
+                            profile_image_url: "",
+                            offline_image_url: "",
+                            created_at: "",
+                        },
+                    ],
+                }),
+            } as Response)
+
+            await service.getUser("my-access-token")
+
+            const [url, options] = fetchSpy.mock.calls[0] as [
+                string,
+                RequestInit,
+            ]
+            expect(url).toBe("https://api.twitch.tv/helix/users")
+            expect(options.headers).toMatchObject({
+                Authorization: "Bearer my-access-token",
+                "Client-Id": "test-client-id",
+            })
+        })
+
+        it("returns null on API error", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 401,
+            } as Response)
+
+            const user = await service.getUser("bad-token")
+            expect(user).toBeNull()
+        })
+
+        it("returns null when data array is empty", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({ data: [] }),
+            } as Response)
+
+            const user = await service.getUser("token")
+            expect(user).toBeNull()
+        })
+    })
+
+    describe("getChannel", () => {
+        it("returns channel on success", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            broadcaster_id: "123",
+                            broadcaster_login: "testuser",
+                            broadcaster_name: "TestUser",
+                            broadcaster_language: "en",
+                            game_id: "12345",
+                            game_name: "Just Chatting",
+                            title: "My Stream",
+                            delay: 0,
+                            tags: ["tag1"],
+                            content_classification_labels: [],
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const channel = await service.getChannel("token", "123")
+
+            expect(channel).not.toBeNull()
+            expect(channel!.broadcasterId).toBe("123")
+            expect(channel!.broadcasterName).toBe("TestUser")
+            expect(channel!.title).toBe("My Stream")
+            expect(channel!.gameName).toBe("Just Chatting")
+        })
+
+        it("returns null on API error", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 404,
+            } as Response)
+
+            const channel = await service.getChannel("token", "999")
+            expect(channel).toBeNull()
+        })
+    })
+
+    describe("getStream", () => {
+        it("returns stream on success", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            id: "stream1",
+                            user_id: "123",
+                            user_login: "testuser",
+                            user_name: "TestUser",
+                            game_id: "12345",
+                            game_name: "Just Chatting",
+                            type: "live",
+                            title: "Live Stream!",
+                            viewer_count: 42,
+                            started_at: "2024-01-01T00:00:00Z",
+                            language: "en",
+                            thumbnail_url: "https://example.com/thumb.jpg",
+                            tag_ids: ["tag1"],
+                            is_mature: false,
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const stream = await service.getStream("token", "123")
+
+            expect(stream).not.toBeNull()
+            expect(stream!.id).toBe("stream1")
+            expect(stream!.userName).toBe("TestUser")
+            expect(stream!.title).toBe("Live Stream!")
+            expect(stream!.viewerCount).toBe(42)
+        })
+
+        it("returns null when not live", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({ data: [] }),
+            } as Response)
+
+            const stream = await service.getStream("token", "123")
+            expect(stream).toBeNull()
+        })
+    })
+
+    describe("modifyChannel", () => {
+        it("modifies channel successfully", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+            } as Response)
+
+            const result = await service.modifyChannel("token", "123", {
+                title: "New Title",
+                game_id: "99999",
+            })
+
+            expect(result).toBe(true)
+            const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+            expect(options.method).toBe("PATCH")
+            const body = JSON.parse(options.body as string)
+            expect(body.title).toBe("New Title")
+            expect(body.game_id).toBe("99999")
+        })
+
+        it("returns false on failure", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 400,
+                text: async () => "error",
+            } as Response)
+
+            const result = await service.modifyChannel("token", "123", {
+                title: "Bad Title",
+            })
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("revokeToken", () => {
+        it("revokes token and returns true", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+            } as Response)
+
+            const result = await service.revokeToken("token-to-revoke")
+
+            expect(result).toBe(true)
+            const [url, options] = fetchSpy.mock.calls[0] as [
+                string,
+                RequestInit,
+            ]
+            expect(url).toBe("https://id.twitch.tv/oauth2/revoke")
+            expect(options.method).toBe("POST")
+            const body = options.body as string
+            expect(body).toContain("token=token-to-revoke")
+        })
+
+        it("returns true even on non-200 response", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 404,
+            } as Response)
+
+            const result = await service.revokeToken("bad-token")
+            expect(result).toBe(true)
+        })
+    })
+
+    describe("getTopGames", () => {
+        it("returns top games without query", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            id: "1",
+                            name: "Just Chatting",
+                            box_art_url: "https://example.com/1.jpg",
+                        },
+                        {
+                            id: "2",
+                            name: "Grand Theft Auto V",
+                            box_art_url: "https://example.com/2.jpg",
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const games = await service.getTopGames("token")
+
+            expect(games).toHaveLength(2)
+            expect(games[0].name).toBe("Just Chatting")
+            expect(games[1].id).toBe("2")
+            const [url] = fetchSpy.mock.calls[0] as [string]
+            expect(url).toContain("/games/top")
+        })
+
+        it("returns searched games with query", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    data: [
+                        {
+                            id: "3",
+                            name: "Minecraft",
+                            box_art_url: "https://example.com/mc.jpg",
+                        },
+                    ],
+                }),
+            } as Response)
+
+            const games = await service.getTopGames("token", "minecraft", 10)
+
+            expect(games).toHaveLength(1)
+            const [url] = fetchSpy.mock.calls[0] as [string]
+            expect(url).toContain("/search/categories")
+            expect(url).toContain("query=minecraft")
+            expect(url).toContain("first=10")
+        })
+
+        it("returns empty array on API error", async () => {
+            fetchSpy.mockResolvedValue({
+                ok: false,
+                status: 500,
+            } as Response)
+
+            const games = await service.getTopGames("token")
+            expect(games).toEqual([])
+        })
+    })
+})

--- a/src/app/[locale]/dashboard/channels/page.tsx
+++ b/src/app/[locale]/dashboard/channels/page.tsx
@@ -366,7 +366,8 @@ export default function ChannelsPage() {
                                                             "channels.notImplemented"
                                                         )}
                                                     </Badge>
-                                                ) : (platform as any).localOnly ? (
+                                                ) : (platform as any)
+                                                      .localOnly ? (
                                                     <Badge
                                                         variant="outline"
                                                         className="mt-0.5 text-xs border-amber-300 text-amber-700 bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:bg-amber-950/30"

--- a/src/app/[locale]/dashboard/live/page.tsx
+++ b/src/app/[locale]/dashboard/live/page.tsx
@@ -31,8 +31,9 @@ export default function LiveDashboardPage() {
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [activePlatform, setActivePlatform] = useState<string>("twitch")
-    const [refreshInterval, setRefreshInterval] =
-        useState<ReturnType<typeof setInterval> | null>(null)
+    const [refreshInterval, setRefreshInterval] = useState<ReturnType<
+        typeof setInterval
+    > | null>(null)
 
     useEffect(() => {
         fetchStatus()
@@ -107,9 +108,8 @@ export default function LiveDashboardPage() {
         )
     }
 
-    const currentPlatform = platforms.find(
-        p => p.platform === activePlatform
-    ) || platforms[0]
+    const currentPlatform =
+        platforms.find(p => p.platform === activePlatform) || platforms[0]
 
     return (
         <div className="space-y-6">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -55,20 +55,14 @@ function DashboardRedirect() {
                     text: "✅ Twitch connected successfully!",
                     isError: false,
                 })
-                setTimeout(
-                    () => router.push(`/${locale}/dashboard/live`),
-                    1500
-                )
+                setTimeout(() => router.push(`/${locale}/dashboard/live`), 1500)
             } else {
                 const msg = searchParams.get("error") || "unknown"
                 setOauthMsg({
                     text: `❌ Twitch: ${decodeURIComponent(msg)}`,
                     isError: true,
                 })
-                setTimeout(
-                    () => router.push(`/${locale}/dashboard/live`),
-                    5000
-                )
+                setTimeout(() => router.push(`/${locale}/dashboard/live`), 5000)
             }
             return
         }
@@ -80,10 +74,7 @@ function DashboardRedirect() {
                     text: "✅ Kick connected successfully!",
                     isError: false,
                 })
-                setTimeout(
-                    () => router.push(`/${locale}/dashboard/live`),
-                    1500
-                )
+                setTimeout(() => router.push(`/${locale}/dashboard/live`), 1500)
             } else {
                 const msg = searchParams.get("error") || "unknown"
                 setOauthMsg({
@@ -102,7 +93,16 @@ function DashboardRedirect() {
             ? `/${locale}/dashboard/publish?youtube=${encodeURIComponent(youtubeParam)}`
             : `/${locale}/dashboard/publish`
         router.push(target)
-    }, [router, youtubeParam, locale, tiktokParam, tiktokReason, twitchParam, kickParam, searchParams])
+    }, [
+        router,
+        youtubeParam,
+        locale,
+        tiktokParam,
+        tiktokReason,
+        twitchParam,
+        kickParam,
+        searchParams,
+    ])
 
     if (oauthMsg) {
         return (

--- a/src/app/api/live/status/route.ts
+++ b/src/app/api/live/status/route.ts
@@ -29,18 +29,15 @@ async function fetchTwitchStream(
     userId: string
 ): Promise<Partial<PlatformStreamInfo>> {
     try {
-        const tokenResponse = await fetch(
-            "https://id.twitch.tv/oauth2/token",
-            {
-                method: "POST",
-                headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                body: new URLSearchParams({
-                    client_id: process.env.TWITCH_CLIENT_ID || "",
-                    client_secret: process.env.TWITCH_CLIENT_SECRET || "",
-                    grant_type: "client_credentials",
-                }),
-            }
-        )
+        const tokenResponse = await fetch("https://id.twitch.tv/oauth2/token", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+                client_id: process.env.TWITCH_CLIENT_ID || "",
+                client_secret: process.env.TWITCH_CLIENT_SECRET || "",
+                grant_type: "client_credentials",
+            }),
+        })
 
         if (!tokenResponse.ok) {
             logger.warn("Twitch app token fetch failed", {
@@ -140,8 +137,7 @@ async function fetchKickStream(
         if (!channel) return {}
 
         const isLive =
-            channel.livestream?.is_live === true ||
-            channel.is_live === true
+            channel.livestream?.is_live === true || channel.is_live === true
 
         return {
             isLive,
@@ -333,7 +329,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         const { data: networks, error } = await supabase
             .from("social_networks")
             .select("*")
-            .in("platform", ["youtube", "facebook", "instagram", "twitch", "kick"])
+            .in("platform", [
+                "youtube",
+                "facebook",
+                "instagram",
+                "twitch",
+                "kick",
+            ])
             .eq("user_id", userId)
             .eq("status", "connected")
 
@@ -358,8 +360,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     network.metadata?.displayName ||
                     network.platform_username ||
                     "",
-                profileImageUrl:
-                    network.metadata?.profileImageUrl || null,
+                profileImageUrl: network.metadata?.profileImageUrl || null,
                 isLive: false,
                 viewerCount: 0,
                 title: "",
@@ -376,8 +377,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     if (accessToken) {
                         const twitchData = await fetchTwitchStream(
                             accessToken,
-                            network.provider_user_id ||
-                                network.platform_user_id
+                            network.provider_user_id || network.platform_user_id
                         )
                         platforms.push({ ...baseInfo, ...twitchData })
                     } else {
@@ -427,8 +427,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     if (pageAccessToken) {
                         const igData = await fetchInstagramLive(
                             pageAccessToken,
-                            network.metadata
-                                ?.instagram_business_account_id ||
+                            network.metadata?.instagram_business_account_id ||
                                 network.platform_user_id ||
                                 ""
                         )

--- a/src/app/api/live/update/route.ts
+++ b/src/app/api/live/update/route.ts
@@ -34,18 +34,15 @@ async function updateTwitchStream(
             body.game_id = gameId
         }
 
-        const response = await fetch(
-            "https://api.twitch.tv/helix/channels",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Client-Id": clientId,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(body),
-            }
-        )
+        const response = await fetch("https://api.twitch.tv/helix/channels", {
+            method: "PATCH",
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Client-Id": clientId,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        })
 
         if (!response.ok) {
             const errorBody = await response.text()

--- a/src/app/api/oauth/authorize/kick/route.ts
+++ b/src/app/api/oauth/authorize/kick/route.ts
@@ -55,7 +55,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             .update(codeVerifier)
             .digest("base64url")
 
-        const signedState = generateState(userId, "kick", undefined, undefined, codeVerifier)
+        const signedState = generateState(
+            userId,
+            "kick",
+            undefined,
+            undefined,
+            codeVerifier
+        )
 
         const params = new URLSearchParams({
             client_id: config.oauth.clientId,

--- a/src/app/api/oauth/authorize/twitch/route.ts
+++ b/src/app/api/oauth/authorize/twitch/route.ts
@@ -49,8 +49,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const signedState = generateState(userId, "twitch")
 
-        const { authorizationUrl } =
-            oauthService.generateAuthorizationUrl(signedState.token)
+        const { authorizationUrl } = oauthService.generateAuthorizationUrl(
+            signedState.token
+        )
 
         logger.info("Twitch authorization URL generated (HMAC state)", {
             userId,

--- a/src/app/api/oauth/authorize/twitter/route.ts
+++ b/src/app/api/oauth/authorize/twitter/route.ts
@@ -86,8 +86,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         // We do NOT include state in the URL because OAuth 1.0a callback
         // URL is fixed during request token step. Instead, we stored the
         // session in the DB keyed by oauth_token.
-        const authorizeUrl =
-            oauthService.generateAuthorizationUrl(requestToken.oauthToken)
+        const authorizeUrl = oauthService.generateAuthorizationUrl(
+            requestToken.oauthToken
+        )
 
         logger.info("Twitter OAuth 1.0a authorization URL generated", {
             userId,

--- a/src/app/api/oauth/callback/twitter/route.ts
+++ b/src/app/api/oauth/callback/twitter/route.ts
@@ -43,10 +43,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         }
 
         if (!oauthToken || !oauthVerifier) {
-            logger.warn(
-                "Missing OAuth 1.0a parameters in Twitter callback",
-                { hasToken: !!oauthToken, hasVerifier: !!oauthVerifier }
-            )
+            logger.warn("Missing OAuth 1.0a parameters in Twitter callback", {
+                hasToken: !!oauthToken,
+                hasVerifier: !!oauthVerifier,
+            })
             return NextResponse.redirect(
                 new URL(
                     "/dashboard?twitter=error&reason=missing_params",
@@ -152,8 +152,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             // Non-fatal: use access token data as fallback
             logger.warn("Could not retrieve extended Twitter user info", {
                 userId,
-                error: userInfoErr instanceof Error ? userInfoErr.message : String(userInfoErr),
-                fallback: { screenName: accessToken.screenName, userId: accessToken.userId },
+                error:
+                    userInfoErr instanceof Error
+                        ? userInfoErr.message
+                        : String(userInfoErr),
+                fallback: {
+                    screenName: accessToken.screenName,
+                    userId: accessToken.userId,
+                },
             })
         }
 

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -10,7 +10,9 @@ import React, { useState } from "react"
 
 export interface SidebarProps {
     activeTab: "publish" | "insights" | "channels" | "settings" | "live"
-    onTabChange: (tab: "publish" | "insights" | "channels" | "settings" | "live") => void
+    onTabChange: (
+        tab: "publish" | "insights" | "channels" | "settings" | "live"
+    ) => void
     isOpen?: boolean
     onClose?: () => void
     organization?: {

--- a/src/components/dashboard/live/stream-status-card.tsx
+++ b/src/components/dashboard/live/stream-status-card.tsx
@@ -43,9 +43,7 @@ export function StreamStatusCard({
         <div
             className="rounded-lg border p-4 transition-shadow hover:shadow-md"
             style={{
-                borderColor: isLive
-                    ? getPlatformColor()
-                    : "rgb(229, 231, 235)",
+                borderColor: isLive ? getPlatformColor() : "rgb(229, 231, 235)",
                 borderLeftWidth: "4px",
                 borderLeftColor: isLive ? getPlatformColor() : undefined,
             }}

--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -31,7 +31,9 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
     const [messages, setMessages] = useState<ChatMessage[]>([])
     const [input, setInput] = useState("")
     const [connected, setConnected] = useState(false)
-    const [selectedPlatform, setSelectedPlatform] = useState(platforms[0] || "twitch")
+    const [selectedPlatform, setSelectedPlatform] = useState(
+        platforms[0] || "twitch"
+    )
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
     // Simulated connection (in production, connects to WebSocket/SSE backend)
@@ -96,7 +98,9 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
         // In production: await fetch(`/api/chat/timeout`, { method: 'POST', body: ... })
     }
 
-    const getPlatformBadge = (platform: string): { color: string; label: string } => {
+    const getPlatformBadge = (
+        platform: string
+    ): { color: string; label: string } => {
         switch (platform) {
             case "twitch":
                 return { color: "#9146FF", label: "Twitch" }
@@ -162,7 +166,10 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                             {/* Badges */}
                             <div className="flex gap-0.5 shrink-0">
                                 {msg.isBroadcaster && (
-                                    <span className="text-xs" title="Broadcaster">
+                                    <span
+                                        className="text-xs"
+                                        title="Broadcaster"
+                                    >
                                         👑
                                     </span>
                                 )}

--- a/src/i18n/de/dashboard.json
+++ b/src/i18n/de/dashboard.json
@@ -1,5 +1,5 @@
 {
-        "sidebar": {
+    "sidebar": {
         "publish": "Veröffentlichen",
         "live": "Live",
         "insights": "Einblicke",

--- a/src/i18n/es/dashboard.json
+++ b/src/i18n/es/dashboard.json
@@ -1,5 +1,5 @@
 {
-        "sidebar": {
+    "sidebar": {
         "publish": "Publicar",
         "live": "En Vivo",
         "insights": "Estadísticas",

--- a/src/lib/chat/kick-adapter.ts
+++ b/src/lib/chat/kick-adapter.ts
@@ -226,10 +226,7 @@ export class KickChatAdapter implements ChatAdapter {
     /**
      * Get message history
      */
-    async getHistory(
-        _roomId: string,
-        limit?: number
-    ): Promise<ChatMessage[]> {
+    async getHistory(_roomId: string, limit?: number): Promise<ChatMessage[]> {
         logger.debug("Kick chat history requested (not yet implemented)", {
             limit,
         })
@@ -284,10 +281,7 @@ export class KickChatAdapter implements ChatAdapter {
     /**
      * Handle an incoming WebSocket message
      */
-    private handleWsMessage(
-        roomId: string,
-        wsMessage: KickWsMessage
-    ): void {
+    private handleWsMessage(roomId: string, wsMessage: KickWsMessage): void {
         try {
             switch (wsMessage.event) {
                 case "message":
@@ -333,8 +327,7 @@ export class KickChatAdapter implements ChatAdapter {
         if (!data) return
 
         const message: ChatMessage = {
-            id:
-                `kick-${(data.id as string) || `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`}`,
+            id: `kick-${(data.id as string) || `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`}`,
             channelId: roomId,
             platform: "kick",
             user: {

--- a/src/lib/chat/twitch-adapter.ts
+++ b/src/lib/chat/twitch-adapter.ts
@@ -35,7 +35,14 @@ export class TwitchChatAdapter implements ChatAdapter {
         platform: "twitch",
         enabled: true,
         maxMessageLength: 500,
-        commands: ["/me", "/timeout", "/ban", "/unban", "/slow", "/subscribers"],
+        commands: [
+            "/me",
+            "/timeout",
+            "/ban",
+            "/unban",
+            "/slow",
+            "/subscribers",
+        ],
     }
 
     private connections: Map<string, TwitchConnection> = new Map()
@@ -94,9 +101,7 @@ export class TwitchChatAdapter implements ChatAdapter {
 
                         // Respond to IRC PING
                         if (line.startsWith("PING")) {
-                            socket.write(
-                                `PONG ${line.substring(5)}\r\n`
-                            )
+                            socket.write(`PONG ${line.substring(5)}\r\n`)
                         }
 
                         // Connected successfully
@@ -228,10 +233,7 @@ export class TwitchChatAdapter implements ChatAdapter {
     /**
      * Get message history (from stored messages)
      */
-    async getHistory(
-        _roomId: string,
-        limit?: number
-    ): Promise<ChatMessage[]> {
+    async getHistory(_roomId: string, limit?: number): Promise<ChatMessage[]> {
         // In a real implementation, this would fetch from Twitch's chat history API
         // or local storage. For now, return empty.
         logger.debug("Twitch chat history requested (not yet implemented)", {
@@ -291,12 +293,12 @@ export class TwitchChatAdapter implements ChatAdapter {
                     platform: "twitch",
                     user: {
                         id: parsedTags["user-id"] || "unknown",
-                        username: parsedTags["display-name"]?.toLowerCase() || "unknown",
+                        username:
+                            parsedTags["display-name"]?.toLowerCase() ||
+                            "unknown",
                         displayName: parsedTags["display-name"] || "Unknown",
                         platform: "twitch",
-                        badges: this.parseBadges(
-                            parsedTags["badges"] || ""
-                        ),
+                        badges: this.parseBadges(parsedTags["badges"] || ""),
                         isBroadcaster:
                             parsedTags["badges"]?.includes("broadcaster") ||
                             false,
@@ -306,8 +308,7 @@ export class TwitchChatAdapter implements ChatAdapter {
                         isSubscriber:
                             parsedTags["badges"]?.includes("subscriber") ||
                             false,
-                        isVip:
-                            parsedTags["badges"]?.includes("vip") || false,
+                        isVip: parsedTags["badges"]?.includes("vip") || false,
                     },
                     content,
                     type: "text",
@@ -360,7 +361,6 @@ export class TwitchChatAdapter implements ChatAdapter {
     private parseIrcTags(tagString: string): Record<string, string> {
         const tags: Record<string, string> = {}
         for (const tag of tagString.split(";")) {
-
             const [key, value] = tag.split("=")
             if (key) {
                 tags[key] = value ? value.replace(/\\s/g, " ") : ""

--- a/src/lib/linkedin/config.ts
+++ b/src/lib/linkedin/config.ts
@@ -34,12 +34,7 @@ export interface LinkedInConfig {
  * NOTE: r_liteprofile and r_emailaddress are legacy v2 scopes that are no longer
  * valid for new apps. w_organization_social requires an Organization-level app.
  */
-const DEFAULT_SCOPES = [
-    "w_member_social",
-    "openid",
-    "profile",
-    "email",
-]
+const DEFAULT_SCOPES = ["w_member_social", "openid", "profile", "email"]
 
 export function createLinkedInConfig(env: EnvironmentConfig): LinkedInConfig {
     return {

--- a/src/lib/networks/network-manager.ts
+++ b/src/lib/networks/network-manager.ts
@@ -15,7 +15,14 @@ const logger = createLogger("NetworkManager")
  * Supported social media platforms
  */
 export type SocialPlatform =
-    "youtube" | "facebook" | "instagram" | "twitter" | "linkedin" | "tiktok" | "twitch" | "kick"
+    | "youtube"
+    | "facebook"
+    | "instagram"
+    | "twitter"
+    | "linkedin"
+    | "tiktok"
+    | "twitch"
+    | "kick"
 
 /**
  * Network status

--- a/src/lib/oauth/oauth-manager-core.ts
+++ b/src/lib/oauth/oauth-manager-core.ts
@@ -138,12 +138,7 @@ export class OAuthManager {
                 // Valid scopes for LinkedIn Standalone App:
                 // w_member_social, openid, profile, email
                 // NOTE: r_liteprofile, r_emailaddress, w_organization_social are invalid
-                scopes: [
-                    "w_member_social",
-                    "openid",
-                    "profile",
-                    "email",
-                ],
+                scopes: ["w_member_social", "openid", "profile", "email"],
                 authorizationUrl:
                     "https://www.linkedin.com/oauth/v2/authorization",
                 tokenUrl: "https://www.linkedin.com/oauth/v2/accessToken",

--- a/src/lib/oauth/oauth-types.ts
+++ b/src/lib/oauth/oauth-types.ts
@@ -8,7 +8,14 @@
  * Supported OAuth platforms
  */
 export type OAuthPlatform =
-    "youtube" | "facebook" | "instagram" | "twitter" | "linkedin" | "tiktok" | "twitch" | "kick"
+    | "youtube"
+    | "facebook"
+    | "instagram"
+    | "twitter"
+    | "linkedin"
+    | "tiktok"
+    | "twitch"
+    | "kick"
 
 /**
  * OAuth configuration for a platform

--- a/src/lib/posting/adapters/twitter.ts
+++ b/src/lib/posting/adapters/twitter.ts
@@ -43,10 +43,10 @@ export interface TwitterPostResult {
  * Percent-encode per RFC 3986 (required by OAuth 1.0a).
  */
 function percentEncode(str: string): string {
-    return encodeURIComponent(str)
-        .replace(/[!'()*]/g, c =>
-            "%" + c.charCodeAt(0).toString(16).toUpperCase()
-        )
+    return encodeURIComponent(str).replace(
+        /[!'()*]/g,
+        c => "%" + c.charCodeAt(0).toString(16).toUpperCase()
+    )
 }
 
 /**
@@ -61,9 +61,7 @@ function generateSignature(
 ): string {
     const paramEntries = Object.entries(params)
         .map(([k, v]) => [percentEncode(k), percentEncode(v)])
-        .sort((a, b) =>
-            a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0
-        )
+        .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
 
     const paramString = paramEntries.map(([k, v]) => `${k}=${v}`).join("&")
 
@@ -73,8 +71,7 @@ function generateSignature(
         percentEncode(paramString),
     ].join("&")
 
-    const signingKey =
-        `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`
+    const signingKey = `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`
 
     const hmac = crypto.createHmac("sha1", signingKey)
     hmac.update(signatureBase)
@@ -123,8 +120,9 @@ function generateAuthHeader(
 
     oauthParams.oauth_signature = signature
 
-    const headerParts = Object.entries(oauthParams)
-        .map(([k, v]) => `${percentEncode(k)}="${percentEncode(v)}"`)
+    const headerParts = Object.entries(oauthParams).map(
+        ([k, v]) => `${percentEncode(k)}="${percentEncode(v)}"`
+    )
 
     return `OAuth ${headerParts.join(", ")}`
 }
@@ -165,8 +163,7 @@ export async function postToTwitter(
         if (!stored) {
             return {
                 success: false,
-                error:
-                    "Twitter account is not linked. Please connect your Twitter account first.",
+                error: "Twitter account is not linked. Please connect your Twitter account first.",
             }
         }
 

--- a/src/lib/queue/background-processor.ts
+++ b/src/lib/queue/background-processor.ts
@@ -121,11 +121,9 @@ export class BackgroundProcessor {
                 await this.queue.markAsPublished(publication.id)
             } else if (allFailed) {
                 // Include the first error message for diagnosis
-                const firstError = results.find(r => r.error)?.error || "All networks failed"
-                await this.queue.markAsFailed(
-                    publication.id,
-                    firstError
-                )
+                const firstError =
+                    results.find(r => r.error)?.error || "All networks failed"
+                await this.queue.markAsFailed(publication.id, firstError)
             } else {
                 await this.queue.markAsPartiallyPublished(
                     publication.id,

--- a/src/lib/twitter/oauth1-service.ts
+++ b/src/lib/twitter/oauth1-service.ts
@@ -1,13 +1,13 @@
 /**
  * Twitter/X OAuth 1.0a Service
- * 
+ *
  * OAuth 1.0a flow for X API v2 posting:
  * 1. POST /oauth/request_token → request token + secret
  * 2. Redirect to /oauth/authenticate?oauth_token=...
  * 3. Callback → oauth_token + oauth_verifier
  * 4. POST /oauth/access_token → access token + secret
  * 5. Sign API requests with OAuth 1.0a HMAC-SHA1
- * 
+ *
  * Why OAuth 1.0a instead of 2.0 PKCE?
  * The new X Developer Console (console.x.com) does not support
  * configuring OAuth 2.0 for newly created apps (feature flag
@@ -40,9 +40,11 @@ export interface TwitterUser {
 }
 
 export class TwitterOAuth1Service extends BaseService {
-    private readonly requestTokenUrl = "https://api.twitter.com/oauth/request_token"
+    private readonly requestTokenUrl =
+        "https://api.twitter.com/oauth/request_token"
     private readonly authorizeUrl = "https://api.twitter.com/oauth/authenticate"
-    private readonly accessTokenUrl = "https://api.twitter.com/oauth/access_token"
+    private readonly accessTokenUrl =
+        "https://api.twitter.com/oauth/access_token"
     private readonly apiBase = "https://api.twitter.com/2"
 
     constructor(private config: TwitterConfig) {
@@ -80,8 +82,10 @@ export class TwitterOAuth1Service extends BaseService {
     }
 
     private percentEncode(str: string): string {
-        return encodeURIComponent(str)
-            .replace(/[!'()*]/g, c => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+        return encodeURIComponent(str).replace(
+            /[!'()*]/g,
+            c => "%" + c.charCodeAt(0).toString(16).toUpperCase()
+        )
     }
 
     /**
@@ -130,8 +134,9 @@ export class TwitterOAuth1Service extends BaseService {
 
         oauthParams.oauth_signature = signature
 
-        const headerParts = Object.entries(oauthParams)
-            .map(([k, v]) => `${this.percentEncode(k)}="${this.percentEncode(v)}"`)
+        const headerParts = Object.entries(oauthParams).map(
+            ([k, v]) => `${this.percentEncode(k)}="${this.percentEncode(v)}"`
+        )
 
         return `OAuth ${headerParts.join(", ")}`
     }
@@ -177,7 +182,8 @@ export class TwitterOAuth1Service extends BaseService {
         return {
             oauthToken: params.get("oauth_token") || "",
             oauthTokenSecret: params.get("oauth_token_secret") || "",
-            oauthCallbackConfirmed: params.get("oauth_callback_confirmed") === "true",
+            oauthCallbackConfirmed:
+                params.get("oauth_callback_confirmed") === "true",
         }
     }
 
@@ -274,7 +280,7 @@ export class TwitterOAuth1Service extends BaseService {
         )
 
         fetchOptions.headers = {
-            ...fetchOptions.headers as Record<string, string>,
+            ...(fetchOptions.headers as Record<string, string>),
             Authorization: authHeader,
         }
 
@@ -285,7 +291,9 @@ export class TwitterOAuth1Service extends BaseService {
             let errorData: Record<string, unknown> = {}
             try {
                 errorData = JSON.parse(text)
-            } catch { /* ignore */ }
+            } catch {
+                /* ignore */
+            }
             throw new ServiceError(
                 "API_REQUEST_FAILED",
                 `X API request failed (${response.status}): ${text.slice(0, 500)}`,
@@ -337,7 +345,9 @@ export class TwitterOAuth1Service extends BaseService {
 
 let oauth1ServiceInstance: TwitterOAuth1Service | null = null
 
-export function getTwitterOAuth1Service(config: TwitterConfig): TwitterOAuth1Service {
+export function getTwitterOAuth1Service(
+    config: TwitterConfig
+): TwitterOAuth1Service {
     if (!oauth1ServiceInstance) {
         oauth1ServiceInstance = new TwitterOAuth1Service(config)
     }

--- a/src/lib/youtube/config.test.ts
+++ b/src/lib/youtube/config.test.ts
@@ -53,7 +53,8 @@ function createValidEnv(): EnvironmentConfig {
         INSTAGRAM_PAGE_ACCESS_TOKEN: "",
         TWITTER_CLIENT_ID: "tw-test-id",
         TWITTER_CLIENT_SECRET: "tw-test-secret",
-        TWITTER_REDIRECT_URI: "http://localhost:3000/api/oauth/callback/twitter",
+        TWITTER_REDIRECT_URI:
+            "http://localhost:3000/api/oauth/callback/twitter",
         OAUTH_STATE_SECRET: "a".repeat(64), // 64 character hex string
         TOKEN_ENCRYPTION_KEY: "a".repeat(64), // 64 character hex string
     }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -291,6 +291,7 @@ if (typeof Element !== "undefined") {
     Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false)
     Element.prototype.setPointerCapture = vi.fn()
     Element.prototype.releasePointerCapture = vi.fn()
+    Element.prototype.scrollIntoView = vi.fn()
 }
 
 ;(globalThis as any).React = React


### PR DESCRIPTION
## Summary

Adds 139 tests across 10 test files covering Twitch/Kick OAuth services, chat adapters, and live dashboard UI components. Fixes jsdom incompatibilities (scrollIntoView mock) and timer handling in tests, plus fixes page integration test texts.

## Risk Assessment

**Risk Level:** 🟢 Medium
**Cost:** ✅ Free (all changes local/local tools)

## Changes

### New test files (10):
- \src/__tests__/lib/twitch/twitch-config.test.ts\ - 18 tests for Twitch config
- \src/__tests__/lib/twitch/twitch-oauth-service.test.ts\ - 20 tests for Twitch OAuth
- \src/__tests__/lib/kick/kick-config.test.ts\ - 16 tests for Kick config
- \src/__tests__/lib/kick/kick-oauth-service.test.ts\ - 13 tests for Kick OAuth
- \src/__tests__/lib/chat/twitch-adapter.test.ts\ - 15 tests for Twitch IRC chat
- \src/__tests__/lib/chat/kick-adapter.test.ts\ - 14 tests for Kick WebSocket chat
- \src/__tests__/components/dashboard/live/stream-status-card.test.tsx\ - 12 tests
- \src/__tests__/components/dashboard/live/stream-title-editor.test.tsx\ - 9 tests
- \src/__tests__/components/dashboard/live/unified-chat.test.tsx\ - 12 tests
- \src/__tests__/app/dashboard/live/page.test.tsx\ - 8 integration tests

### Fixes:
- \itest.setup.ts\: Added \scrollIntoView\ mock for jsdom
- \stream-title-editor.test.tsx\: Fixed fake timer handling with \i.waitFor\ and \ct\
- \page.test.tsx\: Fixed loading text, removed fake timers, fixed duplicate element matching

## Testing
- [x] Type check passes
- [x] Lint passes (0 errors, 33 pre-existing warnings)
- [x] All 139 tests pass across 10 test files
- [x] Build passes

Closes #232

_Generated by engineering-loop | Cost-free: ✅_