### PR TITLE
fix: Twitch live status viewer count, uptime, game name and chat not showing

### DIFF
--- a/src/app/api/live/chat/stream/route.ts
+++ b/src/app/api/live/chat/stream/route.ts
@@ -59,14 +59,20 @@ export async function GET(request: NextRequest): Promise<Response> {
             )
         }
 
-        // Determine which platforms the user has connected
-        const platforms: Array<"twitch" | "kick"> = []
+        // Determine which platforms the user has connected and their channel names
+        const platformConnect: Partial<
+            Record<"twitch" | "kick", { channelName: string }>
+        > = {}
         for (const network of networks || []) {
-            if (network.platform === "twitch" || network.platform === "kick") {
-                platforms.push(network.platform)
+            const plat = network.platform as "twitch" | "kick"
+            if (plat === "twitch" || plat === "kick") {
+                platformConnect[plat] = {
+                    channelName: network.platform_username || plat,
+                }
             }
         }
 
+        const platforms = Object.keys(platformConnect)
         if (platforms.length === 0) {
             return new Response(
                 JSON.stringify({
@@ -85,7 +91,7 @@ export async function GET(request: NextRequest): Promise<Response> {
         const { response, connectionId } = createSSEStream(request, userId)
 
         // Start message aggregator
-        const aggregator = new MessageAggregator(userId, platforms)
+        const aggregator = new MessageAggregator(userId, platformConnect)
         aggregator.start().catch(err => {
             logger.error("Aggregator failed to start", {
                 userId,

--- a/src/app/api/live/status/route.ts
+++ b/src/app/api/live/status/route.ts
@@ -25,7 +25,6 @@ interface PlatformStreamInfo {
 }
 
 async function fetchTwitchStream(
-    accessToken: string,
     userId: string
 ): Promise<Partial<PlatformStreamInfo>> {
     try {
@@ -376,15 +375,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
             switch (network.platform) {
                 case "twitch":
-                    if (accessToken) {
-                        const twitchData = await fetchTwitchStream(
-                            accessToken,
-                            network.provider_user_id || network.platform_user_id
-                        )
-                        platforms.push({ ...baseInfo, ...twitchData })
-                    } else {
-                        platforms.push(baseInfo)
-                    }
+                    const twitchData = await fetchTwitchStream(
+                        network.provider_user_id || network.platform_user_id
+                    )
+                    platforms.push({ ...baseInfo, ...twitchData })
                     break
 
                 case "kick":

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -14,6 +14,10 @@ const logger = createLogger("MessageAggregator")
 
 type ChatPlatform = "twitch" | "kick"
 
+type PlatformConnectInfo = Partial<
+    Record<ChatPlatform, { channelName: string }>
+>
+
 interface PlatformAdapterEntry {
     adapter: ChatAdapter
     cleanupFns: Array<() => void>
@@ -27,17 +31,18 @@ const ADAPTER_REGISTRY: Record<ChatPlatform, () => ChatAdapter> = {
 export class MessageAggregator {
     private userId: string
     private platforms: ChatPlatform[]
+    private platformConnect: PlatformConnectInfo
     private adapters: Map<ChatPlatform, PlatformAdapterEntry> = new Map()
     private started = false
-    private roomId: string
 
-    constructor(userId: string, platforms: ChatPlatform[]) {
+    constructor(userId: string, platformConnect: PlatformConnectInfo) {
+        const platforms = Object.keys(platformConnect) as ChatPlatform[]
         if (platforms.length === 0) {
             throw new Error("At least one platform must be configured")
         }
         this.userId = userId
         this.platforms = platforms
-        this.roomId = userId // Use userId as the chat room identifier
+        this.platformConnect = platformConnect
     }
 
     /**
@@ -66,14 +71,22 @@ export class MessageAggregator {
                 }
 
                 const adapter = factory()
+                const connectInfo = this.platformConnect[platform]
                 const entry: PlatformAdapterEntry = {
                     adapter,
                     cleanupFns: [],
                 }
 
-                // Register message handler
+                if (!connectInfo) {
+                    logger.warn("No connect info for platform", { platform })
+                    continue
+                }
+
+                const channelName = connectInfo.channelName
+
+                // Register message handler with channel name
                 const unsubMessage = adapter.onMessage(
-                    this.roomId,
+                    channelName,
                     (message: ChatMessage) => {
                         this.handleMessage(message)
                     }
@@ -88,8 +101,8 @@ export class MessageAggregator {
 
                 this.adapters.set(platform, entry)
 
-                // Connect to the platform chat
-                await adapter.connect(this.roomId, "")
+                // Connect to the platform chat with actual channel name
+                await adapter.connect(channelName, "")
                 logger.info("Connected to platform chat", {
                     userId: this.userId,
                     platform,
@@ -150,7 +163,9 @@ export class MessageAggregator {
 
             // Disconnect adapter
             try {
-                await entry.adapter.disconnect(this.roomId)
+                const connectInfo = this.platformConnect[platform]
+                if (!connectInfo) continue
+                await entry.adapter.disconnect(connectInfo.channelName)
             } catch (error) {
                 logger.warn("Failed to disconnect adapter", {
                     platform,


### PR DESCRIPTION
## Context

User connected Twitch account but no live data appears:
- Viewer count → "—"
- Uptime → "—"  
- Game/Category → "—"
- Chat messages → never arrive

## Root Causes

### 1. Live Status (fetchTwitchStream never called)
`src/app/api/live/status/route.ts`

`network.access_token` is **never stored** in `social_networks` during Twitch OAuth callback — it goes to a separate token table. The `if (accessToken)` guard on line 379 was always falsy, so `fetchTwitchStream` was **never executed**. The function also never used the accessToken param — it generates its own app token via `client_credentials` grant.

**Fix:** Removed the `accessToken` parameter and the `if (accessToken)` guard. Twitch stream fetch now always runs when there's a Twitch social_network entry.

### 2. Chat (wrong channel name)
`src/lib/realtime/message-aggregator.ts` + `src/app/api/live/chat/stream/route.ts`

The `MessageAggregator` used the user's internal UUID (`this.roomId = userId`) as the Twitch channel name. The Twitch IRC adapter then tried to `JOIN #<uuid>` and `NICK <uuid>`, which is a non-existent channel.

**Fix:** 
- `MessageAggregator` constructor now accepts `PlatformConnectInfo` (a mapping of platform → `{ channelName }`) instead of raw platform names
- Chat stream route extracts `platform_username` from `social_networks` and passes it as the channel name
- Twitch IRC now correctly joins `#<twitch_username>`

## Risk: 🟢 Low
- No DB changes, no env var changes
- Live status was previously non-functional for Twitch — this only improves it
- Chat was previously connecting to wrong channel — this corrects the target

## Plan
1. ✅ Identify root causes
2. ✅ Fix live status guard
3. ✅ Fix chat channel name
4. ✅ TypeScript check passes

Closes #N