### PR TITLE
refactor(publish): split YouTubeMetadataForm into 7 section components

### DIFF
--- a/src/components/publish/wizard/AudienceSection.tsx
+++ b/src/components/publish/wizard/AudienceSection.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+
+interface AudienceSectionProps {
+    madeForKids: boolean
+    onMadeForKidsChange: (value: boolean) => void
+}
+
+export default function AudienceSection({
+    madeForKids,
+    onMadeForKidsChange,
+}: AudienceSectionProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">{t("step4.audience")}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-3">
+                    <Label>{t("step4.madeForKids")}</Label>
+                    <div className="flex gap-4">
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="madeForKids"
+                                checked={!madeForKids}
+                                onChange={() => onMadeForKidsChange(false)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.madeForKidsNo")}
+                            </span>
+                        </label>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="madeForKids"
+                                checked={madeForKids}
+                                onChange={() => onMadeForKidsChange(true)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.madeForKidsYes")}
+                            </span>
+                        </label>
+                    </div>
+                    <p className="text-xs text-gray-400">
+                        {t("step4.madeForKidsHint")}
+                    </p>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/BasicInfoSection.test.tsx
+++ b/src/components/publish/wizard/BasicInfoSection.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import BasicInfoSection from "./BasicInfoSection"
+
+describe("BasicInfoSection", () => {
+    const defaultProps = {
+        title: "",
+        onTitleChange: vi.fn(),
+        description: "",
+        onDescriptionChange: vi.fn(),
+        tags: [] as string[],
+        onTagsChange: vi.fn(),
+        errors: {} as Record<string, string>,
+    }
+
+    it("renders all input fields", () => {
+        render(<BasicInfoSection {...defaultProps} />)
+        expect(screen.getByText("Title")).toBeInTheDocument()
+        expect(screen.getByText("Description")).toBeInTheDocument()
+        expect(screen.getByText("Tags")).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                "Thumbnail is auto-generated. You can customize it later in YouTube Studio."
+            )
+        ).toBeInTheDocument()
+    })
+
+    it("calls onTitleChange when typing in title", () => {
+        const onTitleChange = vi.fn()
+        render(
+            <BasicInfoSection {...defaultProps} onTitleChange={onTitleChange} />
+        )
+        const input = screen.getByPlaceholderText("Enter your video title")
+        fireEvent.change(input, { target: { value: "My Video Title" } })
+        expect(onTitleChange).toHaveBeenCalledWith("My Video Title")
+    })
+
+    it("shows title char count", () => {
+        render(<BasicInfoSection {...defaultProps} title="Hello" />)
+        // Text is "5/100 Maximum 100 characters" but spans multiple elements
+        expect(screen.getByText(/5\/100/)).toBeInTheDocument()
+        expect(screen.getByText(/Maximum 100 characters/)).toBeInTheDocument()
+    })
+
+    it("shows error when title error is provided", () => {
+        render(
+            <BasicInfoSection
+                {...defaultProps}
+                errors={{ title: "Title is required" }}
+            />
+        )
+        expect(screen.getByText("Title is required")).toBeInTheDocument()
+    })
+
+    it("shows tag count", () => {
+        render(<BasicInfoSection {...defaultProps} tags={["tag1", "tag2"]} />)
+        expect(screen.getByText("2/30 tags")).toBeInTheDocument()
+    })
+})

--- a/src/components/publish/wizard/BasicInfoSection.tsx
+++ b/src/components/publish/wizard/BasicInfoSection.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+interface BasicInfoSectionProps {
+    title: string
+    onTitleChange: (title: string) => void
+    description: string
+    onDescriptionChange: (description: string) => void
+    tags: string[]
+    onTagsChange: (raw: string) => void
+    errors: Record<string, string>
+}
+
+export default function BasicInfoSection({
+    title,
+    onTitleChange,
+    description,
+    onDescriptionChange,
+    tags,
+    onTagsChange,
+    errors,
+}: BasicInfoSectionProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">
+                    {t("step4.basicInfo")}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {/* Title */}
+                <div className="space-y-2">
+                    <Label htmlFor="video-title">
+                        {t("step4.title")}
+                        <span className="text-red-500">*</span>
+                    </Label>
+                    <Input
+                        id="video-title"
+                        value={title}
+                        onChange={e =>
+                            onTitleChange(e.target.value.slice(0, 100))
+                        }
+                        placeholder={t("step4.titlePlaceholder")}
+                        maxLength={100}
+                    />
+                    <div className="flex justify-between text-xs text-gray-400">
+                        <span>
+                            {title.length}/100 {t("step4.titleMax")}
+                        </span>
+                        {errors.title && (
+                            <span className="text-red-500">{errors.title}</span>
+                        )}
+                    </div>
+                </div>
+
+                {/* Description */}
+                <div className="space-y-2">
+                    <Label htmlFor="video-description">
+                        {t("step4.description")}
+                    </Label>
+                    <Textarea
+                        id="video-description"
+                        value={description}
+                        onChange={e =>
+                            onDescriptionChange(e.target.value.slice(0, 5000))
+                        }
+                        placeholder={t("step4.descriptionPlaceholder")}
+                        className="min-h-24 resize-none"
+                        maxLength={5000}
+                    />
+                    <div className="flex justify-between text-xs text-gray-400">
+                        <span>
+                            {description.length}/5000{" "}
+                            {t("step4.descriptionMax")}
+                        </span>
+                        {errors.description && (
+                            <span className="text-red-500">
+                                {errors.description}
+                            </span>
+                        )}
+                    </div>
+                </div>
+
+                {/* Thumbnail hint */}
+                <div className="rounded bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-900">
+                    {t("step4.thumbnailHint")}
+                </div>
+
+                {/* Tags */}
+                <div className="space-y-2">
+                    <Label htmlFor="video-tags">{t("step4.tags")}</Label>
+                    <Input
+                        id="video-tags"
+                        value={tags.join(", ")}
+                        onChange={e => onTagsChange(e.target.value)}
+                        placeholder={t("step4.tagsPlaceholder")}
+                    />
+                    <div className="flex justify-between text-xs text-gray-400">
+                        <span>{t("step4.tagsHint")}</span>
+                        <span>{tags.length}/30 tags</span>
+                    </div>
+                    {errors.tags && (
+                        <span className="text-xs text-red-500">
+                            {errors.tags}
+                        </span>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/CardsEndScreensSection.tsx
+++ b/src/components/publish/wizard/CardsEndScreensSection.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface CardsEndScreensSectionProps {
+    linkedVideoStart: string
+    onLinkedVideoStartChange: (value: string) => void
+    linkedVideoEnd: string
+    onLinkedVideoEndChange: (value: string) => void
+}
+
+export default function CardsEndScreensSection({
+    linkedVideoStart,
+    onLinkedVideoStartChange,
+    linkedVideoEnd,
+    onLinkedVideoEndChange,
+}: CardsEndScreensSectionProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">{t("step4.cards")}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <p className="text-xs text-gray-400">{t("step4.cardsHint")}</p>
+                <div className="space-y-3">
+                    <div>
+                        <Label htmlFor="video-link-start">
+                            {t("step4.addVideoStart")}
+                        </Label>
+                        <Input
+                            id="video-link-start"
+                            value={linkedVideoStart}
+                            onChange={e =>
+                                onLinkedVideoStartChange(e.target.value)
+                            }
+                            placeholder={t("step4.videoUrlPlaceholder")}
+                            className="mt-1"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="video-link-end">
+                            {t("step4.addVideoEnd")}
+                        </Label>
+                        <Input
+                            id="video-link-end"
+                            value={linkedVideoEnd}
+                            onChange={e =>
+                                onLinkedVideoEndChange(e.target.value)
+                            }
+                            placeholder={t("step4.videoUrlPlaceholder")}
+                            className="mt-1"
+                        />
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/ContentDisclosureSection.tsx
+++ b/src/components/publish/wizard/ContentDisclosureSection.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+
+interface ContentDisclosureSectionProps {
+    aiGenerated: boolean
+    onAiGeneratedChange: (value: boolean) => void
+    paidPromotion: boolean
+    onPaidPromotionChange: (value: boolean) => void
+}
+
+export default function ContentDisclosureSection({
+    aiGenerated,
+    onAiGeneratedChange,
+    paidPromotion,
+    onPaidPromotionChange,
+}: ContentDisclosureSectionProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">{t("step4.content")}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {/* AI Generated */}
+                <div className="space-y-3">
+                    <Label>{t("step4.aiGenerated")}</Label>
+                    <div className="flex gap-4">
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="aiGenerated"
+                                checked={!aiGenerated}
+                                onChange={() => onAiGeneratedChange(false)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.aiGeneratedNo")}
+                            </span>
+                        </label>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="aiGenerated"
+                                checked={aiGenerated}
+                                onChange={() => onAiGeneratedChange(true)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.aiGeneratedYes")}
+                            </span>
+                        </label>
+                    </div>
+                    <p className="text-xs text-gray-400">
+                        {t("step4.aiGeneratedHint")}
+                    </p>
+                </div>
+
+                {/* Paid Promotion */}
+                <div className="space-y-3">
+                    <Label>{t("step4.paidPromotion")}</Label>
+                    <div className="flex gap-4">
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="paidPromotion"
+                                checked={!paidPromotion}
+                                onChange={() => onPaidPromotionChange(false)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.paidPromotionNo")}
+                            </span>
+                        </label>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="paidPromotion"
+                                checked={paidPromotion}
+                                onChange={() => onPaidPromotionChange(true)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.paidPromotionYes")}
+                            </span>
+                        </label>
+                    </div>
+                    <p className="text-xs text-gray-400">
+                        {t("step4.paidPromotionHint")}
+                    </p>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/MonetizationSection.tsx
+++ b/src/components/publish/wizard/MonetizationSection.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+
+interface MonetizationSectionProps {
+    monetizationEnabled: boolean
+    onMonetizationChange: (value: boolean) => void
+}
+
+export default function MonetizationSection({
+    monetizationEnabled,
+    onMonetizationChange,
+}: MonetizationSectionProps) {
+    const t = useTranslations("publish")
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">
+                    {t("step4.monetization")}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-3">
+                    <Label>{t("step4.monetizationTitle")}</Label>
+                    <div className="flex gap-4">
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="monetization"
+                                checked={monetizationEnabled}
+                                onChange={() => onMonetizationChange(true)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.monetizationYes")}
+                            </span>
+                        </label>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="monetization"
+                                checked={!monetizationEnabled}
+                                onChange={() => onMonetizationChange(false)}
+                                className="h-4 w-4"
+                            />
+                            <span className="text-sm">
+                                {t("step4.monetizationNo")}
+                            </span>
+                        </label>
+                    </div>
+                    <p className="text-xs text-gray-400">
+                        {t("step4.monetizationHint")}
+                    </p>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/PrivacyScheduleSection.test.tsx
+++ b/src/components/publish/wizard/PrivacyScheduleSection.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import PrivacyScheduleSection from "./PrivacyScheduleSection"
+
+describe("PrivacyScheduleSection", () => {
+    const defaultProps = {
+        privacyStatus: "unlisted" as const,
+        onPrivacyStatusChange: vi.fn(),
+        scheduleType: "now" as const,
+        onScheduleTypeChange: vi.fn(),
+        scheduledDate: null,
+        onScheduledDateChange: vi.fn(),
+        scheduledTime: "",
+        onScheduledTimeChange: vi.fn(),
+        allowSchedule: true,
+        errors: {} as Record<string, string>,
+    }
+
+    it("renders privacy status select", () => {
+        render(<PrivacyScheduleSection {...defaultProps} />)
+        expect(screen.getByText("Privacy Status")).toBeInTheDocument()
+    })
+
+    it("shows schedule options when allowSchedule is true", () => {
+        render(<PrivacyScheduleSection {...defaultProps} />)
+        expect(screen.getByText("Publish now")).toBeInTheDocument()
+        expect(screen.getByText("Schedule for later")).toBeInTheDocument()
+    })
+
+    it("calls onScheduleTypeChange when 'Schedule for later' is clicked", () => {
+        const onScheduleTypeChange = vi.fn()
+        render(
+            <PrivacyScheduleSection
+                {...defaultProps}
+                onScheduleTypeChange={onScheduleTypeChange}
+            />
+        )
+        fireEvent.click(screen.getByText("Schedule for later"))
+        expect(onScheduleTypeChange).toHaveBeenCalledWith("later")
+    })
+
+    it("shows date/time inputs when scheduleType is 'later'", () => {
+        render(
+            <PrivacyScheduleSection
+                {...defaultProps}
+                scheduleType="later"
+                scheduledTime="10:00"
+            />
+        )
+        expect(screen.getByText("Publish Date")).toBeInTheDocument()
+        expect(screen.getByText("Publish Time")).toBeInTheDocument()
+    })
+
+    it("does not show schedule options when allowSchedule is false", () => {
+        render(
+            <PrivacyScheduleSection {...defaultProps} allowSchedule={false} />
+        )
+        expect(screen.queryByText("Publish now")).not.toBeInTheDocument()
+        expect(screen.queryByText("Schedule for later")).not.toBeInTheDocument()
+    })
+
+    it("shows schedule error when provided", () => {
+        render(
+            <PrivacyScheduleSection
+                {...defaultProps}
+                errors={{ schedule: "Schedule date is required" }}
+            />
+        )
+        expect(
+            screen.getByText("Schedule date is required")
+        ).toBeInTheDocument()
+    })
+})

--- a/src/components/publish/wizard/PrivacyScheduleSection.tsx
+++ b/src/components/publish/wizard/PrivacyScheduleSection.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useEffect } from "react"
+import { useTranslations } from "next-intl"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+interface PrivacyScheduleSectionProps {
+    privacyStatus: "public" | "unlisted" | "private"
+    onPrivacyStatusChange: (value: "public" | "unlisted" | "private") => void
+    scheduleType: "now" | "later"
+    onScheduleTypeChange: (value: "now" | "later") => void
+    scheduledDate: Date | null
+    onScheduledDateChange: (date: Date | null) => void
+    scheduledTime: string
+    onScheduledTimeChange: (time: string) => void
+    allowSchedule: boolean
+    errors: Record<string, string>
+}
+
+export default function PrivacyScheduleSection({
+    privacyStatus,
+    onPrivacyStatusChange,
+    scheduleType,
+    onScheduleTypeChange,
+    scheduledDate,
+    onScheduledDateChange,
+    scheduledTime,
+    onScheduledTimeChange,
+    allowSchedule,
+    errors,
+}: PrivacyScheduleSectionProps) {
+    const t = useTranslations("publish")
+
+    // Set default schedule time to tomorrow 10am if switching to schedule
+    useEffect(() => {
+        if (scheduleType === "later" && !scheduledDate) {
+            const tomorrow = new Date()
+            tomorrow.setDate(tomorrow.getDate() + 1)
+            tomorrow.setHours(10, 0, 0, 0)
+            onScheduledDateChange(tomorrow)
+            onScheduledTimeChange("10:00")
+        }
+    }, [scheduleType]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg">{t("step4.privacy")}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {/* Privacy Status */}
+                <div className="space-y-2">
+                    <Label>{t("step4.privacyStatus")}</Label>
+                    <Select
+                        value={privacyStatus}
+                        onValueChange={(v: "public" | "unlisted" | "private") =>
+                            onPrivacyStatusChange(v)
+                        }
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="public">
+                                {t("step4.public")}
+                            </SelectItem>
+                            <SelectItem value="unlisted">
+                                {t("step4.unlisted")}
+                            </SelectItem>
+                            <SelectItem value="private">
+                                {t("step4.private")}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Schedule type */}
+                {allowSchedule && (
+                    <div className="space-y-3 border-t pt-3 dark:border-gray-700">
+                        <div className="flex gap-4">
+                            <label className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="radio"
+                                    name="scheduleType"
+                                    checked={scheduleType === "now"}
+                                    onChange={() => onScheduleTypeChange("now")}
+                                    className="h-4 w-4"
+                                />
+                                <span className="text-sm">
+                                    {t("step4.scheduleNow")}
+                                </span>
+                            </label>
+                            <label className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="radio"
+                                    name="scheduleType"
+                                    checked={scheduleType === "later"}
+                                    onChange={() =>
+                                        onScheduleTypeChange("later")
+                                    }
+                                    className="h-4 w-4"
+                                />
+                                <span className="text-sm">
+                                    {t("step4.scheduleLater")}
+                                </span>
+                            </label>
+                        </div>
+
+                        {scheduleType === "later" && (
+                            <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                    <Label htmlFor="schedule-date">
+                                        {t("step4.scheduleDate")}
+                                    </Label>
+                                    <Input
+                                        id="schedule-date"
+                                        type="date"
+                                        value={
+                                            scheduledDate
+                                                ? scheduledDate
+                                                      .toISOString()
+                                                      .split("T")[0]
+                                                : ""
+                                        }
+                                        onChange={e => {
+                                            const dateVal = e.target.value
+                                            const d = dateVal
+                                                ? new Date(
+                                                      dateVal +
+                                                          "T" +
+                                                          (scheduledTime ||
+                                                              "10:00")
+                                                  )
+                                                : null
+                                            onScheduledDateChange(d)
+                                        }}
+                                        className="mt-1"
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="schedule-time">
+                                        {t("step4.scheduleTime")}
+                                    </Label>
+                                    <Input
+                                        id="schedule-time"
+                                        type="time"
+                                        value={scheduledTime}
+                                        onChange={e =>
+                                            onScheduledTimeChange(
+                                                e.target.value
+                                            )
+                                        }
+                                        className="mt-1"
+                                    />
+                                </div>
+                            </div>
+                        )}
+
+                        {scheduleType === "later" && (
+                            <div className="rounded bg-amber-50 p-3 text-xs text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+                                {t("step4.scheduleWarning")}
+                            </div>
+                        )}
+
+                        {errors.schedule && (
+                            <span className="text-xs text-red-500">
+                                {errors.schedule}
+                            </span>
+                        )}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/publish/wizard/VideoUploadSection.test.tsx
+++ b/src/components/publish/wizard/VideoUploadSection.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import VideoUploadSection, { formatBytes } from "./VideoUploadSection"
+
+describe("VideoUploadSection", () => {
+    const defaultProps = {
+        videoFile: null,
+        onVideoFileChange: vi.fn(),
+        error: undefined,
+    }
+
+    it("renders dropzone when no file is selected", () => {
+        render(<VideoUploadSection {...defaultProps} />)
+        expect(
+            screen.getByText("Drag & drop video file here, or click to select")
+        ).toBeInTheDocument()
+        expect(screen.getByText("Browse Files")).toBeInTheDocument()
+    })
+
+    it("renders file info when a file is selected", () => {
+        const file = new File(["test"], "test-video.mp4", { type: "video/mp4" })
+        Object.defineProperty(file, "size", { value: 1024 * 1024 })
+        render(<VideoUploadSection {...defaultProps} videoFile={file} />)
+        expect(screen.getByText("test-video.mp4")).toBeInTheDocument()
+    })
+
+    it("calls onVideoFileChange when remove button is clicked", () => {
+        const file = new File(["test"], "test-video.mp4", { type: "video/mp4" })
+        const onVideoFileChange = vi.fn()
+        render(
+            <VideoUploadSection
+                {...defaultProps}
+                videoFile={file}
+                onVideoFileChange={onVideoFileChange}
+            />
+        )
+        fireEvent.click(screen.getByLabelText("Remove file"))
+        expect(onVideoFileChange).toHaveBeenCalledWith(null)
+    })
+
+    it("displays error message when error prop is set", () => {
+        render(
+            <VideoUploadSection
+                {...defaultProps}
+                error="Video file is required"
+            />
+        )
+        expect(screen.getByText("Video file is required")).toBeInTheDocument()
+    })
+})
+
+describe("formatBytes", () => {
+    it("returns KB for small values", () => {
+        expect(formatBytes(500)).toBe("0KB")
+    })
+
+    it("returns MB for values above 1 MB", () => {
+        expect(formatBytes(1024 * 1024)).toBe("1MB")
+    })
+
+    it("returns GB for values above 1 GB", () => {
+        expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0GB")
+    })
+})

--- a/src/components/publish/wizard/VideoUploadSection.tsx
+++ b/src/components/publish/wizard/VideoUploadSection.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+import { useTranslations } from "next-intl"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Upload, FileVideo, AlertCircle, X } from "lucide-react"
+
+function formatBytes(bytes: number): string {
+    if (bytes >= 1024 * 1024 * 1024) {
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
+    }
+    if (bytes >= 1024 * 1024) {
+        return `${(bytes / (1024 * 1024)).toFixed(0)}MB`
+    }
+    return `${(bytes / 1024).toFixed(0)}KB`
+}
+
+interface VideoUploadSectionProps {
+    videoFile: File | null
+    onVideoFileChange: (file: File | null) => void
+    error: string | undefined
+}
+
+export default function VideoUploadSection({
+    videoFile,
+    onVideoFileChange,
+    error,
+}: VideoUploadSectionProps) {
+    const t = useTranslations("publish")
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const [dragOver, setDragOver] = useState(false)
+
+    const handleVideoDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault()
+            setDragOver(false)
+            const file = e.dataTransfer.files?.[0]
+            if (file && file.type.startsWith("video/")) {
+                onVideoFileChange(file)
+            }
+        },
+        [onVideoFileChange]
+    )
+
+    const handleVideoChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0]
+            if (file) {
+                if (!file.type.startsWith("video/")) return
+                onVideoFileChange(file)
+            }
+        },
+        [onVideoFileChange]
+    )
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                    <FileVideo className="h-5 w-5" />
+                    {t("step4.videoFile")}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {!videoFile ? (
+                    <div
+                        onDragOver={e => {
+                            e.preventDefault()
+                            setDragOver(true)
+                        }}
+                        onDragLeave={() => setDragOver(false)}
+                        onDrop={handleVideoDrop}
+                        onClick={() => fileInputRef.current?.click()}
+                        className={`flex cursor-pointer flex-col items-center gap-4 rounded-lg border-2 border-dashed p-8 transition-colors ${
+                            dragOver
+                                ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                                : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
+                        }`}
+                    >
+                        <Upload className="h-10 w-10 text-gray-400" />
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {t("step4.dropzone")}
+                        </p>
+                        <p className="text-xs text-gray-400">
+                            {t("step4.maxSize")}
+                        </p>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={e => {
+                                e.stopPropagation()
+                                fileInputRef.current?.click()
+                            }}
+                        >
+                            {t("step4.browse")}
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-4 dark:bg-gray-900">
+                        <FileVideo className="h-8 w-8 text-blue-500" />
+                        <div className="flex-1 min-w-0">
+                            <p className="font-medium truncate">
+                                {videoFile.name}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                                {formatBytes(videoFile.size)}
+                            </p>
+                        </div>
+                        <button
+                            onClick={() => onVideoFileChange(null)}
+                            className="rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-700"
+                            aria-label={t("step4.removeFile")}
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                    </div>
+                )}
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="video/*"
+                    className="hidden"
+                    onChange={handleVideoChange}
+                />
+                {error && (
+                    <div className="mt-2 flex items-center gap-2 text-sm text-red-600">
+                        <AlertCircle className="h-4 w-4" />
+                        <span>{error}</span>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+export { formatBytes }

--- a/src/components/publish/wizard/YouTubeMetadataForm.test.tsx
+++ b/src/components/publish/wizard/YouTubeMetadataForm.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import YouTubeMetadataForm from "./YouTubeMetadataForm"
+import { DEFAULT_YOUTUBE_METADATA } from "./types"
+
+// Mock child sections to test orchestration
+vi.mock("./VideoUploadSection", () => ({
+    default: () => <div>VideoUploadSection</div>,
+}))
+
+vi.mock("./BasicInfoSection", () => ({
+    default: () => <div>BasicInfoSection</div>,
+}))
+
+vi.mock("./AudienceSection", () => ({
+    default: () => <div>AudienceSection</div>,
+}))
+
+vi.mock("./ContentDisclosureSection", () => ({
+    default: () => <div>ContentDisclosureSection</div>,
+}))
+
+vi.mock("./MonetizationSection", () => ({
+    default: () => <div>MonetizationSection</div>,
+}))
+
+vi.mock("./CardsEndScreensSection", () => ({
+    default: () => <div>CardsEndScreensSection</div>,
+}))
+
+vi.mock("./PrivacyScheduleSection", () => ({
+    default: () => <div>PrivacyScheduleSection</div>,
+}))
+
+describe("YouTubeMetadataForm", () => {
+    const defaultProps = {
+        metadata: { ...DEFAULT_YOUTUBE_METADATA },
+        onMetadataChange: vi.fn(),
+        videoFile: null,
+        onVideoFileChange: vi.fn(),
+        onBack: vi.fn(),
+        onNext: vi.fn(),
+    }
+
+    it("renders all 7 section components", () => {
+        render(<YouTubeMetadataForm {...defaultProps} />)
+        expect(screen.getByText("VideoUploadSection")).toBeInTheDocument()
+        expect(screen.getByText("BasicInfoSection")).toBeInTheDocument()
+        expect(screen.getByText("AudienceSection")).toBeInTheDocument()
+        expect(screen.getByText("ContentDisclosureSection")).toBeInTheDocument()
+        expect(screen.getByText("MonetizationSection")).toBeInTheDocument()
+        expect(screen.getByText("CardsEndScreensSection")).toBeInTheDocument()
+        expect(screen.getByText("PrivacyScheduleSection")).toBeInTheDocument()
+    })
+
+    it("renders the page title using translations", () => {
+        render(<YouTubeMetadataForm {...defaultProps} />)
+        expect(screen.getByText("Title")).toBeInTheDocument()
+    })
+
+    it("renders the page description using translations", () => {
+        render(<YouTubeMetadataForm {...defaultProps} />)
+        expect(screen.getByText("Description")).toBeInTheDocument()
+    })
+
+    it("calls onBack when back button is clicked", () => {
+        render(<YouTubeMetadataForm {...defaultProps} />)
+        fireEvent.click(screen.getByText("Back"))
+        expect(defaultProps.onBack).toHaveBeenCalledTimes(1)
+    })
+
+    it("renders next button", () => {
+        render(<YouTubeMetadataForm {...defaultProps} />)
+        expect(screen.getByText("Next")).toBeInTheDocument()
+    })
+})

--- a/src/components/publish/wizard/YouTubeMetadataForm.tsx
+++ b/src/components/publish/wizard/YouTubeMetadataForm.tsx
@@ -1,21 +1,16 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select"
 import { useTranslations } from "next-intl"
-import { Upload, FileVideo, AlertCircle, X } from "lucide-react"
-import { useCallback, useRef, useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { useState } from "react"
 import type { YouTubeMetadata } from "./types"
+import VideoUploadSection from "./VideoUploadSection"
+import BasicInfoSection from "./BasicInfoSection"
+import AudienceSection from "./AudienceSection"
+import ContentDisclosureSection from "./ContentDisclosureSection"
+import MonetizationSection from "./MonetizationSection"
+import CardsEndScreensSection from "./CardsEndScreensSection"
+import PrivacyScheduleSection from "./PrivacyScheduleSection"
 
 interface YouTubeMetadataFormProps {
     metadata: YouTubeMetadata
@@ -24,18 +19,7 @@ interface YouTubeMetadataFormProps {
     onVideoFileChange: (file: File | null) => void
     onBack: () => void
     onNext: () => void
-    /** Whether to allow scheduling instead of immediate */
     allowSchedule?: boolean
-}
-
-function formatBytes(bytes: number): string {
-    if (bytes >= 1024 * 1024 * 1024) {
-        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
-    }
-    if (bytes >= 1024 * 1024) {
-        return `${(bytes / (1024 * 1024)).toFixed(0)}MB`
-    }
-    return `${(bytes / 1024).toFixed(0)}KB`
 }
 
 export default function YouTubeMetadataForm({
@@ -48,24 +32,24 @@ export default function YouTubeMetadataForm({
     allowSchedule = true,
 }: YouTubeMetadataFormProps) {
     const t = useTranslations("publish")
-    const fileInputRef = useRef<HTMLInputElement>(null)
-    const [dragOver, setDragOver] = useState(false)
     const [errors, setErrors] = useState<Record<string, string>>({})
     const [scheduleType, setScheduleType] = useState<"now" | "later">("now")
 
-    // Set default schedule time to now+1hr if switching to schedule
-    useEffect(() => {
-        if (scheduleType === "later" && !metadata.scheduledDate) {
-            const tomorrow = new Date()
-            tomorrow.setDate(tomorrow.getDate() + 1)
-            tomorrow.setHours(10, 0, 0, 0)
-            onMetadataChange({
-                ...metadata,
-                scheduledDate: tomorrow,
-                scheduledTime: "10:00",
-            })
+    const handleTagsChange = (raw: string) => {
+        const tags = raw
+            .split(",")
+            .map(t => t.trim())
+            .filter(Boolean)
+            .slice(0, 30)
+        let total = 0
+        const limited: string[] = []
+        for (const tag of tags) {
+            if (total + tag.length + 1 > 500) break
+            limited.push(tag)
+            total += tag.length + 1
         }
-    }, [scheduleType])
+        onMetadataChange({ ...metadata, tags: limited })
+    }
 
     const validate = (): boolean => {
         const newErrors: Record<string, string> = {}
@@ -99,7 +83,6 @@ export default function YouTubeMetadataForm({
 
     const handleNext = () => {
         if (validate()) {
-            // Convert schedule type to privacy status
             const updatedMetadata = {
                 ...metadata,
                 privacyStatus:
@@ -112,56 +95,6 @@ export default function YouTubeMetadataForm({
         }
     }
 
-    const handleVideoDrop = useCallback(
-        (e: React.DragEvent) => {
-            e.preventDefault()
-            setDragOver(false)
-            const file = e.dataTransfer.files?.[0]
-            if (file && file.type.startsWith("video/")) {
-                onVideoFileChange(file)
-                setErrors(prev => {
-                    const next = { ...prev }
-                    delete next.videoFile
-                    return next
-                })
-            }
-        },
-        [onVideoFileChange]
-    )
-
-    const handleVideoChange = useCallback(
-        (e: React.ChangeEvent<HTMLInputElement>) => {
-            const file = e.target.files?.[0]
-            if (file) {
-                if (!file.type.startsWith("video/")) return
-                onVideoFileChange(file)
-                setErrors(prev => {
-                    const next = { ...prev }
-                    delete next.videoFile
-                    return next
-                })
-            }
-        },
-        [onVideoFileChange]
-    )
-
-    const handleTagsChange = (raw: string) => {
-        const tags = raw
-            .split(",")
-            .map(t => t.trim())
-            .filter(Boolean)
-            .slice(0, 30)
-        // Limit total chars to 500
-        let total = 0
-        const limited: string[] = []
-        for (const tag of tags) {
-            if (total + tag.length + 1 > 500) break
-            limited.push(tag)
-            total += tag.length + 1
-        }
-        onMetadataChange({ ...metadata, tags: limited })
-    }
-
     return (
         <div className="space-y-6">
             <div>
@@ -171,588 +104,87 @@ export default function YouTubeMetadataForm({
                 </p>
             </div>
 
-            {/* Video File Upload */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2 text-lg">
-                        <FileVideo className="h-5 w-5" />
-                        {t("step4.videoFile")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    {!videoFile ? (
-                        <div
-                            onDragOver={e => {
-                                e.preventDefault()
-                                setDragOver(true)
-                            }}
-                            onDragLeave={() => setDragOver(false)}
-                            onDrop={handleVideoDrop}
-                            onClick={() => fileInputRef.current?.click()}
-                            className={`flex cursor-pointer flex-col items-center gap-4 rounded-lg border-2 border-dashed p-8 transition-colors ${
-                                dragOver
-                                    ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
-                                    : "border-gray-300 hover:border-gray-400 dark:border-gray-600"
-                            }`}
-                        >
-                            <Upload className="h-10 w-10 text-gray-400" />
-                            <p className="text-sm text-gray-600 dark:text-gray-400">
-                                {t("step4.dropzone")}
-                            </p>
-                            <p className="text-xs text-gray-400">
-                                {t("step4.maxSize")}
-                            </p>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={e => {
-                                    e.stopPropagation()
-                                    fileInputRef.current?.click()
-                                }}
-                            >
-                                {t("step4.browse")}
-                            </Button>
-                        </div>
-                    ) : (
-                        <div className="flex items-center gap-4 rounded-lg border bg-gray-50 p-4 dark:bg-gray-900">
-                            <FileVideo className="h-8 w-8 text-blue-500" />
-                            <div className="flex-1 min-w-0">
-                                <p className="font-medium truncate">
-                                    {videoFile.name}
-                                </p>
-                                <p className="text-xs text-gray-500">
-                                    {formatBytes(videoFile.size)}
-                                </p>
-                            </div>
-                            <button
-                                onClick={() => onVideoFileChange(null)}
-                                className="rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-700"
-                                aria-label={t("step4.removeFile")}
-                            >
-                                <X className="h-4 w-4" />
-                            </button>
-                        </div>
-                    )}
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        accept="video/*"
-                        className="hidden"
-                        onChange={handleVideoChange}
-                    />
-                    {errors.videoFile && (
-                        <div className="mt-2 flex items-center gap-2 text-sm text-red-600">
-                            <AlertCircle className="h-4 w-4" />
-                            <span>{errors.videoFile}</span>
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
+            <VideoUploadSection
+                videoFile={videoFile}
+                onVideoFileChange={onVideoFileChange}
+                error={errors.videoFile}
+            />
 
-            {/* Basic Information */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.basicInfo")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {/* Title */}
-                    <div className="space-y-2">
-                        <Label htmlFor="video-title">
-                            {t("step4.title")}
-                            <span className="text-red-500">*</span>
-                        </Label>
-                        <Input
-                            id="video-title"
-                            value={metadata.title}
-                            onChange={e =>
-                                onMetadataChange({
-                                    ...metadata,
-                                    title: e.target.value.slice(0, 100),
-                                })
-                            }
-                            placeholder={t("step4.titlePlaceholder")}
-                            maxLength={100}
-                        />
-                        <div className="flex justify-between text-xs text-gray-400">
-                            <span>
-                                {metadata.title.length}/100{" "}
-                                {t("step4.titleMax")}
-                            </span>
-                            {errors.title && (
-                                <span className="text-red-500">
-                                    {errors.title}
-                                </span>
-                            )}
-                        </div>
-                    </div>
+            <BasicInfoSection
+                title={metadata.title}
+                onTitleChange={title =>
+                    onMetadataChange({ ...metadata, title })
+                }
+                description={metadata.description}
+                onDescriptionChange={description =>
+                    onMetadataChange({ ...metadata, description })
+                }
+                tags={metadata.tags}
+                onTagsChange={handleTagsChange}
+                errors={errors}
+            />
 
-                    {/* Description */}
-                    <div className="space-y-2">
-                        <Label htmlFor="video-description">
-                            {t("step4.description")}
-                        </Label>
-                        <Textarea
-                            id="video-description"
-                            value={metadata.description}
-                            onChange={e =>
-                                onMetadataChange({
-                                    ...metadata,
-                                    description: e.target.value.slice(0, 5000),
-                                })
-                            }
-                            placeholder={t("step4.descriptionPlaceholder")}
-                            className="min-h-24 resize-none"
-                            maxLength={5000}
-                        />
-                        <div className="flex justify-between text-xs text-gray-400">
-                            <span>
-                                {metadata.description.length}/5000{" "}
-                                {t("step4.descriptionMax")}
-                            </span>
-                            {errors.description && (
-                                <span className="text-red-500">
-                                    {errors.description}
-                                </span>
-                            )}
-                        </div>
-                    </div>
+            <AudienceSection
+                madeForKids={metadata.madeForKids}
+                onMadeForKidsChange={value =>
+                    onMetadataChange({ ...metadata, madeForKids: value })
+                }
+            />
 
-                    {/* Thumbnail hint */}
-                    <div className="rounded bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-900">
-                        {t("step4.thumbnailHint")}
-                    </div>
+            <ContentDisclosureSection
+                aiGenerated={metadata.aiGenerated}
+                onAiGeneratedChange={value =>
+                    onMetadataChange({ ...metadata, aiGenerated: value })
+                }
+                paidPromotion={metadata.paidPromotion}
+                onPaidPromotionChange={value =>
+                    onMetadataChange({ ...metadata, paidPromotion: value })
+                }
+            />
 
-                    {/* Tags */}
-                    <div className="space-y-2">
-                        <Label htmlFor="video-tags">{t("step4.tags")}</Label>
-                        <Input
-                            id="video-tags"
-                            value={metadata.tags.join(", ")}
-                            onChange={e => handleTagsChange(e.target.value)}
-                            placeholder={t("step4.tagsPlaceholder")}
-                        />
-                        <div className="flex justify-between text-xs text-gray-400">
-                            <span>{t("step4.tagsHint")}</span>
-                            <span>{metadata.tags.length}/30 tags</span>
-                        </div>
-                        {errors.tags && (
-                            <span className="text-xs text-red-500">
-                                {errors.tags}
-                            </span>
-                        )}
-                    </div>
-                </CardContent>
-            </Card>
+            <MonetizationSection
+                monetizationEnabled={metadata.monetization}
+                onMonetizationChange={value =>
+                    onMetadataChange({ ...metadata, monetization: value })
+                }
+            />
 
-            {/* Audience - Made for Kids */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.audience")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <div className="space-y-3">
-                        <Label>{t("step4.madeForKids")}</Label>
-                        <div className="flex gap-4">
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="madeForKids"
-                                    checked={!metadata.madeForKids}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            madeForKids: false,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.madeForKidsNo")}
-                                </span>
-                            </label>
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="madeForKids"
-                                    checked={metadata.madeForKids}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            madeForKids: true,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.madeForKidsYes")}
-                                </span>
-                            </label>
-                        </div>
-                        <p className="text-xs text-gray-400">
-                            {t("step4.madeForKidsHint")}
-                        </p>
-                    </div>
-                </CardContent>
-            </Card>
+            {/* Ad Suitability — placeholder section */}
+            <CardPlaceholder
+                title={t("step4.adSuitability")}
+                description={t("step4.adSuitabilityQuestion")}
+                hint={t("step4.adSuitabilityWhy")}
+            />
 
-            {/* Content - AI Generated */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.content")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {/* AI Generated */}
-                    <div className="space-y-3">
-                        <Label>{t("step4.aiGenerated")}</Label>
-                        <div className="flex gap-4">
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="aiGenerated"
-                                    checked={!metadata.aiGenerated}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            aiGenerated: false,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.aiGeneratedNo")}
-                                </span>
-                            </label>
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="aiGenerated"
-                                    checked={metadata.aiGenerated}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            aiGenerated: true,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.aiGeneratedYes")}
-                                </span>
-                            </label>
-                        </div>
-                        <p className="text-xs text-gray-400">
-                            {t("step4.aiGeneratedHint")}
-                        </p>
-                    </div>
+            <CardsEndScreensSection
+                linkedVideoStart={metadata.linkedVideoStart}
+                onLinkedVideoStartChange={value =>
+                    onMetadataChange({ ...metadata, linkedVideoStart: value })
+                }
+                linkedVideoEnd={metadata.linkedVideoEnd}
+                onLinkedVideoEndChange={value =>
+                    onMetadataChange({ ...metadata, linkedVideoEnd: value })
+                }
+            />
 
-                    {/* Paid Promotion */}
-                    <div className="space-y-3">
-                        <Label>{t("step4.paidPromotion")}</Label>
-                        <div className="flex gap-4">
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="paidPromotion"
-                                    checked={!metadata.paidPromotion}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            paidPromotion: false,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.paidPromotionNo")}
-                                </span>
-                            </label>
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="paidPromotion"
-                                    checked={metadata.paidPromotion}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            paidPromotion: true,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.paidPromotionYes")}
-                                </span>
-                            </label>
-                        </div>
-                        <p className="text-xs text-gray-400">
-                            {t("step4.paidPromotionHint")}
-                        </p>
-                    </div>
-                </CardContent>
-            </Card>
-
-            {/* Monetization */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.monetization")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <div className="space-y-3">
-                        <Label>{t("step4.monetizationTitle")}</Label>
-                        <div className="flex gap-4">
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="monetization"
-                                    checked={metadata.monetization}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            monetization: true,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.monetizationYes")}
-                                </span>
-                            </label>
-                            <label className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    name="monetization"
-                                    checked={!metadata.monetization}
-                                    onChange={() =>
-                                        onMetadataChange({
-                                            ...metadata,
-                                            monetization: false,
-                                        })
-                                    }
-                                    className="h-4 w-4"
-                                />
-                                <span className="text-sm">
-                                    {t("step4.monetizationNo")}
-                                </span>
-                            </label>
-                        </div>
-                        <p className="text-xs text-gray-400">
-                            {t("step4.monetizationHint")}
-                        </p>
-                    </div>
-                </CardContent>
-            </Card>
-
-            {/* Content Guidelines */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.adSuitability")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <p className="text-xs text-gray-400">
-                        {t("step4.adSuitabilityQuestion")}
-                    </p>
-                    <p className="mt-1 text-xs text-gray-400">
-                        {t("step4.adSuitabilityWhy")}
-                    </p>
-                </CardContent>
-            </Card>
-
-            {/* Cards and End Screens */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.cards")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <p className="text-xs text-gray-400">
-                        {t("step4.cardsHint")}
-                    </p>
-                    <div className="space-y-3">
-                        <div>
-                            <Label htmlFor="video-link-start">
-                                {t("step4.addVideoStart")}
-                            </Label>
-                            <Input
-                                id="video-link-start"
-                                value={metadata.linkedVideoStart}
-                                onChange={e =>
-                                    onMetadataChange({
-                                        ...metadata,
-                                        linkedVideoStart: e.target.value,
-                                    })
-                                }
-                                placeholder={t("step4.videoUrlPlaceholder")}
-                                className="mt-1"
-                            />
-                        </div>
-                        <div>
-                            <Label htmlFor="video-link-end">
-                                {t("step4.addVideoEnd")}
-                            </Label>
-                            <Input
-                                id="video-link-end"
-                                value={metadata.linkedVideoEnd}
-                                onChange={e =>
-                                    onMetadataChange({
-                                        ...metadata,
-                                        linkedVideoEnd: e.target.value,
-                                    })
-                                }
-                                placeholder={t("step4.videoUrlPlaceholder")}
-                                className="mt-1"
-                            />
-                        </div>
-                    </div>
-                </CardContent>
-            </Card>
-
-            {/* Privacy and Scheduling */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">
-                        {t("step4.privacy")}
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {/* Privacy Status */}
-                    <div className="space-y-2">
-                        <Label>{t("step4.privacyStatus")}</Label>
-                        <Select
-                            value={metadata.privacyStatus}
-                            onValueChange={(
-                                v: "public" | "unlisted" | "private"
-                            ) =>
-                                onMetadataChange({
-                                    ...metadata,
-                                    privacyStatus: v,
-                                })
-                            }
-                        >
-                            <SelectTrigger>
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="public">
-                                    {t("step4.public")}
-                                </SelectItem>
-                                <SelectItem value="unlisted">
-                                    {t("step4.unlisted")}
-                                </SelectItem>
-                                <SelectItem value="private">
-                                    {t("step4.private")}
-                                </SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
-
-                    {/* Schedule type */}
-                    {allowSchedule && (
-                        <div className="space-y-3 border-t pt-3 dark:border-gray-700">
-                            <div className="flex gap-4">
-                                <label className="flex items-center gap-2 cursor-pointer">
-                                    <input
-                                        type="radio"
-                                        name="scheduleType"
-                                        checked={scheduleType === "now"}
-                                        onChange={() => setScheduleType("now")}
-                                        className="h-4 w-4"
-                                    />
-                                    <span className="text-sm">
-                                        {t("step4.scheduleNow")}
-                                    </span>
-                                </label>
-                                <label className="flex items-center gap-2 cursor-pointer">
-                                    <input
-                                        type="radio"
-                                        name="scheduleType"
-                                        checked={scheduleType === "later"}
-                                        onChange={() =>
-                                            setScheduleType("later")
-                                        }
-                                        className="h-4 w-4"
-                                    />
-                                    <span className="text-sm">
-                                        {t("step4.scheduleLater")}
-                                    </span>
-                                </label>
-                            </div>
-
-                            {scheduleType === "later" && (
-                                <div className="grid grid-cols-2 gap-3">
-                                    <div>
-                                        <Label htmlFor="schedule-date">
-                                            {t("step4.scheduleDate")}
-                                        </Label>
-                                        <Input
-                                            id="schedule-date"
-                                            type="date"
-                                            value={
-                                                metadata.scheduledDate
-                                                    ? metadata.scheduledDate
-                                                          .toISOString()
-                                                          .split("T")[0]
-                                                    : ""
-                                            }
-                                            onChange={e => {
-                                                const dateVal = e.target.value
-                                                const d = dateVal
-                                                    ? new Date(
-                                                          dateVal +
-                                                              "T" +
-                                                              (metadata.scheduledTime ||
-                                                                  "10:00")
-                                                      )
-                                                    : null
-                                                onMetadataChange({
-                                                    ...metadata,
-                                                    scheduledDate: d,
-                                                })
-                                            }}
-                                            className="mt-1"
-                                        />
-                                    </div>
-                                    <div>
-                                        <Label htmlFor="schedule-time">
-                                            {t("step4.scheduleTime")}
-                                        </Label>
-                                        <Input
-                                            id="schedule-time"
-                                            type="time"
-                                            value={metadata.scheduledTime}
-                                            onChange={e =>
-                                                onMetadataChange({
-                                                    ...metadata,
-                                                    scheduledTime:
-                                                        e.target.value,
-                                                })
-                                            }
-                                            className="mt-1"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-
-                            {scheduleType === "later" && (
-                                <div className="rounded bg-amber-50 p-3 text-xs text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
-                                    {t("step4.scheduleWarning")}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
+            <PrivacyScheduleSection
+                privacyStatus={metadata.privacyStatus}
+                onPrivacyStatusChange={value =>
+                    onMetadataChange({ ...metadata, privacyStatus: value })
+                }
+                scheduleType={scheduleType}
+                onScheduleTypeChange={setScheduleType}
+                scheduledDate={metadata.scheduledDate}
+                onScheduledDateChange={date =>
+                    onMetadataChange({ ...metadata, scheduledDate: date })
+                }
+                scheduledTime={metadata.scheduledTime}
+                onScheduledTimeChange={time =>
+                    onMetadataChange({ ...metadata, scheduledTime: time })
+                }
+                allowSchedule={allowSchedule}
+                errors={errors}
+            />
 
             {/* Navigation */}
             <div className="flex justify-between border-t pt-4 dark:border-gray-700">
@@ -764,3 +196,26 @@ export default function YouTubeMetadataForm({
         </div>
     )
 }
+
+/** Small inline component for static informational card */
+function CardPlaceholder({
+    title,
+    description,
+    hint,
+}: {
+    title: string
+    description: string
+    hint: string
+}) {
+    return (
+        <div className="rounded-lg border p-4">
+            <h3 className="font-semibold mb-2">{title}</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+                {description}
+            </p>
+            <p className="mt-1 text-xs text-gray-400">{hint}</p>
+        </div>
+    )
+}
+
+export type { YouTubeMetadataFormProps }


### PR DESCRIPTION
## Summary
Split 766-line YouTubeMetadataForm.tsx into 7 focused section components + thin orchestrator. Dead code refactor.

## Risk Assessment
**Risk Level:** MEDIUM
**Cost:** ✅ Free (all changes local)

## Changes
- **VideoUploadSection.tsx**: File upload with drag-and-drop, formatBytes utility
- **BasicInfoSection.tsx**: Title, description, tags with character limits
- **AudienceSection.tsx**: Made for Kids radio buttons
- **ContentDisclosureSection.tsx**: AI Generated + Paid Promotion disclosures
- **MonetizationSection.tsx**: Monetization toggle
- **CardsEndScreensSection.tsx**: Linked video URL inputs
- **PrivacyScheduleSection.tsx**: Privacy status + schedule date/time picker
- **YouTubeMetadataForm.tsx** → ~100-line orchestrator composing all sections
- **4 new test files**: Covering sections + orchestrator

## Testing
- [x] Type check passes
- [x] Tests pass (23 new tests)
- [x] Format passes

Closes #237

_Generated by engineering-loop | Cost-free: ✅_