### PR TITLE
ci: make test suite blocking by removing continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,7 @@ jobs:
     test-suite:
         runs-on: ubuntu-latest
         name: Test Suite
-        # Tests are optional - don't block deployment if they fail
-        continue-on-error: true
+        needs: [quality-check]
 
         steps:
             - name: Checkout
@@ -91,5 +90,3 @@ jobs:
 
             - name: Run Tests
               run: npm run test
-              # Don't fail the workflow if tests fail
-              continue-on-error: true


### PR DESCRIPTION
## Summary
Make CI test suite blocking by removing \continue-on-error: true\ from the test-suite job. Test failures will now block the CI pipeline, preventing deployment when tests fail.

## Risk Assessment
**Risk Level:** 🔵 Low
**Cost:** ✅ Free (all changes local/local tools)

## Changes
- \.github/workflows/ci.yml\: Removed \continue-on-error: true\ from both the job and step level of the test-suite job
- Added \
eeds: [quality-check]\ so tests only run after quality checks pass (saves CI minutes)

## Testing
- [x] YAML syntax validated
- [x] Tests pass

Closes #239

_Generated by engineering-loop | Cost-free: ✅_