### PR TITLE
fix: echo duplication and chat settings body format

### DIFF
--- a/src/app/api/live/chat/send/route.ts
+++ b/src/app/api/live/chat/send/route.ts
@@ -108,13 +108,13 @@ const COMMANDS: CommandHandler[] = [
         pattern: /^\/slow(?:\s+(\d+))?$/i,
         handler: async (args, api) => {
             const seconds = args[1] ? parseInt(args[1]) : 30
-            return execHelix(api, "PATCH", `/chat/settings?broadcaster_id=${api.broadcasterId}&moderator_id=${api.moderatorId}`, { data: { slow_mode: true, slow_mode_wait_time: seconds } })
+            return execHelix(api, "PATCH", `/chat/settings?broadcaster_id=${api.broadcasterId}&moderator_id=${api.moderatorId}`, { slow_mode: true, slow_mode_wait_time: seconds })
         },
     },
     {
         pattern: /^\/subscribers$/i,
         handler: async (_args, api) => {
-            return execHelix(api, "PATCH", `/chat/settings?broadcaster_id=${api.broadcasterId}&moderator_id=${api.moderatorId}`, { data: { subscriber_mode: true } })
+            return execHelix(api, "PATCH", `/chat/settings?broadcaster_id=${api.broadcasterId}&moderator_id=${api.moderatorId}`, { subscriber_mode: true })
         },
     },
 ]
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         }
 
         // Fallback to IRC for regular messages and /me
-        await MessageAggregator.sendMessage(
+        const sentViaActive = await MessageAggregator.sendMessage(
             userId,
             "twitch",
             network.platform_username,
@@ -224,7 +224,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             stored.accessToken
         )
 
-        return NextResponse.json({ success: true })
+        return NextResponse.json({ success: true, sentViaActive })
     } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error))
         logger.error("Chat send failed", err)

--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -104,25 +104,30 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                 return
             }
 
-            // Inject sent message into feed locally since Twitch echo
-            // goes to the temp connection (not the SSE IRC connection)
-            addMessage({
-                id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
-                channelId: selectedPlatform,
-                platform: selectedPlatform,
-                user: {
-                    id: "self",
-                    username: "ogabrieltoth",
-                    displayName: "ogabrieltoth",
+            const data = await res.json()
+
+            // Only inject locally if the message was sent via temp connection
+            // (no active aggregator to receive the Twitch echo via SSE).
+            // When sentViaActive is true, the echo arrives via SSE.
+            if (!data.sentViaActive) {
+                addMessage({
+                    id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
+                    channelId: selectedPlatform,
                     platform: selectedPlatform,
-                    badges: [],
-                    isBroadcaster: true,
-                },
-                content: text,
-                type: "text",
-                timestamp: Date.now(),
-                isAction: text.startsWith("/me "),
-            })
+                    user: {
+                        id: "self",
+                        username: "ogabrieltoth",
+                        displayName: "ogabrieltoth",
+                        platform: selectedPlatform,
+                        badges: [],
+                        isBroadcaster: true,
+                    },
+                    content: text,
+                    type: "text",
+                    timestamp: Date.now(),
+                    isAction: text.startsWith("/me "),
+                })
+            }
 
             historyRef.current.push(text)
             setInput("")

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -258,14 +258,14 @@ export class MessageAggregator {
         channelName: string,
         message: string,
         token: string
-    ): Promise<void> {
+    ): Promise<boolean> {
         // Prefer active adapter from running aggregator
         const aggregator = MessageAggregator.instances.get(userId)
         if (aggregator?.started) {
             const entry = aggregator.adapters.get(platform)
             if (entry && entry.adapter) {
                 await entry.adapter.sendMessage(channelName, message)
-                return
+                return true
             }
         }
 
@@ -278,6 +278,7 @@ export class MessageAggregator {
         } finally {
             await adapter.disconnect(channelName)
         }
+        return false
     }
 
     /**

--- a/src/lib/twitch/oauth-service.ts
+++ b/src/lib/twitch/oauth-service.ts
@@ -541,7 +541,7 @@ export class TwitchOAuthService {
             non_moderator_chat_delay_duration?: number
         }
     ): Promise<boolean> {
-        const body = { data: settings as Record<string, unknown> }
+        const body = settings as Record<string, unknown>
 
         const params = new URLSearchParams({
             broadcaster_id: broadcasterId,


### PR DESCRIPTION
Fixes two issues:

**1. Message duplication**: MessageAggregator.sendMessage now returns a boolean indicating whether the active aggregator was used. Frontend only injects locally when sentViaActive is false (temp connection path). When the active aggregator is used, Twitch echo arrives via SSE so local injection would create a duplicate.

**2. /slow and /subscribers not working**: PATCH /helix/chat/settings requires a flat JSON body (e.g., `{"slow_mode": true}`), not wrapped in a `data` key. Both the route and TwitchOAuthService.updateChatSettings were using { data: settings } which Twitch silently ignored.
