### PR TITLE
fix: stop polling YouTube API to preserve daily quota

### DIFF
--- a/src/app/api/live/chat/stream/route.ts
+++ b/src/app/api/live/chat/stream/route.ts
@@ -68,6 +68,13 @@ export async function GET(request: NextRequest): Promise<Response> {
         for (const network of networks || []) {
             const plat = network.platform as "twitch" | "kick" | "youtube"
             if (plat === "twitch" || plat === "kick" || plat === "youtube") {
+                // Skip YouTube channels without chatroomId to avoid API quota waste
+                if (plat === "youtube") {
+                    const meta = network.metadata as Record<string, unknown> | null
+                    if (!meta?.chatroomId) {
+                        continue
+                    }
+                }
                 const info: { channelName: string; token?: string } = {
                     channelName: network.platform_username || plat,
                 }

--- a/src/app/api/live/status/route.ts
+++ b/src/app/api/live/status/route.ts
@@ -461,19 +461,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
                     break
                 }
 
-                case "youtube": {
-                    const ytAccessToken = await getValidAccessToken(userId, "youtube")
-                    if (ytAccessToken) {
-                        const youtubeData = await fetchYouTubeLive(
-                            ytAccessToken,
-                            network.platform_user_id || ""
-                        )
-                        platforms.push({ ...baseInfo, ...youtubeData })
-                    } else {
-                        platforms.push(baseInfo)
-                    }
+                case "youtube":
+                    // Skip YouTube API calls to preserve quota (search endpoint costs 100 units each)
+                    platforms.push(baseInfo)
                     break
-                }
 
                 case "facebook":
                     if (pageAccessToken) {


### PR DESCRIPTION
## Problem

YouTube Data API v3 free tier has 10,000 quota units/day. `youtube/v3/search` costs **100 units** per call. With 2 YouTube channels being polled every dashboard load, quota was exhausted in minutes (error 403 quotaExceeded).

## Changes

- **Status route** (`GET /api/live/status`): removed `fetchYouTubeLive()` calls entirely. YouTube now returns basic info (username, avatar) with `isLive: false` — no API calls made.
- **Stream route** (`GET /api/live/chat/stream`): only attempts YouTube chat connection for channels that have `chatroomId` in metadata. Channels without it (e.g., the main channel that doesn't stream) are skipped entirely.

## Rationale

YouTube live status can be determined reactively (e.g., when a chat message arrives on the Live channel) rather than by polling. For persistent WebSocket connections, the .203 machine can be used later as a relay.

Closes # (no issue)