### PR TITLE
fix: Twitch ON CONFLICT, Kick scopes, add TikTok/Twitter platform coverage

### DIFF
--- a/src/__tests__/app/dashboard/live/page.test.tsx
+++ b/src/__tests__/app/dashboard/live/page.test.tsx
@@ -39,18 +39,14 @@ describe("LiveDashboardPage", () => {
         render(<LiveDashboardPage />)
 
         // Should show a loading spinner with translation text
-        expect(
-            screen.getByText("Loading stream status...")
-        ).toBeInTheDocument()
+        expect(screen.getByText("Loading stream status...")).toBeInTheDocument()
     })
 
     it("fetches live status from /api/live/status on mount", async () => {
-        const fetchSpy = vi
-            .spyOn(globalThis, "fetch")
-            .mockResolvedValue({
-                ok: true,
-                json: async () => mockLiveData,
-            } as Response)
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockLiveData,
+        } as Response)
 
         render(<LiveDashboardPage />)
 

--- a/src/__tests__/components/dashboard/live/stream-title-editor.test.tsx
+++ b/src/__tests__/components/dashboard/live/stream-title-editor.test.tsx
@@ -31,7 +31,9 @@ describe("StreamTitleEditor", () => {
         expect(titleInput).toBeInTheDocument()
         expect(titleInput).toHaveValue("My Current Title")
 
-        const gameInput = screen.getByPlaceholderText("Enter game or category...")
+        const gameInput = screen.getByPlaceholderText(
+            "Enter game or category..."
+        )
         expect(gameInput).toBeInTheDocument()
         expect(gameInput).toHaveValue("Just Chatting")
     })
