### PR TITLE
feat: implement chat message send via POST /api/live/chat/send

### DIFF
--- a/src/app/api/live/chat/send/route.ts
+++ b/src/app/api/live/chat/send/route.ts
@@ -1,0 +1,84 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { createLogger } from "@/lib/logger"
+import { createClient } from "@supabase/supabase-js"
+import { NextRequest, NextResponse } from "next/server"
+import { getTokenStore } from "@/lib/token-store"
+import { TwitchChatAdapter } from "@/lib/chat"
+
+const logger = createLogger("ChatSendEndpoint")
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return NextResponse.json(
+                { success: false, error: "UNAUTHORIZED" },
+                { status: 401 }
+            )
+        }
+
+        const userId = session.user.id
+        const body = await request.json()
+        const { platform, message } = body
+
+        if (!platform || !message) {
+            return NextResponse.json(
+                { success: false, error: "MISSING_FIELDS" },
+                { status: 400 }
+            )
+        }
+
+        if (platform !== "twitch") {
+            return NextResponse.json(
+                { success: false, error: "UNSUPPORTED_PLATFORM" },
+                { status: 400 }
+            )
+        }
+
+        const supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+        )
+
+        const { data: network } = await supabase
+            .from("social_networks")
+            .select("platform_username")
+            .eq("user_id", userId)
+            .eq("platform", "twitch")
+            .eq("status", "connected")
+            .single()
+
+        if (!network?.platform_username) {
+            return NextResponse.json(
+                { success: false, error: "TWITCH_NOT_CONNECTED" },
+                { status: 400 }
+            )
+        }
+
+        const tokenStore = getTokenStore()
+        const stored = await tokenStore.getToken(userId, "twitch")
+        if (!stored?.accessToken) {
+            return NextResponse.json(
+                { success: false, error: "NO_TOKEN" },
+                { status: 400 }
+            )
+        }
+
+        const adapter = new TwitchChatAdapter()
+        try {
+            await adapter.connect(network.platform_username, stored.accessToken)
+            await adapter.sendMessage(network.platform_username, message)
+        } finally {
+            await adapter.disconnect(network.platform_username)
+        }
+
+        return NextResponse.json({ success: true })
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("Chat send failed", err)
+        return NextResponse.json(
+            { success: false, error: "SEND_FAILED", message: err.message },
+            { status: 500 }
+        )
+    }
+}

--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -1,18 +1,21 @@
 /**
  * UnifiedChat Component
  * Displays combined chat feed from multiple platforms (Twitch + Kick)
- * Uses SSE backend for real-time messages. Send remains simulated.
+ * Uses SSE backend for real-time messages.
  */
 
 "use client"
 
 import { useChatSSE } from "@/hooks/use-chat-sse"
+import { createLogger } from "@/lib/logger"
 import { useRef, useEffect, useState } from "react"
 
 interface UnifiedChatProps {
     platforms: string[]
     activePlatform: string
 }
+
+const logger = createLogger("UnifiedChat")
 
 export function UnifiedChat({ platforms }: UnifiedChatProps) {
     const { messages, isConnected, error } = useChatSSE(platforms)
@@ -28,10 +31,35 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
     }, [messages])
 
     const handleSend = async () => {
-        if (!input.trim()) return
+        const text = input.trim()
+        if (!text) return
 
-        // Simulated send — POST endpoint not yet implemented
-        setInput("")
+        try {
+            const res = await fetch("/api/live/chat/send", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    platform: selectedPlatform,
+                    message: text,
+                }),
+            })
+
+            if (!res.ok) {
+                const err = await res.json()
+                logger.error("Failed to send message", {
+                    platform: selectedPlatform,
+                    error: err.error,
+                })
+                return
+            }
+
+            setInput("")
+        } catch (error) {
+            logger.error("Failed to send message", {
+                platform: selectedPlatform,
+                error: String(error),
+            })
+        }
     }
 
     const handleTimeout = (_username: string) => {


### PR DESCRIPTION
## Context

Send button in unified chat only cleared the input — no actual request was made ("Simulated send — POST endpoint not yet implemented").

## Changes

### POST /api/live/chat/send
Creates a temporary `TwitchChatAdapter`, connects to IRC with the user's OAuth token, sends the message, and disconnects. Supports:
- Regular messages (`PRIVMSG #channel :message`)
- Commands (e.g. `/timeout user`, `/ban user`)
- Action messages (`/me does something`)

### Frontend
`handleSend` now POSTs to `/api/live/chat/send` with `{ platform, message }` using the selected platform. Falls back to `console.error` on failure without blocking UI.

## Risk: 🟢 Low