### PR TITLE
test(tiktok): add coverage for OAuth token operations

### DIFF
--- a/src/app/api/oauth/authorize/tiktok/route.test.ts
+++ b/src/app/api/oauth/authorize/tiktok/route.test.ts
@@ -1,0 +1,150 @@
+import { NextRequest } from "next/server"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { POST } from "./route"
+
+vi.mock("@/lib/logger", () => ({
+    createLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    }),
+}))
+
+const mockGetServerSession = vi.hoisted(() =>
+    vi.fn().mockResolvedValue({ user: { id: "test-user-123" } })
+)
+
+vi.mock("@/lib/auth/get-server-session", () => ({
+    getServerSession: mockGetServerSession,
+}))
+
+vi.mock("@/lib/tiktok/config", () => ({
+    getTikTokConfig: () => ({
+        oauth: {
+            clientKey: "test-client-key",
+            clientSecret: "test-client-secret",
+            redirectUri: "https://example.com/callback",
+            scopes: ["user.info.basic", "user.info.profile"],
+            apiVersion: "v2",
+        },
+        rateLimit: {
+            linkingAttemptsPerHour: 5,
+            publishAttemptsPerHour: 6,
+        },
+        security: {
+            tokenExpiryBufferMs: 300000,
+        },
+    }),
+}))
+
+const mockOAuthService = vi.hoisted(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@/lib/tiktok/oauth-service", () => ({
+    getTikTokOAuthService: () => mockOAuthService,
+    resetTikTokOAuthService: vi.fn(),
+}))
+
+const mockGenerateState = vi.hoisted(() =>
+    vi.fn(() => ({
+        token: "signed-state-token-abc123",
+        payload: {
+            userId: "test-user-123",
+            platform: "tiktok",
+            nonce: "abc123",
+            iat: Date.now(),
+        },
+    }))
+)
+
+vi.mock("@/lib/oauth/state-signer", () => ({
+    generateState: mockGenerateState,
+}))
+
+describe("POST /api/oauth/authorize/tiktok", () => {
+    let mockRequest: NextRequest
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetServerSession.mockResolvedValue({ user: { id: "test-user-123" } })
+        mockGenerateState.mockReturnValue({
+            token: "signed-state-token-abc123",
+            payload: {
+                userId: "test-user-123",
+                platform: "tiktok",
+                nonce: "abc123",
+                iat: Date.now(),
+            },
+        })
+        mockRequest = { headers: new Map() } as unknown as NextRequest
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it("returns 200 with authorization URL and state on success", async () => {
+        const response = await POST(mockRequest)
+        const data = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(data).toEqual({
+            success: true,
+            authorizationUrl: expect.stringContaining(
+                "https://www.tiktok.com/v2/auth/authorize/"
+            ),
+            state: "signed-state-token-abc123",
+        })
+        expect(data.authorizationUrl).toContain("client_key=test-client-key")
+        expect(data.authorizationUrl).toContain("redirect_uri=https%3A%2F%2Fexample.com%2Fcallback")
+        expect(data.authorizationUrl).toContain("state=signed-state-token-abc123")
+        expect(data.authorizationUrl).toContain("response_type=code")
+        expect(data.authorizationUrl).toContain("scope=user.info.basic%2Cuser.info.profile")
+    })
+
+    it("returns 401 when user is not authenticated", async () => {
+        mockGetServerSession.mockResolvedValueOnce(null)
+
+        const response = await POST(mockRequest)
+        const data = await response.json()
+
+        expect(response.status).toBe(401)
+        expect(data).toEqual({
+            success: false,
+            error: "UNAUTHORIZED",
+            message: "Authentication required",
+        })
+    })
+
+    it("returns 401 when session has no user id", async () => {
+        mockGetServerSession.mockResolvedValueOnce({ user: {} })
+
+        const response = await POST(mockRequest)
+        const data = await response.json()
+
+        expect(response.status).toBe(401)
+        expect(data).toEqual({
+            success: false,
+            error: "UNAUTHORIZED",
+            message: "Authentication required",
+        })
+    })
+
+    it("returns 500 when an unexpected error occurs", async () => {
+        mockOAuthService.initialize.mockRejectedValueOnce(
+            new Error("Unexpected failure")
+        )
+
+        const response = await POST(mockRequest)
+        const data = await response.json()
+
+        expect(response.status).toBe(500)
+        expect(data).toEqual({
+            success: false,
+            error: "LINKING_INITIATION_FAILED",
+            message: "Unexpected failure",
+        })
+    })
+})

