### PR TITLE
fix: own chat messages not appearing in SSE feed

### DIFF
--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -51,7 +51,7 @@ const COMMANDS = [
 const logger = createLogger("UnifiedChat")
 
 export function UnifiedChat({ platforms }: UnifiedChatProps) {
-    const { messages, isConnected, error } = useChatSSE(platforms)
+    const { messages, isConnected, error, addMessage } = useChatSSE(platforms)
     const [input, setInput] = useState("")
     const [selectedPlatform, setSelectedPlatform] = useState(
         platforms[0] || "twitch"
@@ -90,6 +90,26 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                 return
             }
 
+            // Inject sent message into feed locally since Twitch echo
+            // goes to the temp connection (not the SSE IRC connection)
+            addMessage({
+                id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
+                channelId: selectedPlatform,
+                platform: selectedPlatform,
+                user: {
+                    id: "self",
+                    username: "ogabrieltoth",
+                    displayName: "ogabrieltoth",
+                    platform: selectedPlatform,
+                    badges: [],
+                    isBroadcaster: true,
+                },
+                content: text,
+                type: "text",
+                timestamp: Date.now(),
+                isAction: text.startsWith("/me "),
+            })
+
             historyRef.current.push(text)
             setInput("")
             setHistoryIndex(-1)
@@ -99,7 +119,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                 error: String(error),
             })
         }
-    }, [input, selectedPlatform])
+    }, [input, selectedPlatform, addMessage])
 
     const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/hooks/use-chat-sse.ts
+++ b/src/hooks/use-chat-sse.ts
@@ -55,6 +55,7 @@ interface UseChatSSEReturn {
     statuses: PlatformStatus[]
     isConnected: boolean
     error: SSEError | null
+    addMessage: (message: SSEChatMessage) => void
 }
 
 const MAX_RECONNECT_DELAY_MS = 30_000
@@ -188,10 +189,18 @@ export function useChatSSE(_platforms: string[]): UseChatSSEReturn {
         }
     }, [connect])
 
+    const addMessage = useCallback((message: SSEChatMessage) => {
+        setMessages(prev => {
+            if (prev.some(m => m.id === message.id)) return prev
+            return [...prev, message]
+        })
+    }, [])
+
     return {
         messages,
         statuses,
         isConnected,
         error,
+        addMessage,
     }
 }


### PR DESCRIPTION
## Context

Messages sent from the site appear on Twitch but not in our own chat feed.

## Root Cause

The send endpoint uses a **temporary** IRC connection (or falls back to one when the aggregator is on a different serverless instance). Twitch echoes the message back to the temp connection, which closes immediately — the echo never reaches the SSE stream's IRC connection.

## Fix

- `useChatSSE` hook now returns an `addMessage()` function
- When the POST `/api/live/chat/send` succeeds, the component injects the sent message directly into the local chat feed via `addMessage()`
- Dedup check (`prev.some(m => m.id === message.id)`) prevents duplicates if the echo eventually arrives