### PR TITLE
fix: prevent chat message duplication on SSE reconnect

### DIFF
--- a/src/hooks/use-chat-sse.ts
+++ b/src/hooks/use-chat-sse.ts
@@ -94,7 +94,10 @@ export function useChatSSE(_platforms: string[]): UseChatSSEReturn {
             if (!mountedRef.current) return
             try {
                 const message: SSEChatMessage = JSON.parse(event.data)
-                setMessages(prev => [...prev, message])
+                setMessages(prev => {
+                    if (prev.some(m => m.id === message.id)) return prev
+                    return [...prev, message]
+                })
             } catch (parseError) {
                 logger.warn("Failed to parse SSE message", {
                     error: String(parseError),

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -29,6 +29,8 @@ const ADAPTER_REGISTRY: Record<ChatPlatform, () => ChatAdapter> = {
 }
 
 export class MessageAggregator {
+    private static instances = new Map<string, MessageAggregator>()
+
     private userId: string
     private platforms: ChatPlatform[]
     private platformConnect: PlatformConnectInfo
@@ -53,6 +55,16 @@ export class MessageAggregator {
             logger.debug("Aggregator already started", { userId: this.userId })
             return
         }
+
+        // Stop any existing aggregator for this user to prevent duplicates
+        const existing = MessageAggregator.instances.get(this.userId)
+        if (existing && existing !== this) {
+            logger.info("Stopping previous aggregator for user", {
+                userId: this.userId,
+            })
+            await existing.stop()
+        }
+        MessageAggregator.instances.set(this.userId, this)
 
         this.started = true
         logger.info("Starting message aggregator", {
@@ -181,6 +193,12 @@ export class MessageAggregator {
         }
 
         this.adapters.clear()
+
+        // Remove from registry if this is the current instance
+        if (MessageAggregator.instances.get(this.userId) === this) {
+            MessageAggregator.instances.delete(this.userId)
+        }
+
         logger.info("Message aggregator stopped", { userId: this.userId })
     }
 


### PR DESCRIPTION
## Context

Chat messages appear multiplied (2-4x duplicates). Root cause: SSE connection drops every ~10s due to Vercel serverless function timeout, client reconnects, but old IRC connections are never cleaned up.

## Root Cause

1. Vercel Hobby plan serverless functions have a 10s timeout
2. SSE stream drops → client reconnects after 1s
3. New HTTP request → new SSE stream → new Twitch IRC connection
4. **Old aggregator's `request.signal.abort` never fires** — Vercel doesn't reliably propagate abort in serverless
5. Multiple Twitch IRC connections accumulate, all receiving same messages
6. Each broadcasts to all active SSE connections → messages × N

## Fix

### Server: Singleton aggregator per userId
`MessageAggregator` now has a static `instances` Map. When `start()` is called, it stops any previous aggregator for the same userId before starting a new one. This prevents multiple IRC connections regardless of whether the abort signal fired.

### Client: Deduplication by message ID
`useChatSSE` now checks `prev.some(m => m.id === message.id)` before appending — safety net even if server has edge cases.

## Risk: 🟢 Low
- Only affects chat message deduplication
- Falls back to original behavior (no dedup) if no previous instance exists
- Client-side check by message ID is zero-cost