--- a/src/app/api/posts/token-normalize.test.ts
+++ b/src/app/api/posts/token-normalize.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for TikTok token response normalization.
+ *
+ * The private normalizeTokenResponse method in TikTokOAuthService handles both
+ * flat (per docs) and wrapped (observed) response formats from TikTok's API.
+ * These tests verify the normalization through the public exchangeCodeForToken
+ * and refreshAccessToken methods which internally use normalizeTokenResponse.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { TikTokConfig } from "@/lib/tiktok/config"
+import { TikTokOAuthService } from "@/lib/tiktok/oauth-service"
+
+// Mock BaseService to avoid initialization dependencies
+vi.mock("@/lib/youtube/base-service", () => ({
+    BaseService: class MockBaseService {
+        protected logger = {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+        }
+        protected isInitialized = true
+        assertReady() {}
+        async initialize() {}
+    },
+    ServiceError: class ServiceError extends Error {
+        code: string
+        statusCode: number
+        context?: Record<string, unknown>
+
+        constructor(
+            code: string,
+            message: string,
+            statusCode: number = 500,
+            context?: Record<string, unknown>
+        ) {
+            super(message)
+            this.name = "ServiceError"
+            this.code = code
+            this.statusCode = statusCode
+            this.context = context
+        }
+    },
+}))
+
+const mockConfig: TikTokConfig = {
+    oauth: {
+        clientKey: "test-client-key",
+        clientSecret: "test-client-secret",
+        redirectUri: "https://example.com/callback",
+        scopes: ["user.info.basic"],
+        apiVersion: "v2",
+    },
+    rateLimit: {
+        linkingAttemptsPerHour: 5,
+        publishAttemptsPerHour: 6,
+    },
+    security: {
+        tokenExpiryBufferMs: 300000,
+    },
+}
+
+let service: TikTokOAuthService
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    service = new TikTokOAuthService(mockConfig)
+    ;(service as any).isInitialized = true
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe("token normalization behavior", () => {
+    describe("exchangeCodeForToken — flat response format", () => {
+        it("extracts fields from flat response with all optional fields", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "flat-at",
+                        refresh_token: "flat-rt",
+                        expires_in: 7200,
+                        token_type: "bearer",
+                        open_id: "open-id-123",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("code-123")
+            expect(result.accessToken).toBe("flat-at")
+            expect(result.refreshToken).toBe("flat-rt")
+            expect(result.expiresIn).toBe(7200)
+            expect(result.tokenType).toBe("bearer")
+        })
+
+        it("defaults refresh_token to empty string when absent", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "flat-at-no-rt",
+                        expires_in: 86400,
+                        token_type: "bearer",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("code-no-rt")
+            expect(result.accessToken).toBe("flat-at-no-rt")
+            expect(result.refreshToken).toBe("")
+        })
+
+        it("defaults expires_in and token_type when missing", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "minimal-token",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("code-minimal")
+            expect(result.accessToken).toBe("minimal-token")
+            expect(result.expiresIn).toBe(86400)
+            expect(result.tokenType).toBe("bearer")
+        })
+    })
+
+    describe("exchangeCodeForToken — wrapped data format", () => {
+        it("extracts fields from wrapped data.data format", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            access_token: "wrapped-at",
+                            refresh_token: "wrapped-rt",
+                            expires_in: 86400,
+                            token_type: "bearer",
+                            open_id: "open-wrapped",
+                        },
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("code-wrapped")
+            expect(result.accessToken).toBe("wrapped-at")
+            expect(result.refreshToken).toBe("wrapped-rt")
+        })
+    })
+
+    describe("exchangeCodeForToken — error responses", () => {
+        it("throws on missing access_token in response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: { refresh_token: "rt-without-at" },
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            await expect(
+                service.exchangeCodeForToken("code-missing-at")
+            ).rejects.toThrow(/TikTok returned no access_token/)
+        })
+
+        it("throws on empty response object", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(JSON.stringify({}), { status: 200 })
+            )
+
+            await expect(
+                service.exchangeCodeForToken("code-empty")
+            ).rejects.toThrow(/TikTok returned no access_token/)
+        })
+    })
+
+    describe("refreshAccessToken — normalization", () => {
+        it("normalizes flat refresh response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "refreshed-at",
+                        refresh_token: "new-rt",
+                        expires_in: 86400,
+                        token_type: "bearer",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.refreshAccessToken("old-rt")
+            expect(result.accessToken).toBe("refreshed-at")
+            expect(result.refreshToken).toBe("new-rt")
+        })
+
+        it("normalizes wrapped refresh response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            access_token: "refreshed-wrapped-at",
+                            refresh_token: "new-wrapped-rt",
+                            expires_in: 86400,
+                            token_type: "bearer",
+                        },
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.refreshAccessToken("old-wrapped-rt")
+            expect(result.accessToken).toBe("refreshed-wrapped-at")
+            expect(result.refreshToken).toBe("new-wrapped-rt")
+        })
+    })
+})

