### PR TITLE
fix: pass Twitch OAuth token to IRC adapter for chat authentication

### DIFF
--- a/src/app/api/live/chat/stream/route.ts
+++ b/src/app/api/live/chat/stream/route.ts
@@ -11,6 +11,7 @@ import { createClient } from "@supabase/supabase-js"
 import { NextRequest } from "next/server"
 import { MessageAggregator } from "@/lib/realtime/message-aggregator"
 import { createSSEStream, closeConnections } from "@/lib/realtime/sse-manager"
+import { getTokenStore } from "@/lib/token-store"
 
 const logger = createLogger("ChatStreamEndpoint")
 
@@ -61,14 +62,42 @@ export async function GET(request: NextRequest): Promise<Response> {
 
         // Determine which platforms the user has connected and their channel names
         const platformConnect: Partial<
-            Record<"twitch" | "kick", { channelName: string }>
+            Record<"twitch" | "kick", { channelName: string; token?: string }>
         > = {}
         for (const network of networks || []) {
             const plat = network.platform as "twitch" | "kick"
             if (plat === "twitch" || plat === "kick") {
-                platformConnect[plat] = {
+                const info: { channelName: string; token?: string } = {
                     channelName: network.platform_username || plat,
                 }
+
+                // Fetch OAuth token for Twitch (required for IRC authentication)
+                if (plat === "twitch") {
+                    try {
+                        const tokenStore = getTokenStore()
+                        const stored = await tokenStore.getToken(
+                            userId,
+                            "twitch"
+                        )
+                        if (stored?.accessToken) {
+                            info.token = stored.accessToken
+                            logger.debug(
+                                "Twitch OAuth token retrieved for chat",
+                                { userId }
+                            )
+                        }
+                    } catch (tokenErr) {
+                        logger.warn(
+                            "Failed to retrieve Twitch token for chat",
+                            {
+                                userId,
+                                error: String(tokenErr),
+                            }
+                        )
+                    }
+                }
+
+                platformConnect[plat] = info
             }
         }
 

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -15,7 +15,7 @@ const logger = createLogger("MessageAggregator")
 type ChatPlatform = "twitch" | "kick"
 
 type PlatformConnectInfo = Partial<
-    Record<ChatPlatform, { channelName: string }>
+    Record<ChatPlatform, { channelName: string; token?: string }>
 >
 
 interface PlatformAdapterEntry {
@@ -83,6 +83,7 @@ export class MessageAggregator {
                 }
 
                 const channelName = connectInfo.channelName
+                const token = connectInfo.token || ""
 
                 // Register message handler with channel name
                 const unsubMessage = adapter.onMessage(
@@ -101,8 +102,8 @@ export class MessageAggregator {
 
                 this.adapters.set(platform, entry)
 
-                // Connect to the platform chat with actual channel name
-                await adapter.connect(channelName, "")
+                // Connect to the platform chat with actual channel name and token
+                await adapter.connect(channelName, token)
                 logger.info("Connected to platform chat", {
                     userId: this.userId,
                     platform,


### PR DESCRIPTION
## Context

Twitch chat keeps disconnecting with "Twitch IRC connection timeout".

## Root Cause

The `TwitchChatAdapter.connect()` receives an empty token (`""`):
```
PASS oauth:\r\n
```
Twitch IRC requires a valid OAuth token — empty token causes timeout.

## Fix

- Chat stream route now retrieves the user's Twitch OAuth token from `TokenStore.getToken()` and passes it through `PlatformConnectInfo`
- `MessageAggregator` passes the token to `adapter.connect(channelName, token)` instead of `adapter.connect(channelName, "")`

## Risk: 🟢 Low

- Only affects Twitch chat connection
- Falls back to empty token if fetch fails (same behavior as before)
- TypeScript check passes clean

Closes #N