### PR TITLE
fix: own chat messages not appearing in UI due to unreliable Twitch IRC echo

### DIFF
--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -110,30 +110,27 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                 return
             }
 
-            const data = await res.json()
+            await res.json()
 
-            // Only inject locally if the message was sent via temp connection
-            // (no active aggregator to receive the Twitch echo via SSE).
-            // When sentViaActive is true, the echo arrives via SSE.
-            if (!data.sentViaActive) {
-                addMessage({
-                    id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
-                    channelId: selectedPlatform,
+            // Always inject locally for instant feedback. The SSE echo arrives
+            // asynchronously and is deduplicated by content+user in useChatSSE.
+            addMessage({
+                id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
+                channelId: selectedPlatform,
+                platform: selectedPlatform,
+                user: {
+                    id: "self",
+                    username: "ogabrieltoth",
+                    displayName: "ogabrieltoth",
                     platform: selectedPlatform,
-                    user: {
-                        id: "self",
-                        username: "ogabrieltoth",
-                        displayName: "ogabrieltoth",
-                        platform: selectedPlatform,
-                        badges: [],
-                        isBroadcaster: true,
-                    },
-                    content: text,
-                    type: "text",
-                    timestamp: Date.now(),
-                    isAction: text.startsWith("/me "),
-                })
-            }
+                    badges: [],
+                    isBroadcaster: true,
+                },
+                content: text,
+                type: "text",
+                timestamp: Date.now(),
+                isAction: text.startsWith("/me "),
+            })
 
             historyRef.current.push(text)
             setInput("")

--- a/src/hooks/use-chat-sse.ts
+++ b/src/hooks/use-chat-sse.ts
@@ -60,6 +60,7 @@ interface UseChatSSEReturn {
 
 const MAX_RECONNECT_DELAY_MS = 30_000
 const INITIAL_RECONNECT_DELAY_MS = 1_000
+const DEDUP_WINDOW_MS = 3_000
 
 export function useChatSSE(_platforms: string[]): UseChatSSEReturn {
     const [messages, setMessages] = useState<SSEChatMessage[]>([])
@@ -97,6 +98,20 @@ export function useChatSSE(_platforms: string[]): UseChatSSEReturn {
                 const message: SSEChatMessage = JSON.parse(event.data)
                 setMessages(prev => {
                     if (prev.some(m => m.id === message.id)) return prev
+                    // Dedup by content+user+channel within a short window
+                    // to catch echoes of locally-injected self-sent messages.
+                    if (
+                        prev.some(
+                            m =>
+                                m.user.id === message.user.id &&
+                                m.content === message.content &&
+                                m.channelId === message.channelId &&
+                                Math.abs(m.timestamp - message.timestamp) <
+                                    DEDUP_WINDOW_MS
+                        )
+                    ) {
+                        return prev
+                    }
                     return [...prev, message]
                 })
             } catch (parseError) {


### PR DESCRIPTION
## Problem

Own chat messages were not appearing in the chat UI. When `MessageAggregator.sendMessage()` returned `sentViaActive: true`, the frontend skipped local injection and relied on the Twitch IRC echo arriving via SSE. But Twitch IRC echo is unreliable — messages appeared on Twitch chat but never reached the UI.

## Fix

1. **Always inject locally** — removed the `sentViaActive` guard so messages appear instantly
2. **Content-based dedup** — SSE message handler now deduplicates by `user.id + content + channelId` within 3s window, preventing duplicate display when the echo does arrive

Closes #293