--- a/src/lib/tiktok/oauth-service.test.ts
+++ b/src/lib/tiktok/oauth-service.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TikTokOAuthService } from "./oauth-service"
+import type { TikTokConfig } from "./config"
+
+// Mock the base service to avoid actual initialization
+vi.mock("@/lib/youtube/base-service", () => ({
+    BaseService: class MockBaseService {
+        protected logger = {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+        }
+        protected isInitialized = true
+        assertReady() {}
+        async initialize() {}
+    },
+    ServiceError: class ServiceError extends Error {
+        code: string
+        statusCode: number
+        context?: Record<string, unknown>
+
+        constructor(
+            code: string,
+            message: string,
+            statusCode: number = 500,
+            context?: Record<string, unknown>
+        ) {
+            super(message)
+            this.name = "ServiceError"
+            this.code = code
+            this.statusCode = statusCode
+            this.context = context
+        }
+    },
+}))
+
+const mockConfig: TikTokConfig = {
+    oauth: {
+        clientKey: "test-client-key",
+        clientSecret: "test-client-secret",
+        redirectUri: "https://example.com/callback",
+        scopes: ["user.info.basic"],
+    },
+}
+
+let service: TikTokOAuthService
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset fetch mock
+    vi.restoreAllMocks()
+    service = new TikTokOAuthService(mockConfig)
+    // Bypass initialization assertion
+    ;(service as any).isInitialized = true
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe("TikTokOAuthService", () => {
+    describe("generateAuthorizationUrl", () => {
+        it("returns authorization URL and state for a user", () => {
+            const result = service.generateAuthorizationUrl("user-123")
+            expect(result.authorizationUrl).toContain(
+                "https://www.tiktok.com/v2/auth/authorize/"
+            )
+            expect(result.authorizationUrl).toContain("client_key=test-client-key")
+            expect(result.state).toBeTruthy()
+            expect(typeof result.state).toBe("string")
+        })
+    })
+
+    describe("exchangeCodeForToken", () => {
+        it("exchanges code for token with flat response format", async () => {
+            const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "flat-access-token",
+                        refresh_token: "flat-refresh-token",
+                        expires_in: 86400,
+                        token_type: "bearer",
+                        open_id: "test-open-id",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("test-code")
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            expect(fetchMock).toHaveBeenCalledWith(
+                "https://open.tiktokapis.com/v2/oauth/token/",
+                expect.objectContaining({
+                    method: "POST",
+                    headers: expect.objectContaining({
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                })
+            )
+            expect(result.accessToken).toBe("flat-access-token")
+            expect(result.refreshToken).toBe("flat-refresh-token")
+            expect(result.expiresIn).toBe(86400)
+            expect(result.tokenType).toBe("bearer")
+        })
+
+        it("exchanges code for token with wrapped response format", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            access_token: "wrapped-access-token",
+                            refresh_token: "wrapped-refresh-token",
+                            expires_in: 86400,
+                            token_type: "bearer",
+                            open_id: "wrapped-open-id",
+                        },
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.exchangeCodeForToken("test-code")
+            expect(result.accessToken).toBe("wrapped-access-token")
+            expect(result.refreshToken).toBe("wrapped-refresh-token")
+        })
+
+        it("throws ServiceError on HTTP 400 response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        error: "invalid_grant",
+                        error_description: "Invalid authorization code",
+                    }),
+                    { status: 400 }
+                )
+            )
+
+            await expect(
+                service.exchangeCodeForToken("bad-code")
+            ).rejects.toThrow(/Failed to exchange code/)
+        })
+
+        it("throws ServiceError on malformed JSON response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response("not-json-at-all", { status: 200 })
+            )
+
+            await expect(
+                service.exchangeCodeForToken("test-code")
+            ).rejects.toThrow(/Invalid JSON response/)
+        })
+
+        it("throws ServiceError when TikTok returns HTTP 200 with error payload", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        error: "invalid_grant",
+                        error_description: "Code already used",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            await expect(
+                service.exchangeCodeForToken("used-code")
+            ).rejects.toThrow(/TikTok API error/)
+        })
+    })
+
+    describe("refreshAccessToken", () => {
+        it("refreshes token successfully", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        access_token: "refreshed-access-token",
+                        refresh_token: "new-refresh-token",
+                        expires_in: 86400,
+                        token_type: "bearer",
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const result = await service.refreshAccessToken("old-refresh-token")
+
+            expect(result.accessToken).toBe("refreshed-access-token")
+            expect(result.refreshToken).toBe("new-refresh-token")
+            expect(result.expiresIn).toBe(86400)
+        })
+
+        it("throws ServiceError on failed refresh", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({ error: "invalid_grant" }),
+                    { status: 400 }
+                )
+            )
+
+            await expect(
+                service.refreshAccessToken("expired-token")
+            ).rejects.toThrow(/Failed to refresh/)
+        })
+    })
+
+    describe("revokeToken", () => {
+        it("returns true on successful revocation", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(null, { status: 200 })
+            )
+
+            const result = await service.revokeToken("valid-token")
+            expect(result).toBe(true)
+        })
+
+        it("returns false when revocation returns HTTP error", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(null, { status: 400 })
+            )
+
+            const result = await service.revokeToken("bad-token")
+            expect(result).toBe(false)
+        })
+
+        it("throws on network failure (uncaught error)", async () => {
+            vi.spyOn(globalThis, "fetch").mockRejectedValue(
+                new Error("Network error")
+            )
+
+            await expect(service.revokeToken("any-token")).rejects.toThrow(
+                "Network error"
+            )
+        })
+    })
+
+    describe("getUserInfo", () => {
+        it("returns user info with valid token", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            user: {
+                                open_id: "open-123",
+                                union_id: "union-123",
+                                display_name: "Test User",
+                                avatar_url: "https://example.com/avatar.jpg",
+                                is_verified: true,
+                                username: "testuser",
+                                follower_count: 100,
+                                following_count: 50,
+                                likes_count: 500,
+                                video_count: 10,
+                            },
+                        },
+                    }),
+                    { status: 200 }
+                )
+            )
+
+            const user = await service.getUserInfo("valid-token")
+            expect(user).not.toBeNull()
+            expect(user!.openId).toBe("open-123")
+            expect(user!.displayName).toBe("Test User")
+            expect(user!.isVerified).toBe(true)
+            expect(user!.followerCount).toBe(100)
+        })
+
+        it("returns null when no access token is provided", async () => {
+            const user = await service.getUserInfo("")
+            expect(user).toBeNull()
+        })
+
+        it("returns null when response lacks user data", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(
+                    JSON.stringify({ data: { user: null } }),
+                    { status: 200 }
+                )
+            )
+
+            const user = await service.getUserInfo("valid-token")
+            expect(user).toBeNull()
+        })
+
+        it("returns null after retries exhausted on error", async () => {
+            vi.spyOn(globalThis, "fetch").mockRejectedValue(
+                new Error("Network error")
+            )
+
+            const user = await service.getUserInfo("valid-token")
+            expect(user).toBeNull()
+        })
+    })
+})


### PR DESCRIPTION
## Summary
Add 27 unit tests across 3 new test files covering TikTok OAuth token operations. These tests address the coverage gap identified in the TikTok OAuth token flow, verifying token exchange, refresh, revocation, user info retrieval, authorization URL generation, and token response normalization for both flat and wrapped response formats.

Closes #9

## Risk Assessment
**Risk Level:** LOW
**Cost:** ✅ Free (all tests, no new dependencies, no infrastructure changes)

## Changes
### New Files
- \src/lib/tiktok/oauth-service.test.ts\ — 15 tests for TikTokOAuthService
- \src/app/api/oauth/authorize/tiktok/route.test.ts\ — 4 tests for POST /api/oauth/authorize/tiktok
- \src/app/api/posts/token-normalize.test.ts\ — 8 tests for token response normalization

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] All 27 new tests pass
- [x] No pre-existing tests regressed

Closes #9

_Generated by engineering-loop | Cost-free: ✅_