@@ -95,7 +97,9 @@ describe("StreamTitleEditor", () => {
         await waitFor(() => {
             expect(screen.getByText("Stream updated!")).toBeInTheDocument()
         })
-        expect(screen.getByText("Stream updated!")).toHaveClass("text-green-600")
+        expect(screen.getByText("Stream updated!")).toHaveClass(
+            "text-green-600"
+        )
     })
 
     it("shows error message on API error response", async () => {

--- a/src/__tests__/lib/chat/twitch-adapter.test.ts
+++ b/src/__tests__/lib/chat/twitch-adapter.test.ts
@@ -106,10 +106,7 @@ describe("TwitchChatAdapter", () => {
         })
 
         it("rejects on connection timeout", async () => {
-            const connectPromise = adapter.connect(
-                "timeoutchannel",
-                "token"
-            )
+            const connectPromise = adapter.connect("timeoutchannel", "token")
 
             // Advance past the 10s timeout
             await vi.advanceTimersByTimeAsync(11000)
@@ -146,7 +143,7 @@ describe("TwitchChatAdapter", () => {
             socket.emit(
                 "data",
                 Buffer.from(
-                    '@badges=moderator/1;color=#FF0000;display-name=TestUser;emotes=;id=abc-123;mod=1;user-id=456;user-type=mod :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Hello world!\r\n'
+                    "@badges=moderator/1;color=#FF0000;display-name=TestUser;emotes=;id=abc-123;mod=1;user-id=456;user-type=mod :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Hello world!\r\n"
                 )
             )
 
@@ -170,7 +167,7 @@ describe("TwitchChatAdapter", () => {
             socket.emit(
                 "data",
                 Buffer.from(
-                    '@system-msg=subscribed :tmi.twitch.tv USERNOTICE #testchannel :Someone just subscribed!\r\n'
+                    "@system-msg=subscribed :tmi.twitch.tv USERNOTICE #testchannel :Someone just subscribed!\r\n"
                 )
             )
 
@@ -202,8 +199,8 @@ describe("TwitchChatAdapter", () => {
                 isAction: true,
             })
 
-            const actionCall = socket.write.mock.calls.find(
-                (call: string[]) => call[0]?.includes("ACTION")
+            const actionCall = socket.write.mock.calls.find((call: string[]) =>
+                call[0]?.includes("ACTION")
             )
             expect(actionCall).toBeTruthy()
         })
@@ -253,9 +250,7 @@ describe("TwitchChatAdapter", () => {
         })
 
         it("handles disconnect when not connected gracefully", async () => {
-            await expect(
-                adapter.disconnect("unknown")
-            ).resolves.not.toThrow()
+            await expect(adapter.disconnect("unknown")).resolves.not.toThrow()
         })
     })
 

--- a/src/app/[locale]/dashboard/channels/page.tsx
+++ b/src/app/[locale]/dashboard/channels/page.tsx
@@ -36,7 +36,7 @@ const ALL_PLATFORMS = [
     { id: "kick", name: "Kick", implemented: true },
     { id: "facebook", name: "Facebook", implemented: true, localOnly: true },
     { id: "instagram", name: "Instagram", implemented: true, localOnly: true },
-    { id: "twitter", name: "Twitter/X", implemented: false },
+    { id: "twitter", name: "Twitter/X", implemented: true },
     { id: "linkedin", name: "LinkedIn", implemented: false },
     { id: "kwai", name: "Kwai", implemented: false },
 ] as const

--- a/src/app/[locale]/dashboard/live/page.tsx
+++ b/src/app/[locale]/dashboard/live/page.tsx
@@ -186,7 +186,17 @@ export default function LiveDashboardPage() {
                                     : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300"
                             }`}
                         >
-                            {p.platform === "twitch" ? "Twitch" : p.platform === "kick" ? "Kick" : p.platform === "youtube" ? "YouTube" : p.platform === "facebook" ? "Facebook" : p.platform === "instagram" ? "Instagram" : p.platform}
+                            {p.platform === "twitch"
+                                ? "Twitch"
+                                : p.platform === "kick"
+                                  ? "Kick"
+                                  : p.platform === "youtube"
+                                    ? "YouTube"
+                                    : p.platform === "facebook"
+                                      ? "Facebook"
+                                      : p.platform === "instagram"
+                                        ? "Instagram"
+                                        : p.platform}
                             {p.isLive && (
                                 <span className="ml-2 inline-block h-2 w-2 rounded-full bg-red-500 animate-pulse" />
                             )}

--- a/src/app/api/live/chat/stream/route.ts
+++ b/src/app/api/live/chat/stream/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest): Promise<Response> {
         const { data: networks, error } = await supabase
             .from("social_networks")
             .select("*")
-            .in("platform", ["twitch", "kick"])
+            .in("platform", ["twitch", "kick", "tiktok", "twitter"])
             .eq("user_id", userId)
             .eq("status", "connected")
 

--- a/src/app/api/live/status/route.ts
+++ b/src/app/api/live/status/route.ts
@@ -335,6 +335,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                 "instagram",
                 "twitch",
                 "kick",
+                "tiktok",
+                "twitter",
             ])
             .eq("user_id", userId)
             .eq("status", "connected")
@@ -435,6 +437,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     } else {
                         platforms.push(baseInfo)
                     }
+                    break
+
+                case "tiktok":
+                case "twitter":
+                    platforms.push(baseInfo)
                     break
 
                 default:

--- a/src/app/api/live/stream-key/route.ts
+++ b/src/app/api/live/stream-key/route.ts
@@ -78,8 +78,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             }
 
             const broadcasterId =
-                network.metadata?.userId ||
-                network.platform_user_id
+                network.metadata?.userId || network.platform_user_id
 
             if (!broadcasterId) {
                 logger.warn("No Twitch broadcaster ID found", { userId })

--- a/src/app/api/oauth/authorize/tiktok/route.test.ts
+++ b/src/app/api/oauth/authorize/tiktok/route.test.ts
@@ -68,7 +68,9 @@ describe("POST /api/oauth/authorize/tiktok", () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockGetServerSession.mockResolvedValue({ user: { id: "test-user-123" } })
+        mockGetServerSession.mockResolvedValue({
+            user: { id: "test-user-123" },
+        })
         mockGenerateState.mockReturnValue({
             token: "signed-state-token-abc123",
             payload: {
@@ -98,10 +100,16 @@ describe("POST /api/oauth/authorize/tiktok", () => {
             state: "signed-state-token-abc123",
         })
         expect(data.authorizationUrl).toContain("client_key=test-client-key")
-        expect(data.authorizationUrl).toContain("redirect_uri=https%3A%2F%2Fexample.com%2Fcallback")
-        expect(data.authorizationUrl).toContain("state=signed-state-token-abc123")
+        expect(data.authorizationUrl).toContain(
+            "redirect_uri=https%3A%2F%2Fexample.com%2Fcallback"
+        )
+        expect(data.authorizationUrl).toContain(
+            "state=signed-state-token-abc123"
+        )
         expect(data.authorizationUrl).toContain("response_type=code")
-        expect(data.authorizationUrl).toContain("scope=user.info.basic%2Cuser.info.profile")
+        expect(data.authorizationUrl).toContain(
+            "scope=user.info.basic%2Cuser.info.profile"
+        )
     })
 
     it("returns 401 when user is not authenticated", async () => {

--- a/src/app/api/oauth/callback/twitch/route.ts
+++ b/src/app/api/oauth/callback/twitch/route.ts
@@ -170,7 +170,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     updated_at: new Date().toISOString(),
                 },
                 {
-                    onConflict: "user_id, platform",
+                    onConflict: "user_id, platform, platform_user_id",
                 }
             )
 

--- a/src/components/dashboard/live/stream-key-card.tsx
+++ b/src/components/dashboard/live/stream-key-card.tsx
@@ -250,7 +250,9 @@ export function StreamKeyCard({ platform }: StreamKeyCardProps) {
                         <button
                             onClick={() => setRevealed(!revealed)}
                             className="rounded-md border border-gray-300 p-2 text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
-                            title={revealed ? "Hide stream key" : "Show stream key"}
+                            title={
+                                revealed ? "Hide stream key" : "Show stream key"
+                            }
                         >
                             {revealed ? (
                                 /* Eye-off icon */

--- a/src/hooks/use-chat-sse.test.ts
+++ b/src/hooks/use-chat-sse.test.ts
@@ -42,8 +42,10 @@ interface MockEventSource {
 }
 
 // Track event listeners per EventSource instance
-const eventListeners: Map<MockEventSource, Map<string, Set<EventListenerCallback>>> =
-    new Map()
+const eventListeners: Map<
+    MockEventSource,
+    Map<string, Set<EventListenerCallback>>
+> = new Map()
 let currentEventSource: MockEventSource | null = null
 let eventSourceConstructorCalls: string[] = []
 

--- a/src/hooks/use-chat-sse.ts
+++ b/src/hooks/use-chat-sse.ts
@@ -60,9 +60,7 @@ interface UseChatSSEReturn {
 const MAX_RECONNECT_DELAY_MS = 30_000
 const INITIAL_RECONNECT_DELAY_MS = 1_000
 
-export function useChatSSE(
-    _platforms: string[]
-): UseChatSSEReturn {
+export function useChatSSE(_platforms: string[]): UseChatSSEReturn {
     const [messages, setMessages] = useState<SSEChatMessage[]>([])
     const [statuses, setStatuses] = useState<PlatformStatus[]>([])
     const [isConnected, setIsConnected] = useState(false)

--- a/src/lib/kick/config.ts
+++ b/src/lib/kick/config.ts
@@ -32,8 +32,8 @@ const DEFAULT_SCOPES = [
     "streamkey:read",
     "chat:write",
     "events:subscribe",
-    "moderation:read",
-    "moderation:write",
+    "moderation:ban",
+    "moderation:chat_message:manage",
 ]
 
 export function createKickConfig(): KickConfig {
@@ -43,7 +43,8 @@ export function createKickConfig(): KickConfig {
             clientSecret: process.env.KICK_CLIENT_SECRET || "",
             redirectUri:
                 process.env.KICK_REDIRECT_URI ||
-                (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL
+                (process.env.VERCEL_ENV === "production" &&
+                process.env.VERCEL_PROJECT_PRODUCTION_URL
                     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}/api/oauth/callback/kick`
                     : "http://localhost:3000/api/oauth/callback/kick"),
             scopes: DEFAULT_SCOPES,

--- a/src/lib/oauth/oauth-manager-core.ts
+++ b/src/lib/oauth/oauth-manager-core.ts
@@ -146,6 +146,26 @@ export class OAuthManager {
             })
         }
 
+        // TikTok
+        if (process.env.TIKTOK_CLIENT_KEY && process.env.TIKTOK_CLIENT_SECRET) {
+            this.configs.set("tiktok", {
+                clientId: process.env.TIKTOK_CLIENT_KEY,
+                clientSecret: process.env.TIKTOK_CLIENT_SECRET,
+                redirectUri:
+                    process.env.TIKTOK_REDIRECT_URI ||
+                    "http://localhost:3000/api/oauth/callback/tiktok",
+                scopes: [
+                    "user.info.basic",
+                    "user.info.profile",
+                    "user.info.stats",
+                    "video.list",
+                    "video.publish",
+                ],
+                authorizationUrl: "https://www.tiktok.com/v2/auth/authorize",
+                tokenUrl: "https://open.tiktokapis.com/v2/oauth/token/",
+            })
+        }
+
         // Kick
         if (process.env.KICK_CLIENT_ID && process.env.KICK_CLIENT_SECRET) {
             this.configs.set("kick", {
@@ -159,8 +179,8 @@ export class OAuthManager {
                     "channel:read",
                     "channel:write",
                     "chat:write",
-                    "moderation:read",
-                    "moderation:write",
+                    "moderation:ban",
+                    "moderation:chat_message:manage",
                 ],
                 authorizationUrl: "https://id.kick.com/oauth/authorize",
                 tokenUrl: "https://id.kick.com/oauth/token",

--- a/src/lib/realtime/connection-store.ts
+++ b/src/lib/realtime/connection-store.ts
@@ -34,7 +34,10 @@ class ConnectionStore {
             this.connections.set(userId, new Map())
         }
         this.connections.get(userId)!.set(connection.id, connection)
-        logger.debug("Connection added", { userId, connectionId: connection.id })
+        logger.debug("Connection added", {
+            userId,
+            connectionId: connection.id,
+        })
     }
 
     /**
@@ -95,7 +98,10 @@ class ConnectionStore {
         let removedCount = 0
 
         for (const [userId, userConnections] of this.connections.entries()) {
-            for (const [connectionId, connection] of userConnections.entries()) {
+            for (const [
+                connectionId,
+                connection,
+            ] of userConnections.entries()) {
                 if (now - connection.lastHeartbeat > STALE_CONNECTION_MS) {
                     try {
                         connection.controller.close()
@@ -157,7 +163,10 @@ class ConnectionStore {
      */
     private startCleanup(): void {
         if (this.cleanupTimer) return
-        this.cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS)
+        this.cleanupTimer = setInterval(
+            () => this.cleanup(),
+            CLEANUP_INTERVAL_MS
+        )
     }
 
     /**

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -101,7 +101,8 @@ export class MessageAggregator {
                     connected: true,
                 })
             } catch (error) {
-                const errorMsg = error instanceof Error ? error.message : String(error)
+                const errorMsg =
+                    error instanceof Error ? error.message : String(error)
                 logger.error("Failed to start platform adapter", {
                     userId: this.userId,
                     platform,

--- a/src/lib/realtime/sse-manager.test.ts
+++ b/src/lib/realtime/sse-manager.test.ts
@@ -35,7 +35,10 @@ vi.mock("./connection-store", () => {
         destroy: vi.fn(),
     }
 
-    return { connectionStore: mockConnectionStore, Connection: {} as Connection }
+    return {
+        connectionStore: mockConnectionStore,
+        Connection: {} as Connection,
+    }
 })
 
 // Mock logger
@@ -65,11 +68,17 @@ describe("SSEManager", () => {
         it("should return a response with SSE headers", async () => {
             const { createSSEStream } = await import("./sse-manager")
 
-            const request = new Request("http://localhost:3000/api/live/chat/stream", {
-                signal: new AbortController().signal,
-            })
+            const request = new Request(
+                "http://localhost:3000/api/live/chat/stream",
+                {
+                    signal: new AbortController().signal,
+                }
+            )
 
-            const { response, connectionId } = createSSEStream(request, "user-1")
+            const { response, connectionId } = createSSEStream(
+                request,
+                "user-1"
+            )
 
             expect(response.headers.get("Content-Type")).toBe(
                 "text/event-stream"
@@ -85,9 +94,12 @@ describe("SSEManager", () => {
         it("should add connection to store", async () => {
             const { createSSEStream } = await import("./sse-manager")
 
-            const request = new Request("http://localhost:3000/api/live/chat/stream", {
-                signal: new AbortController().signal,
-            })
+            const request = new Request(
+                "http://localhost:3000/api/live/chat/stream",
+                {
+                    signal: new AbortController().signal,
+                }
+            )
 
             createSSEStream(request, "user-1")
 
@@ -103,9 +115,12 @@ describe("SSEManager", () => {
             const { createSSEStream } = await import("./sse-manager")
             const controller = new AbortController()
 
-            const request = new Request("http://localhost:3000/api/live/chat/stream", {
-                signal: controller.signal,
-            })
+            const request = new Request(
+                "http://localhost:3000/api/live/chat/stream",
+                {
+                    signal: controller.signal,
+                }
+            )
 
             createSSEStream(request, "user-1")
 
@@ -141,7 +156,9 @@ describe("SSEManager", () => {
             vi.mocked(connectionStore.getConnectionsByUser).mockReturnValue([
                 {
                     id: "conn-1",
-                    controller: { close: mockClose } as unknown as ReadableStreamDefaultController<Uint8Array>,
+                    controller: {
+                        close: mockClose,
+                    } as unknown as ReadableStreamDefaultController<Uint8Array>,
                     createdAt: Date.now(),
                     lastHeartbeat: Date.now(),
                 },

--- a/src/lib/tiktok/oauth-service.test.ts
+++ b/src/lib/tiktok/oauth-service.test.ts
@@ -66,7 +66,9 @@ describe("TikTokOAuthService", () => {
             expect(result.authorizationUrl).toContain(
                 "https://www.tiktok.com/v2/auth/authorize/"
             )
-            expect(result.authorizationUrl).toContain("client_key=test-client-key")
+            expect(result.authorizationUrl).toContain(
+                "client_key=test-client-key"
+            )
             expect(result.state).toBeTruthy()
             expect(typeof result.state).toBe("string")
         })
@@ -192,10 +194,9 @@ describe("TikTokOAuthService", () => {
 
         it("throws ServiceError on failed refresh", async () => {
             vi.spyOn(globalThis, "fetch").mockResolvedValue(
-                new Response(
-                    JSON.stringify({ error: "invalid_grant" }),
-                    { status: 400 }
-                )
+                new Response(JSON.stringify({ error: "invalid_grant" }), {
+                    status: 400,
+                })
             )
 
             await expect(
@@ -273,10 +274,9 @@ describe("TikTokOAuthService", () => {
 
         it("returns null when response lacks user data", async () => {
             vi.spyOn(globalThis, "fetch").mockResolvedValue(
-                new Response(
-                    JSON.stringify({ data: { user: null } }),
-                    { status: 200 }
-                )
+                new Response(JSON.stringify({ data: { user: null } }), {
+                    status: 200,
+                })
             )
 
             const user = await service.getUserInfo("valid-token")

--- a/src/lib/twitch/config.ts
+++ b/src/lib/twitch/config.ts
@@ -52,7 +52,8 @@ export function createTwitchConfig(): TwitchConfig {
             clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
             redirectUri:
                 process.env.TWITCH_REDIRECT_URI ||
-                (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL
+                (process.env.VERCEL_ENV === "production" &&
+                process.env.VERCEL_PROJECT_PRODUCTION_URL
                     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}/api/oauth/callback/twitch`
                     : "http://localhost:3000/api/oauth/callback/twitch"),
             scopes: DEFAULT_SCOPES,

--- a/src/middleware/cors.test.ts
+++ b/src/middleware/cors.test.ts
@@ -531,4 +531,3 @@ describe("CORS Middleware", () => {
         })
     })
 })
-

--- a/src/middleware/security-headers.test.ts
+++ b/src/middleware/security-headers.test.ts
@@ -481,4 +481,3 @@ describe("Security Headers Middleware (src/middleware/)", () => {
         })
     })
 })
-


### PR DESCRIPTION
## Summary

### Task A: Fix OAuth bugs
- Twitch callback: ON CONFLICT now matches UNIQUE constraint (user_id, platform, platform_user_id) 
- Kick scopes: moderation:read/write replaced with valid moderation:ban/chat_message:manage

### Task B: Platform coverage
- Twitter enabled on channels page (implemented: true)
- TikTok/Twitter added to live status query filter + switch cases
- TikTok/Twitter added to chat stream filter
- TikTok OAuth config registered in oauth-manager-core.ts

### Task C: Infrastructure
- scheduled_streams table already applied to production Supabase

Closes #276