### PR TITLE
Add dedicated WebSocket relay server with Cloudflare Tunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ audit2.json
 
 # Test output files
 test-output.txt
+.env*.local

--- a/relay/setup-tunnel.ps1
+++ b/relay/setup-tunnel.ps1
@@ -1,0 +1,116 @@
+param(
+    [string]$TunnelName = "gabrieltoth-relay",
+    [string]$Domain = "relay.gabrieltoth.com",
+    [string]$RelayPort = "3100"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Log($msg) {
+    Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $msg" -ForegroundColor Cyan
+}
+
+function CheckLastExit {
+    if (-not $?) { throw "Last command failed" }
+}
+
+Log "=== Cloudflare Tunnel Setup for Relay Server ==="
+Log "Tunnel: $TunnelName"
+Log "Domain: $Domain"
+Log "Relay port: $RelayPort"
+
+# ─── Step 1: Check cloudflared ────────────────────────────
+Log "Step 1: Checking cloudflared..."
+
+$cf = Get-Command cloudflared -ErrorAction SilentlyContinue
+if (-not $cf) {
+    Log "cloudflared not found. Installing via winget..."
+    winget install --id Cloudflare.cloudflared --silent
+    CheckLastExit
+    $env:Path = [Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + $env:Path
+    Log "cloudflared installed. Please restart PowerShell and re-run this script."
+    exit 1
+}
+
+$version = & cloudflared --version
+Log "cloudflared found: $version"
+
+# ─── Step 2: Authenticate ─────────────────────────────────
+Log "Step 2: Authenticating cloudflared with Cloudflare..."
+Log "A browser window will open. Log in to Cloudflare and authorize."
+& cloudflared tunnel login
+CheckLastExit
+Log "Authentication complete."
+
+# ─── Step 3: Create tunnel ────────────────────────────────
+Log "Step 3: Creating tunnel '$TunnelName'..."
+$existing = & cloudflared tunnel list 2>&1 | Select-String $TunnelName
+if ($existing) {
+    Log "Tunnel '$TunnelName' already exists. Skipping creation."
+} else {
+    & cloudflared tunnel create $TunnelName
+    CheckLastExit
+    Log "Tunnel created."
+}
+
+# ─── Step 4: Get tunnel ID ────────────────────────────────
+Log "Step 4: Getting tunnel ID..."
+$list = & cloudflared tunnel list --output json
+$tunnels = $list | ConvertFrom-Json
+$tunnel = $tunnels | Where-Object { $_.Name -eq $TunnelName } | Select-Object -First 1
+if (-not $tunnel) {
+    throw "Tunnel '$TunnelName' not found in list"
+}
+$tunnelId = $tunnel.Id
+$tunnelFile = "$env:USERPROFILE\.cloudflared\$tunnelId.json"
+Log "Tunnel ID: $tunnelId"
+
+# ─── Step 5: Write config.yml ─────────────────────────────
+Log "Step 5: Writing config.yml..."
+$configPath = "$env:USERPROFILE\.cloudflared\config.yml"
+$config = @"
+tunnel: $tunnelId
+credentials-file: $tunnelFile
+
+ingress:
+  - hostname: $Domain
+    service: http://localhost:$RelayPort
+    originRequest:
+      noTLSVerify: true
+  - service: http_status:404
+"@
+Set-Content -Path $configPath -Value $config -Encoding UTF8
+Log "Config written to $configPath"
+
+# ─── Step 6: Route DNS ────────────────────────────────────
+Log "Step 6: Routing DNS for $Domain -> tunnel..."
+& cloudflared tunnel route dns $TunnelName $Domain
+CheckLastExit
+Log "DNS routed."
+
+# ─── Step 7: Install as Windows service ───────────────────
+Log "Step 7: Installing cloudflared as Windows service..."
+$existingSvc = Get-Service cloudflared -ErrorAction SilentlyContinue
+if ($existingSvc) {
+    Log "Service 'cloudflared' already exists. Stopping + restarting..."
+    & cloudflared service uninstall
+    CheckLastExit
+}
+& cloudflared service install
+CheckLastExit
+Start-Service cloudflared
+CheckLastExit
+Log "Service installed and started."
+
+# ─── Verify ────────────────────────────────────────────────
+Start-Sleep -Seconds 3
+$svc = Get-Service cloudflared
+Log "Service status: $($svc.Status)"
+Log ""
+Log "=== Setup complete ==="
+Log "Next steps on your dev machine:"
+Log "1. Set Vercel env: vercel env add NEXT_PUBLIC_RELAY_WS_URL wss://$Domain"
+Log "2. Remove old env: vercel env rm YOUTUBE_RELAY_WS_URL"
+Log "3. Redeploy: vercel --prod"
+Log ""
+Log "Your relay server is now accessible at: wss://$Domain"

--- a/relay/src/jwt-verify.js
+++ b/relay/src/jwt-verify.js
@@ -1,0 +1,43 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+
+function base64urlDecode(str) {
+  str = str.replace(/-/g, "+").replace(/_/g, "/")
+  while (str.length % 4) str += "="
+  return Buffer.from(str, "base64")
+}
+
+export function verifyJwt(token, secret) {
+  const parts = token.split(".")
+  if (parts.length !== 3) {
+    throw new Error("Invalid JWT format")
+  }
+
+  const [headerB64, payloadB64, signatureB64] = parts
+
+  const expectedSig = createHmac("sha256", secret)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest("base64url")
+
+  const actualSig = signatureB64
+
+  const expectedBuf = Buffer.from(expectedSig, "utf8")
+  const actualBuf = Buffer.from(actualSig, "utf8")
+
+  if (expectedBuf.length !== actualBuf.length || !timingSafeEqual(expectedBuf, actualBuf)) {
+    throw new Error("Invalid JWT signature")
+  }
+
+  let payload
+  try {
+    const decoded = base64urlDecode(payloadB64)
+    payload = JSON.parse(decoded.toString("utf8"))
+  } catch {
+    throw new Error("Invalid JWT payload")
+  }
+
+  if (payload.exp && Date.now() >= payload.exp * 1000) {
+    throw new Error("JWT expired")
+  }
+
+  return payload
+}

--- a/relay/src/server-updated.js
+++ b/relay/src/server-updated.js
@@ -1,0 +1,447 @@
+import { createServer } from "node:http"
+import { WebSocketServer } from "ws"
+import { config } from "dotenv"
+import { createLogger } from "./lib/logger.js"
+import { TwitchIrcClient } from "./lib/twitch-irc.js"
+import { KickChatClient } from "./lib/kick-chat.js"
+import { YouTubeStreamListRelay } from "./lib/youtube-relay.js"
+import { getCachedImage, getContentType, cleanExpired } from "./lib/image-cache.js"
+import { verifyJwt } from "./lib/jwt-verify.js"
+
+config()
+
+const logger = createLogger("WSServer")
+
+const PORT = parseInt(process.env.WS_PORT || "3100", 10)
+const PING_INTERVAL = 30000
+const CACHE_CLEAN_INTERVAL = 24 * 60 * 60 * 1000
+
+const ALLOWED_ORIGINS = [
+  "https://gabrieltoth.com",
+  "https://ws.gabrieltoth.com",
+  "http://localhost:3000",
+  "http://localhost:3100",
+]
+
+function isLanAddress(ip) {
+  const parts = ip.split(".").map(Number)
+  if (parts.length !== 4) return false
+  const first = parts[0]
+  if (first === 10 || first === 127) return true
+  if (first === 172 && parts[1] >= 16 && parts[1] <= 31) return true
+  if (first === 192 && parts[1] === 168) return true
+  return false
+}
+
+function isLocalRequest(info) {
+  const remote = (info.req.socket.remoteAddress || "").replace(/^::ffff:/, "")
+  const cfIp = info.req.headers["cf-connecting-ip"] || ""
+  if (isLanAddress(remote)) return true
+  if (cfIp && isLanAddress(cfIp)) return true
+  return false
+}
+
+const STARTED_AT = Date.now()
+
+function getStatus(connections) {
+  const values = Array.from(connections.values())
+  const twitchStatus = values.some(c => c.twitchConnected) ? "connected" : "disconnected"
+  const kickStatus = values.some(c => c.kickConnected) ? "connected" : "disconnected"
+  const youtubeStatus = values.some(c => c.youtubeConnected) ? "connected" : "disconnected"
+  return {
+    status: "online",
+    uptime: Math.floor((Date.now() - STARTED_AT) / 1000),
+    clients: connections.size,
+    twitch: twitchStatus,
+    kick: kickStatus,
+    youtube: youtubeStatus,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+async function serveCachedImage(res, platform, name, type) {
+  const fetcherMap = {
+    "twitch:avatar": async () => {
+      const r = await fetch(`https://api.twitch.tv/helix/users?login=${name}`, {
+        headers: { "Client-Id": process.env.TWITCH_CLIENT_ID || "", Authorization: `Bearer ${process.env.TWITCH_APP_TOKEN || ""}` },
+      })
+      if (!r.ok) throw new Error(`Twitch API ${r.status}`)
+      const d = await r.json()
+      if (!d.data?.[0]?.profile_image_url) throw new Error("no avatar")
+      const img = await fetch(d.data[0].profile_image_url)
+      return Buffer.from(await img.arrayBuffer())
+    },
+    "kick:avatar": async () => {
+      const r = await fetch(`https://kick.com/api/v2/channels/${name}`, {
+        headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" },
+      })
+      if (!r.ok) throw new Error(`Kick API ${r.status}`)
+      const d = await r.json()
+      const url = d.user?.profile_picture || d.banner_picture || ""
+      if (!url) throw new Error("no avatar")
+      const img = await fetch(url)
+      return Buffer.from(await img.arrayBuffer())
+    },
+    "twitch:thumbnail": async () => {
+      const r = await fetch(`https://api.twitch.tv/helix/streams?user_login=${name}`, {
+        headers: { "Client-Id": process.env.TWITCH_CLIENT_ID || "", Authorization: `Bearer ${process.env.TWITCH_APP_TOKEN || ""}` },
+      })
+      if (!r.ok) throw new Error(`Twitch API ${r.status}`)
+      const d = await r.json()
+      const tmpl = d.data?.[0]?.thumbnail_url
+      if (!tmpl) throw new Error("offline")
+      const url = tmpl.replace("{width}", "640").replace("{height}", "360")
+      const img = await fetch(url)
+      return Buffer.from(await img.arrayBuffer())
+    },
+    "kick:thumbnail": async () => {
+      const r = await fetch(`https://kick.com/api/v2/channels/${name}`, {
+        headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" },
+      })
+      if (!r.ok) throw new Error(`Kick API ${r.status}`)
+      const d = await r.json()
+      const url = d.livestream?.thumbnail?.url || d.banner_picture || ""
+      if (!url) throw new Error("no thumbnail")
+      const img = await fetch(url)
+      return Buffer.from(await img.arrayBuffer())
+    },
+  }
+
+  const key = `${platform}:${type}`
+  const fetcher = fetcherMap[key]
+  if (!fetcher) {
+    res.writeHead(400)
+    res.end()
+    return
+  }
+
+  const result = await getCachedImage(platform, name, type, fetcher)
+  if (!result) {
+    res.writeHead(404)
+    res.end()
+    return
+  }
+
+  if (result instanceof Buffer) {
+    res.writeHead(200, {
+      "Content-Type": getContentType(result),
+      "Cache-Control": "public, max-age=86400",
+      "Access-Control-Allow-Origin": "*",
+    })
+    res.end(result)
+  } else {
+    res.writeHead(200, {
+      "Cache-Control": "public, max-age=86400",
+      "Access-Control-Allow-Origin": "*",
+    })
+    result.pipe(res)
+  }
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost")
+
+  if (url.pathname === "/health" || url.pathname === "/") {
+    const data = getStatus(connections)
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    })
+    res.end(JSON.stringify(data, null, 2))
+    return
+  }
+
+  const cacheMatch = url.pathname.match(/^\/cache\/(avatars|thumbnails)\/(twitch|kick)\/(.+)$/)
+  if (cacheMatch) {
+    const [, type, platform, name] = cacheMatch
+    serveCachedImage(res, platform, name, type === "thumbnails" ? "thumbnail" : "avatar")
+    return
+  }
+
+  res.writeHead(404)
+  res.end()
+})
+
+const wss = new WebSocketServer({
+  server,
+  verifyClient: (info, cb) => {
+    const origin = info.origin || info.req.headers.origin || ""
+    if (ALLOWED_ORIGINS.includes(origin)) return cb(true)
+    if (isLocalRequest(info)) return cb(true)
+    logger.warn("Connection rejected by origin", { origin, remote: info.req.socket.remoteAddress })
+    cb(false, 403, "Forbidden")
+  },
+})
+
+const connections = new Map()
+const youtubeRelays = new Map()
+
+wss.on("connection", (ws, req) => {
+  const url = new URL(req.url, "http://localhost")
+  const tokenParam = url.searchParams.get("token") || ""
+
+  let twitchToken = ""
+  let kickToken = ""
+  let twitchUsername = ""
+  let kickUsername = ""
+  let userId = ""
+
+  if (tokenParam) {
+    try {
+      const secret = process.env.OAUTH_STATE_SECRET
+      if (secret) {
+        const decoded = verifyJwt(tokenParam, secret)
+        userId = decoded.sub || ""
+        if (decoded.twitch?.accessToken) {
+          twitchToken = decoded.twitch.accessToken
+          twitchUsername = decoded.twitch.username || ""
+        }
+        if (decoded.kick?.accessToken) {
+          kickToken = decoded.kick.accessToken
+          kickUsername = decoded.kick.username || ""
+        }
+        logger.info("JWT verified for user", { userId, platforms: Object.keys(decoded).filter(k => k !== "sub" && k !== "iat" && k !== "exp") })
+      }
+    } catch (err) {
+      logger.warn("JWT verification failed", { error: err.message })
+      ws.send(JSON.stringify({ type: "error", platform: "auth", error: "Invalid token" }))
+    }
+  }
+
+  const connInfo = {
+    userId,
+    twitchToken,
+    kickToken,
+    twitchUsername,
+    kickUsername,
+    connectedAt: Date.now(),
+    twitchConnected: false,
+    kickConnected: false,
+    youtubeConnected: false,
+  }
+
+  connections.set(ws, connInfo)
+
+  const channels = []
+  if (twitchUsername) channels.push(twitchUsername.toLowerCase())
+  if (kickUsername) channels.push(kickUsername.toLowerCase())
+
+  ws.send(JSON.stringify({
+    type: "connected",
+    data: { server: "gabrieltoth-ws", userId, channels },
+  }))
+
+  const twitch = new TwitchIrcClient()
+  const kick = new KickChatClient()
+
+  if (twitchToken && twitchUsername) {
+    twitch.connect([twitchUsername.toLowerCase()], twitchToken)
+    twitch.on("message", (msg) => {
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify(msg))
+      }
+    })
+    twitch.on("connected", () => {
+      connInfo.twitchConnected = true
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "status", platform: "twitch", connected: true }))
+      }
+    })
+    twitch.on("disconnected", () => {
+      connInfo.twitchConnected = false
+    })
+  }
+
+  if (kickToken && kickUsername) {
+    kick.connect([kickUsername.toLowerCase()], kickToken)
+    kick.on("message", (msg) => {
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify(msg))
+      }
+    })
+    kick.on("connected", () => {
+      connInfo.kickConnected = true
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "status", platform: "kick", connected: true }))
+      }
+    })
+    kick.on("disconnected", () => {
+      connInfo.kickConnected = false
+    })
+  }
+
+  ws.on("message", async (raw) => {
+    try {
+      const msg = JSON.parse(raw.toString())
+
+      if (msg.type === "send") {
+        const platform = msg.platform || ""
+        const text = msg.text || ""
+        const channel = msg.channel || ""
+        if (platform === "twitch" && twitchToken && channel) {
+          twitch.send(channel, text, twitchToken)
+        }
+        if (platform === "kick" && kickToken && channel) {
+          kick.send(channel, text, kickToken)
+        }
+        return
+      }
+
+      if (msg.type === "connect" && msg.platform === "youtube") {
+        await handleYouTubeConnect(ws, connInfo, msg.token, msg.liveChatId)
+        return
+      }
+
+      if (msg.type === "disconnect" && msg.platform === "youtube") {
+        handleYouTubeDisconnect(ws, connInfo)
+        return
+      }
+    } catch { /* ignore bad messages */ }
+  })
+
+  ws.on("close", () => {
+    handleYouTubeDisconnect(ws, connInfo)
+    connections.delete(ws)
+    twitch.disconnect()
+    kick.disconnect()
+  })
+
+  ws.on("error", () => {
+    handleYouTubeDisconnect(ws, connInfo)
+    connections.delete(ws)
+    twitch.disconnect()
+    kick.disconnect()
+  })
+})
+
+async function handleYouTubeConnect(ws, connInfo, token, preferredLiveChatId) {
+  const existing = youtubeRelays.get(ws)
+  if (existing) {
+    existing.stop()
+    youtubeRelays.delete(ws)
+  }
+
+  if (!token) {
+    ws.send(JSON.stringify({
+      type: "error",
+      platform: "youtube",
+      error: "No YouTube OAuth token provided",
+    }))
+    return
+  }
+
+  const relay = new YouTubeStreamListRelay(token)
+
+  relay.on("connected", (liveChatId) => {
+    logger.info("YouTube gRPC stream connected", { liveChatId, userId: connInfo.userId })
+    youtubeRelays.set(ws, relay)
+    connInfo.youtubeConnected = true
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        type: "status",
+        platform: "youtube",
+        connected: true,
+        liveChatId,
+      }))
+    }
+  })
+
+  relay.on("message", (msg) => {
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        event: "youtube:message",
+        platform: "youtube",
+        id: msg.id,
+        channelId: msg.channelId,
+        user: msg.user,
+        content: msg.content,
+        msgType: msg.type,
+        timestamp: msg.timestamp,
+      }))
+    }
+  })
+
+  relay.on("disconnected", (reason) => {
+    logger.info("YouTube gRPC stream disconnected", { reason, userId: connInfo.userId })
+    connInfo.youtubeConnected = false
+    youtubeRelays.delete(ws)
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        type: "status",
+        platform: "youtube",
+        connected: false,
+        reason,
+      }))
+    }
+  })
+
+  relay.on("reconnecting", (attempt, delay) => {
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        type: "reconnecting",
+        platform: "youtube",
+        attempt,
+        delay,
+      }))
+    }
+  })
+
+  relay.on("error", (error) => {
+    logger.error("YouTube gRPC error", { error: error.message, userId: connInfo.userId })
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        type: "error",
+        platform: "youtube",
+        error: error.message,
+      }))
+    }
+  })
+
+  try {
+    await relay.start()
+  } catch (error) {
+    logger.error("YouTube relay start failed", { error: error.message, userId: connInfo.userId })
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify({
+        type: "error",
+        platform: "youtube",
+        error: error.message,
+      }))
+    }
+  }
+}
+
+function handleYouTubeDisconnect(ws, connInfo) {
+  const relay = youtubeRelays.get(ws)
+  if (relay) {
+    relay.stop()
+    youtubeRelays.delete(ws)
+  }
+  connInfo.youtubeConnected = false
+  if (ws.readyState === 1) {
+    ws.send(JSON.stringify({
+      type: "status",
+      platform: "youtube",
+      connected: false,
+    }))
+  }
+}
+
+const interval = setInterval(() => {
+  for (const ws of wss.clients) {
+    if (ws.readyState === 1) {
+      ws.ping()
+    }
+  }
+}, PING_INTERVAL)
+
+const cacheClean = setInterval(cleanExpired, CACHE_CLEAN_INTERVAL)
+
+wss.on("close", () => {
+  clearInterval(interval)
+  clearInterval(cacheClean)
+})
+
+server.listen(PORT, "0.0.0.0", () => {
+  logger.info(`WebSocket server listening on 0.0.0.0:${PORT}`)
+})

--- a/relay/start-relay.ps1
+++ b/relay/start-relay.ps1
@@ -1,0 +1,1 @@
+Start-Process -FilePath "C:\ProgramData\nvm\nodejs\node.exe" -ArgumentList "C:\relay\dist\relay-server.js" -WorkingDirectory "C:\relay" -NoNewWindow -RedirectStandardOutput "C:\relay\relay.log" -RedirectStandardError "C:\relay\relay.err"

--- a/src/app/api/auth/relay-token/route.ts
+++ b/src/app/api/auth/relay-token/route.ts
@@ -1,0 +1,109 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { createLogger } from "@/lib/logger"
+import { createClient } from "@supabase/supabase-js"
+import jwt from "jsonwebtoken"
+import { NextRequest } from "next/server"
+import { getTokenStore } from "@/lib/token-store"
+import { isTerminalTokenError, markAccountDisconnected } from "@/lib/auth/token-health"
+
+const logger = createLogger("RelayTokenEndpoint")
+
+export async function GET(request: NextRequest): Promise<Response> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return new Response(
+                JSON.stringify({ success: false, error: "UNAUTHORIZED" }),
+                { status: 401, headers: { "Content-Type": "application/json" } }
+            )
+        }
+
+        const secret = process.env.JWT_SECRET || process.env.OAUTH_STATE_SECRET
+        if (!secret) {
+            logger.error("Relay: JWT_SECRET not configured")
+            return new Response(
+                JSON.stringify({ success: false, error: "SERVER_CONFIG_ERROR" }),
+                { status: 500, headers: { "Content-Type": "application/json" } }
+            )
+        }
+
+        const userId = session.user.id
+        const relayToken = jwt.sign({ sub: userId }, secret, {
+            algorithm: "HS256",
+            expiresIn: "5m",
+        })
+
+        const supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+        )
+
+        const { data: networks } = await supabase
+            .from("social_networks")
+            .select("platform, platform_username")
+            .eq("user_id", userId)
+            .eq("status", "connected")
+            .in("platform", ["youtube", "twitch", "kick"])
+
+        const platforms: Record<string, { channelName: string; accessToken?: string }> = {}
+
+        for (const network of networks || []) {
+            const plat = network.platform
+            const info: { channelName: string; accessToken?: string } = {
+                channelName: network.platform_username || plat,
+            }
+
+            try {
+                const tokenStore = getTokenStore()
+                let stored = await tokenStore.getToken(userId, plat)
+
+                if (plat === "youtube" && stored?.refreshToken && stored.expiresAt && stored.expiresAt < Date.now()) {
+                    try {
+                        const { getYouTubeOAuthService } = await import("@/lib/youtube/oauth-service")
+                        const { getYouTubeChannelLinkingConfig } = await import("@/lib/youtube/config")
+                        const { validateEnv } = await import("@/lib/config/env")
+                        const config = getYouTubeChannelLinkingConfig(validateEnv())
+                        const oauth = getYouTubeOAuthService(config)
+                        await oauth.initialize()
+                        const refreshed = await oauth.refreshAccessToken(stored.refreshToken)
+                        const expiresAt = Date.now() + refreshed.expiresIn * 1000
+                        await tokenStore.refreshToken(userId, "youtube", {
+                            accessToken: refreshed.accessToken,
+                            refreshToken: refreshed.refreshToken,
+                            expiresAt,
+                            platform: "youtube",
+                            userId,
+                        })
+                        stored = await tokenStore.getToken(userId, "youtube")
+                    } catch (err) {
+                        const msg = err instanceof Error ? err.message : String(err)
+                        logger.error("YouTube token refresh failed", { userId, error: msg })
+                        if (isTerminalTokenError(msg)) {
+                            await markAccountDisconnected(userId, "youtube").catch(() => {})
+                        }
+                    }
+                }
+
+                if (stored?.accessToken) {
+                    info.accessToken = stored.accessToken
+                }
+            } catch (tokenErr) {
+                logger.warn(`Failed to retrieve ${plat} token`, { userId, error: String(tokenErr) })
+            }
+
+            platforms[plat] = info
+        }
+
+        return new Response(
+            JSON.stringify({ success: true, token: relayToken, platforms }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("Relay token endpoint error", err)
+        return new Response(
+            JSON.stringify({ success: false, error: "INTERNAL_ERROR" }),
+            { status: 500, headers: { "Content-Type": "application/json" } }
+        )
+    }
+}

--- a/src/app/api/live/chat/send/route.ts
+++ b/src/app/api/live/chat/send/route.ts
@@ -152,7 +152,6 @@ const COMMANDS: CommandHandler[] = [
             )
         },
     },
-    // /slow [seconds], /slow on|off, /slowon, /slowoff
     {
         pattern: /^\/slow(?: (?:(\d+)|on|off))?$/i,
         handler: async (args, api) => {
@@ -204,7 +203,6 @@ const COMMANDS: CommandHandler[] = [
             )
         },
     },
-    // Subscribers mode — all aliases, enable/disable
     {
         pattern: /^\/subscribersoff$/i,
         handler: async (_args, api) => {
@@ -279,6 +277,82 @@ async function tryHelixCommand(
     return null
 }
 
+async function sendTwitchMessage(
+    userId: string,
+    channelName: string,
+    message: string,
+    token: string,
+    platformUserId: string
+): Promise<NextResponse> {
+    const config = getTwitchConfig()
+    const api: HelixApi = {
+        accessToken: token,
+        broadcasterId: platformUserId,
+        moderatorId: platformUserId,
+        clientId: config.oauth.clientId,
+    }
+
+    const helixResult = await tryHelixCommand(message, api)
+    if (helixResult) {
+        if (helixResult.ok) {
+            return NextResponse.json({ success: true })
+        }
+        if (helixResult.twitchStatus === 403) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "MISSING_SCOPE",
+                    message:
+                        "Twitch token missing required scope. Reconnect your Twitch account in Settings.",
+                },
+                { status: 403 }
+            )
+        }
+        return NextResponse.json(
+            {
+                success: false,
+                error: "MOD_COMMAND_FAILED",
+                message: helixResult.twitchError || "Twitch API error",
+            },
+            { status: 500 }
+        )
+    }
+
+    const sentViaActive = await MessageAggregator.sendMessage(
+        userId,
+        "twitch",
+        channelName,
+        message,
+        token
+    )
+    return NextResponse.json({ success: true, sentViaActive })
+}
+
+async function sendKickMessage(
+    userId: string,
+    channelName: string,
+    message: string,
+    token: string
+): Promise<NextResponse> {
+    try {
+        const sentViaActive = await MessageAggregator.sendMessage(
+            userId,
+            "kick",
+            channelName,
+            message,
+            token
+        )
+        return NextResponse.json({ success: true, sentViaActive })
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("Kick send failed", err)
+        return NextResponse.json(
+            { success: false, error: "KICK_SEND_FAILED", message: err.message },
+            { status: 500 }
+        )
+    }
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
         const session = await getServerSession(request)
@@ -300,208 +374,38 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             )
         }
 
-        const supabase = createClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
-            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
-        )
-
-        if (platform === "kick") {
-            const tokenStore = getTokenStore()
-            const stored = await tokenStore.getToken(userId, "kick")
-            if (!stored?.accessToken) {
-                return NextResponse.json(
-                    { success: false, error: "NO_TOKEN" },
-                    { status: 400 }
-                )
-            }
-
-            const { data: kickNetwork } = await supabase
-                .from("social_networks")
-                .select("metadata")
-                .eq("user_id", userId)
-                .eq("platform", "kick")
-                .eq("status", "connected")
-                .single()
-
-            const broadcasterUserId = kickNetwork?.metadata?.channelId
-
-            const body: Record<string, unknown> = {
-                content: message,
-                type: "user",
-            }
-            if (broadcasterUserId) {
-                body.broadcaster_user_id = parseInt(String(broadcasterUserId), 10)
-            }
-
-            const response = await fetch(
-                "https://api.kick.com/public/v1/chat",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${stored.accessToken}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify(body),
-                }
-            )
-
-            if (!response.ok) {
-                const errorBody = await response.text()
-                logger.error("Kick send message failed", {
-                    status: response.status,
-                    body: errorBody,
-                })
-                return NextResponse.json(
-                    { success: false, error: "KICK_SEND_FAILED" },
-                    { status: 500 }
-                )
-            }
-
-            return NextResponse.json({ success: true })
-        }
-
-        if (platform === "youtube") {
-            const tokenStore = getTokenStore()
-            let stored = await tokenStore.getToken(userId, "youtube")
-            if (!stored?.accessToken) {
-                return NextResponse.json(
-                    { success: false, error: "NO_TOKEN" },
-                    { status: 400 }
-                )
-            }
-
-            // Auto-refresh expired token
-            if (stored.refreshToken && stored.expiresAt && stored.expiresAt < Date.now()) {
-                try {
-                    const { getYouTubeOAuthService } = await import("@/lib/youtube/oauth-service")
-                    const { getYouTubeChannelLinkingConfig } = await import("@/lib/youtube/config")
-                    const { validateEnv } = await import("@/lib/config/env")
-                    const ytConfig = getYouTubeChannelLinkingConfig(validateEnv())
-                    const ytOAuth = getYouTubeOAuthService(ytConfig)
-                    await ytOAuth.initialize()
-                    const refreshed = await ytOAuth.refreshAccessToken(stored.refreshToken)
-                    const expiresAt = Date.now() + refreshed.expiresIn * 1000
-                    await tokenStore.refreshToken(userId, "youtube", {
-                        accessToken: refreshed.accessToken,
-                        refreshToken: refreshed.refreshToken,
-                        expiresAt,
-                        platform: "youtube",
-                        userId,
-                    })
-                    stored = await tokenStore.getToken(userId, "youtube")
-                } catch (err) {
-                    const errMsg = err instanceof Error ? err.message : String(err)
-                    logger.error("YouTube token refresh failed", { error: errMsg })
-                    const { isTerminalTokenError, markAccountDisconnected } = await import("@/lib/auth/token-health")
-                    if (isTerminalTokenError(errMsg)) {
-                        await markAccountDisconnected(userId, "youtube").catch(() => {})
-                    }
-                    return NextResponse.json(
-                        { success: false, error: "TOKEN_REFRESH_FAILED" },
-                        { status: 401 }
-                    )
-                }
-            }
-
-            if (!stored?.accessToken) {
-                return NextResponse.json(
-                    { success: false, error: "NO_TOKEN" },
-                    { status: 400 }
-                )
-            }
-
-            const ytAccessToken = stored.accessToken
-
-            // Find the active live broadcast to get liveChatId
-            const broadcastResponse = await fetch(
-                "https://www.googleapis.com/youtube/v3/liveBroadcasts?part=snippet,status&mine=true",
-                {
-                    headers: {
-                        Authorization: `Bearer ${ytAccessToken}`,
-                    },
-                }
-            )
-
-            if (!broadcastResponse.ok) {
-                return NextResponse.json(
-                    { success: false, error: "YOUTUBE_API_ERROR" },
-                    { status: 500 }
-                )
-            }
-
-            const broadcastData = await broadcastResponse.json()
-            const activeBroadcast = broadcastData.items?.find(
-                (item: { status?: { lifeCycleStatus?: string } }) =>
-                    item.status?.lifeCycleStatus === "live"
-            )
-            const liveChatId = activeBroadcast?.snippet?.liveChatId
-
-            if (!liveChatId) {
-                return NextResponse.json(
-                    { success: false, error: "NO_LIVE_CHAT" },
-                    { status: 400 }
-                )
-            }
-
-            const response = await fetch(
-                "https://www.googleapis.com/youtube/v3/liveChat/messages?part=snippet",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${ytAccessToken}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                        snippet: {
-                            liveChatId,
-                            type: "textMessageEvent",
-                            textMessageDetails: {
-                                messageText: message,
-                            },
-                        },
-                    }),
-                }
-            )
-
-            if (!response.ok) {
-                const errorBody = await response.text()
-                logger.error("YouTube send message failed", {
-                    status: response.status,
-                    body: errorBody,
-                })
-                return NextResponse.json(
-                    { success: false, error: "YOUTUBE_SEND_FAILED" },
-                    { status: 500 }
-                )
-            }
-
-            return NextResponse.json({ success: true })
-        }
-
-        if (platform !== "twitch") {
+        if (platform !== "twitch" && platform !== "kick") {
             return NextResponse.json(
                 { success: false, error: "UNSUPPORTED_PLATFORM" },
                 { status: 400 }
             )
         }
 
+        const supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+        )
+
         const { data: network } = await supabase
             .from("social_networks")
             .select("platform_username, platform_user_id")
             .eq("user_id", userId)
-            .eq("platform", "twitch")
+            .eq("platform", platform)
             .eq("status", "connected")
             .single()
 
         if (!network?.platform_username) {
             return NextResponse.json(
-                { success: false, error: "TWITCH_NOT_CONNECTED" },
+                {
+                    success: false,
+                    error: `${platform.toUpperCase()}_NOT_CONNECTED`,
+                },
                 { status: 400 }
             )
         }
 
         const tokenStore = getTokenStore()
-        const stored = await tokenStore.getToken(userId, "twitch")
+        const stored = await tokenStore.getToken(userId, platform)
         if (!stored?.accessToken) {
             return NextResponse.json(
                 { success: false, error: "NO_TOKEN" },
@@ -509,51 +413,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             )
         }
 
-        // Try Helix API for moderation commands
-        const config = getTwitchConfig()
-        const api: HelixApi = {
-            accessToken: stored.accessToken,
-            broadcasterId: network.platform_user_id,
-            moderatorId: network.platform_user_id,
-            clientId: config.oauth.clientId,
-        }
-
-        const helixResult = await tryHelixCommand(message, api)
-        if (helixResult) {
-            if (helixResult.ok) {
-                return NextResponse.json({ success: true })
-            }
-            if (helixResult.twitchStatus === 403) {
-                return NextResponse.json(
-                    {
-                        success: false,
-                        error: "MISSING_SCOPE",
-                        message:
-                            "Twitch token missing required scope. Reconnect your Twitch account in Settings.",
-                    },
-                    { status: 403 }
-                )
-            }
-            return NextResponse.json(
-                {
-                    success: false,
-                    error: "MOD_COMMAND_FAILED",
-                    message: helixResult.twitchError || "Twitch API error",
-                },
-                { status: 500 }
+        if (platform === "twitch") {
+            return sendTwitchMessage(
+                userId,
+                network.platform_username,
+                message,
+                stored.accessToken,
+                network.platform_user_id
             )
         }
 
-        // Fallback to IRC for regular messages and /me
-        const sentViaActive = await MessageAggregator.sendMessage(
+        return sendKickMessage(
             userId,
-            "twitch",
             network.platform_username,
             message,
             stored.accessToken
         )
-
-        return NextResponse.json({ success: true, sentViaActive })
     } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error))
         logger.error("Chat send failed", err)

--- a/src/app/api/live/chat/ws-token/route.ts
+++ b/src/app/api/live/chat/ws-token/route.ts
@@ -1,0 +1,84 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { createLogger } from "@/lib/logger"
+import { createClient } from "@supabase/supabase-js"
+import { NextRequest, NextResponse } from "next/server"
+import { getTokenStore } from "@/lib/token-store"
+import jwt from "jsonwebtoken"
+
+const logger = createLogger("ChatWSTokenEndpoint")
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return NextResponse.json(
+                { success: false, error: "UNAUTHORIZED" },
+                { status: 401 }
+            )
+        }
+
+        const userId = session.user.id
+
+        const supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+            process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+        )
+
+        const { data: networks } = await supabase
+            .from("social_networks")
+            .select("*")
+            .in("platform", ["twitch", "kick"])
+            .eq("user_id", userId)
+            .eq("status", "connected")
+
+        const payload: Record<string, unknown> = {
+            sub: userId,
+            iat: Math.floor(Date.now() / 1000),
+        }
+
+        for (const network of networks || []) {
+            const plat = network.platform as "twitch" | "kick"
+            if (plat !== "twitch" && plat !== "kick") continue
+
+            try {
+                const tokenStore = getTokenStore()
+                const stored = await tokenStore.getToken(userId, plat)
+                if (stored?.accessToken) {
+                    payload[plat] = {
+                        accessToken: stored.accessToken,
+                        refreshToken: stored.refreshToken || undefined,
+                        username: network.platform_username || plat,
+                    }
+                }
+            } catch (tokenErr) {
+                logger.warn(`Failed to retrieve ${plat} token`, {
+                    userId,
+                    error: String(tokenErr),
+                })
+            }
+        }
+
+        const secret = process.env.OAUTH_STATE_SECRET || process.env.TOKEN_ENCRYPTION_KEY
+        if (!secret) {
+            logger.error("No signing secret configured")
+            return NextResponse.json(
+                { success: false, error: "CONFIG_ERROR" },
+                { status: 500 }
+            )
+        }
+
+        const token = jwt.sign(payload, secret, {
+            algorithm: "HS256",
+            expiresIn: "5m",
+        })
+
+        return NextResponse.json({ success: true, token })
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("WS token generation failed", err)
+        return NextResponse.json(
+            { success: false, error: "TOKEN_FAILED", message: err.message },
+            { status: 500 }
+        )
+    }
+}

--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -7,8 +7,9 @@
 "use client"
 
 import { useChatSSE } from "@/hooks/use-chat-sse"
+import { useRelayChat } from "@/hooks/use-relay-chat"
 import { createLogger } from "@/lib/logger"
-import { useCallback, useRef, useEffect, useState } from "react"
+import { useCallback, useRef, useEffect, useState, useMemo } from "react"
 
 interface UnifiedChatProps {
     platforms: string[]
@@ -51,7 +52,26 @@ const COMMANDS = [
 const logger = createLogger("UnifiedChat")
 
 export function UnifiedChat({ platforms }: UnifiedChatProps) {
-    const { messages, isConnected, error, addMessage } = useChatSSE(platforms)
+    const sse = useChatSSE(platforms)
+    const relay = useRelayChat()
+
+    const allMessages = useMemo(() => {
+        const seen = new Set<string>()
+        const merged = [...sse.messages]
+        for (const m of merged) seen.add(m.id)
+        for (const m of relay.messages) {
+            if (!seen.has(m.id)) {
+                merged.push(m)
+                seen.add(m.id)
+            }
+        }
+        merged.sort((a, b) => a.timestamp - b.timestamp)
+        return merged
+    }, [sse.messages, relay.messages])
+
+    const statusText = relay.isConnected
+        ? sse.isConnected ? "Connected" : "Relay (YouTube)"
+        : sse.isConnected ? "SSE (Twitch/Kick)" : "Disconnected"
     const [input, setInput] = useState("")
     const [selectedPlatform, setSelectedPlatform] = useState(
         platforms[0] || "twitch"
@@ -66,7 +86,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
     // Auto-scroll to bottom on new messages
     useEffect(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-    }, [messages])
+    }, [allMessages])
 
     const handleSend = useCallback(async () => {
         const text = input.trim()
@@ -91,7 +111,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                     message: err.message,
                 })
                 if (err.error === "MISSING_SCOPE") {
-                    addMessage({
+                    sse.addMessage({
                         id: `error-${Date.now()}`,
                         channelId: selectedPlatform,
                         platform: "system",
@@ -114,7 +134,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
 
             // Always inject locally for instant feedback. The SSE echo arrives
             // asynchronously and is deduplicated by content+user in useChatSSE.
-            addMessage({
+            sse.addMessage({
                 id: `send-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
                 channelId: selectedPlatform,
                 platform: selectedPlatform,
@@ -143,7 +163,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
         } finally {
             setSending(false)
         }
-    }, [input, selectedPlatform, addMessage, sending])
+    }, [input, selectedPlatform, sse, sending])
 
     const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -270,20 +290,20 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
             <div className="flex items-center gap-2 mb-3 text-xs text-gray-500">
                 <span
                     className={`inline-block h-2 w-2 rounded-full ${
-                        isConnected ? "bg-green-500" : "bg-red-500"
+                        relay.isConnected ? "bg-green-500" : sse.isConnected ? "bg-yellow-500" : "bg-red-500"
                     }`}
                 />
-                {isConnected ? "Connected" : "Disconnected"}
-                {error && (
+                {statusText}
+                {(sse.error || relay.error) && (
                     <span className="text-red-500 ml-2">
-                        {error.platform}: {error.error}
+                        {relay.error || `${sse.error?.platform}: ${sse.error?.error}`}
                     </span>
                 )}
             </div>
 
             {/* Messages */}
             <div className="flex-1 overflow-y-auto space-y-1 bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
-                {messages.map(msg => {
+                {allMessages.map(msg => {
                     const badge = getPlatformBadge(msg.platform)
                     return (
                         <div

--- a/src/hooks/use-chat-ws.ts
+++ b/src/hooks/use-chat-ws.ts
@@ -1,0 +1,285 @@
+"use client"
+
+import { createLogger } from "@/lib/logger"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+const logger = createLogger("useChatWS")
+
+export interface SSEProfileBadge {
+    id: string
+    label: string
+    imageUrl: string
+}
+
+export interface SSEUser {
+    id: string
+    username: string
+    displayName: string
+    platform: string
+    badges: SSEProfileBadge[]
+    isBroadcaster?: boolean
+    isModerator?: boolean
+    isSubscriber?: boolean
+    isVip?: boolean
+}
+
+export interface SSEChatMessage {
+    id: string
+    channelId: string
+    platform: string
+    user: SSEUser
+    content: string
+    type: string
+    timestamp: number
+    isAction?: boolean
+}
+
+export interface PlatformStatus {
+    platform: string
+    connected: boolean
+}
+
+export interface SSEError {
+    platform: string
+    error: string
+}
+
+interface UseChatWSReturn {
+    messages: SSEChatMessage[]
+    statuses: PlatformStatus[]
+    isConnected: boolean
+    error: SSEError | null
+    addMessage: (message: SSEChatMessage) => void
+}
+
+const WS_URL = "wss://ws.gabrieltoth.com"
+const MAX_RECONNECT_DELAY_MS = 30_000
+const INITIAL_RECONNECT_DELAY_MS = 1_000
+const DEDUP_WINDOW_MS = 3_000
+const TOKEN_REFRESH_BEFORE_MS = 60_000
+
+export function useChatWS(_platforms: string[]): UseChatWSReturn {
+    const [messages, setMessages] = useState<SSEChatMessage[]>([])
+    const [statuses, setStatuses] = useState<PlatformStatus[]>([])
+    const [isConnected, setIsConnected] = useState(false)
+    const [error, setError] = useState<SSEError | null>(null)
+
+    const wsRef = useRef<WebSocket | null>(null)
+    const tokenRef = useRef<string | null>(null)
+    const reconnectAttemptRef = useRef(0)
+    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const tokenFetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const mountedRef = useRef(true)
+
+    const fetchToken = useCallback(async (): Promise<string | null> => {
+        try {
+            const res = await fetch("/api/live/chat/ws-token", {
+                method: "POST",
+                credentials: "same-origin",
+            })
+            if (!res.ok) {
+                logger.warn("Failed to fetch WS token", { status: res.status })
+                return null
+            }
+            const data = await res.json()
+            if (data?.token) {
+                return data.token
+            }
+            return null
+        } catch (err) {
+            logger.warn("Failed to fetch WS token", { error: String(err) })
+            return null
+        }
+    }, [])
+
+    const connect = useCallback(async () => {
+        if (!mountedRef.current) return
+
+        if (wsRef.current) {
+            wsRef.current.close()
+            wsRef.current = null
+        }
+
+        let token = tokenRef.current
+        if (!token) {
+            token = await fetchToken()
+            if (!token) {
+                logger.warn("No WS token available, retrying...")
+                reconnectTimerRef.current = setTimeout(() => {
+                    reconnectAttemptRef.current++
+                    connect()
+                }, INITIAL_RECONNECT_DELAY_MS)
+                return
+            }
+            tokenRef.current = token
+        }
+
+        const url = `${WS_URL}?token=${encodeURIComponent(token)}`
+        const ws = new WebSocket(url)
+        wsRef.current = ws
+
+        ws.onopen = () => {
+            if (!mountedRef.current) {
+                ws.close()
+                return
+            }
+            setIsConnected(true)
+            setError(null)
+            reconnectAttemptRef.current = 0
+            logger.debug("WS connected")
+        }
+
+        ws.onmessage = (event: MessageEvent) => {
+            if (!mountedRef.current) return
+            try {
+                const data = JSON.parse(event.data)
+                if (!data.type) return
+
+                switch (data.type) {
+                    case "connected":
+                        setIsConnected(true)
+                        setError(null)
+                        break
+
+                    case "message": {
+                        const msg: SSEChatMessage = {
+                            id: data.id || `${data.platform}-${data.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+                            channelId: data.channel || "",
+                            platform: data.platform || "unknown",
+                            user: {
+                                id: data.user?.id || "",
+                                username: data.user?.username || "unknown",
+                                displayName: data.user?.displayName || data.user?.username || "Unknown",
+                                platform: data.platform || "unknown",
+                                badges: data.user?.badges || [],
+                                isBroadcaster: data.user?.isBroadcaster || false,
+                                isModerator: data.user?.isModerator || false,
+                                isSubscriber: data.user?.isSubscriber || false,
+                                isVip: data.user?.isVip || false,
+                            },
+                            content: data.content || "",
+                            type: data.subtype || "chat",
+                            timestamp: data.timestamp || Date.now(),
+                            isAction: data.isAction || false,
+                        }
+                        setMessages(prev => {
+                            if (prev.some(m => m.id === msg.id)) return prev
+                            if (
+                                prev.some(
+                                    m =>
+                                        m.user.id === msg.user.id &&
+                                        m.content === msg.content &&
+                                        m.channelId === msg.channelId &&
+                                        Math.abs(m.timestamp - msg.timestamp) < DEDUP_WINDOW_MS
+                                )
+                            ) {
+                                return prev
+                            }
+                            return [...prev, msg]
+                        })
+                        break
+                    }
+
+                    case "status": {
+                        const status: PlatformStatus = {
+                            platform: data.platform || "unknown",
+                            connected: data.connected ?? false,
+                        }
+                        setStatuses(prev => {
+                            const existing = prev.findIndex(s => s.platform === status.platform)
+                            if (existing >= 0) {
+                                const updated = [...prev]
+                                updated[existing] = status
+                                return updated
+                            }
+                            return [...prev, status]
+                        })
+                        break
+                    }
+
+                    case "error": {
+                        setError({
+                            platform: data.platform || "unknown",
+                            error: data.error || data.message || "Unknown error",
+                        })
+                        break
+                    }
+                }
+            } catch (parseError) {
+                logger.warn("Failed to parse WS message", { error: String(parseError) })
+            }
+        }
+
+        ws.onclose = () => {
+            if (!mountedRef.current) return
+            setIsConnected(false)
+            tokenRef.current = null
+            scheduleReconnect()
+        }
+
+        ws.onerror = () => {
+            if (!mountedRef.current) return
+        }
+    }, [fetchToken])
+
+    const scheduleReconnect = useCallback(() => {
+        if (!mountedRef.current) return
+        const attempt = reconnectAttemptRef.current
+        const delay = Math.min(
+            INITIAL_RECONNECT_DELAY_MS * Math.pow(2, attempt),
+            MAX_RECONNECT_DELAY_MS
+        )
+        logger.debug("Scheduling WS reconnect", { attempt: attempt + 1, delay })
+        reconnectTimerRef.current = setTimeout(() => {
+            reconnectAttemptRef.current++
+            connect()
+        }, delay)
+    }, [connect])
+
+    useEffect(() => {
+        mountedRef.current = true
+        connect()
+
+        return () => {
+            mountedRef.current = false
+            if (reconnectTimerRef.current) {
+                clearTimeout(reconnectTimerRef.current)
+                reconnectTimerRef.current = null
+            }
+            if (tokenFetchTimerRef.current) {
+                clearTimeout(tokenFetchTimerRef.current)
+                tokenFetchTimerRef.current = null
+            }
+            if (wsRef.current) {
+                wsRef.current.close()
+                wsRef.current = null
+            }
+            setIsConnected(false)
+        }
+    }, [connect])
+
+    const addMessage = useCallback((message: SSEChatMessage) => {
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.send(
+                JSON.stringify({
+                    type: "send",
+                    platform: message.platform,
+                    channel: message.channelId,
+                    text: message.content,
+                })
+            )
+        }
+        setMessages(prev => {
+            if (prev.some(m => m.id === message.id)) return prev
+            return [...prev, message]
+        })
+    }, [])
+
+    return {
+        messages,
+        statuses,
+        isConnected,
+        error,
+        addMessage,
+    }
+}

--- a/src/hooks/use-relay-chat.ts
+++ b/src/hooks/use-relay-chat.ts
@@ -1,0 +1,257 @@
+"use client"
+
+import { createLogger } from "@/lib/logger"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+const logger = createLogger("useRelayChat")
+
+export interface RelayChatMessage {
+    id: string
+    channelId: string
+    platform: string
+    user: {
+        id: string
+        username: string
+        displayName: string
+        platform: string
+        badges: Array<{ id: string; label: string; imageUrl: string }>
+        isBroadcaster?: boolean
+        isModerator?: boolean
+        isSubscriber?: boolean
+    }
+    content: string
+    type: string
+    timestamp: number
+    isAction?: boolean
+}
+
+interface RelayPlatformStatus {
+    platform: string
+    connected: boolean
+    liveChatId?: string
+}
+
+interface UseRelayChatReturn {
+    messages: RelayChatMessage[]
+    statuses: RelayPlatformStatus[]
+    isConnected: boolean
+    error: string | null
+}
+
+const INITIAL_RECONNECT_DELAY = 1_000
+const MAX_RECONNECT_DELAY = 30_000
+const TOKEN_REFRESH_INTERVAL = 4 * 60 * 1000
+
+export function useRelayChat(): UseRelayChatReturn {
+    const [messages, setMessages] = useState<RelayChatMessage[]>([])
+    const [statuses, setStatuses] = useState<RelayPlatformStatus[]>([])
+    const [isConnected, setIsConnected] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const wsRef = useRef<WebSocket | null>(null)
+    const reconnectAttemptRef = useRef(0)
+    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const mountedRef = useRef(true)
+    const tokenRef = useRef<string>("")
+    const platformsRef = useRef<Record<string, { channelName: string; accessToken?: string }>>({})
+    const tokenTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+    const connectRef = useRef<() => void>(() => {})
+
+    const relayUrl = process.env.NEXT_PUBLIC_RELAY_WS_URL || ""
+
+    const fetchCredentials = useCallback(async () => {
+        try {
+            const res = await fetch("/api/auth/relay-token")
+            if (!res.ok) {
+                throw new Error(`Failed to fetch relay credentials: ${res.status}`)
+            }
+            const data = await res.json()
+            if (!data.success) {
+                throw new Error(data.error || "Failed to fetch relay credentials")
+            }
+            tokenRef.current = data.token
+            platformsRef.current = data.platforms || {}
+            return true
+        } catch (err) {
+            logger.error("Failed to fetch relay credentials", { error: String(err) })
+            return false
+        }
+    }, [])
+
+    const sendConnectMessage = useCallback((ws: WebSocket) => {
+        for (const [platform, info] of Object.entries(platformsRef.current)) {
+            if (info.accessToken) {
+                ws.send(JSON.stringify({
+                    type: "connect",
+                    platform,
+                    token: info.accessToken,
+                }))
+                logger.debug("Sent relay connect", { platform })
+            }
+        }
+    }, [])
+
+    const scheduleReconnect = useCallback(() => {
+        if (!mountedRef.current) return
+
+        const attempt = reconnectAttemptRef.current
+        const delay = Math.min(
+            INITIAL_RECONNECT_DELAY * Math.pow(2, attempt),
+            MAX_RECONNECT_DELAY
+        )
+        reconnectAttemptRef.current = attempt + 1
+
+        reconnectTimerRef.current = setTimeout(() => {
+            if (mountedRef.current) {
+                connectRef.current?.()
+            }
+        }, delay)
+    }, [])
+
+    const connect = useCallback(async () => {
+        if (!mountedRef.current) return
+        if (!relayUrl) return
+
+        wsRef.current?.close()
+        wsRef.current = null
+
+        const hasCredentials = await fetchCredentials()
+        if (!hasCredentials) {
+            setError("Failed to get relay credentials")
+            scheduleReconnect()
+            return
+        }
+
+        if (!tokenRef.current) {
+            setError("No relay token available")
+            scheduleReconnect()
+            return
+        }
+
+        try {
+            const url = `${relayUrl}?token=${encodeURIComponent(tokenRef.current)}`
+            const ws = new WebSocket(url)
+            wsRef.current = ws
+
+            ws.onopen = () => {
+                if (!mountedRef.current) {
+                    ws.close()
+                    return
+                }
+                setIsConnected(true)
+                setError(null)
+                reconnectAttemptRef.current = 0
+                sendConnectMessage(ws)
+                logger.info("Relay WebSocket connected")
+            }
+
+            ws.onmessage = (event: MessageEvent) => {
+                if (!mountedRef.current) return
+                try {
+                    const data = JSON.parse(event.data as string)
+
+                    if (data.type === "connected") {
+                        logger.info("Relay connection established", { userId: data.data?.userId })
+                        return
+                    }
+
+                    if (data.type === "status") {
+                        setStatuses(prev => {
+                            const existing = prev.findIndex(s => s.platform === data.platform)
+                            const entry: RelayPlatformStatus = {
+                                platform: data.platform,
+                                connected: data.connected,
+                                liveChatId: data.liveChatId,
+                            }
+                            if (existing >= 0) {
+                                const updated = [...prev]
+                                updated[existing] = entry
+                                return updated
+                            }
+                            return [...prev, entry]
+                        })
+                        return
+                    }
+
+                    if (data.type === "error") {
+                        setError(data.error || "Relay error")
+                        return
+                    }
+
+                    if (data.event === "youtube:message") {
+                        const message: RelayChatMessage = {
+                            id: data.id,
+                            channelId: data.channelId,
+                            platform: "youtube",
+                            user: data.user,
+                            content: data.content,
+                            type: data.msgType || "text",
+                            timestamp: data.timestamp,
+                        }
+                        setMessages(prev => {
+                            if (prev.some(m => m.id === message.id)) return prev
+                            return [...prev, message]
+                        })
+                        return
+                    }
+                } catch {
+                    // ignore unparseable messages
+                }
+            }
+
+            ws.onerror = () => {
+                if (!mountedRef.current) return
+                setError("Relay WebSocket connection failed")
+            }
+
+            ws.onclose = () => {
+                if (!mountedRef.current) return
+                setIsConnected(false)
+                wsRef.current = null
+                scheduleReconnect()
+            }
+        } catch (err) {
+            logger.error("Relay WebSocket connect error", { error: String(err) })
+            setError(String(err))
+            scheduleReconnect()
+        }
+    }, [relayUrl, fetchCredentials, sendConnectMessage, scheduleReconnect])
+
+    useEffect(() => {
+        mountedRef.current = true
+        connectRef.current = connect
+
+        if (relayUrl) {
+            connect()
+
+            tokenTimerRef.current = setInterval(() => {
+                if (wsRef.current?.readyState === WebSocket.OPEN) {
+                    fetchCredentials()
+                }
+            }, TOKEN_REFRESH_INTERVAL)
+        }
+
+        return () => {
+            mountedRef.current = false
+
+            if (reconnectTimerRef.current) {
+                clearTimeout(reconnectTimerRef.current)
+                reconnectTimerRef.current = null
+            }
+
+            if (tokenTimerRef.current) {
+                clearInterval(tokenTimerRef.current)
+                tokenTimerRef.current = null
+            }
+
+            if (wsRef.current) {
+                wsRef.current.close()
+                wsRef.current = null
+            }
+
+            setIsConnected(false)
+        }
+    }, [relayUrl, connect, fetchCredentials])
+
+    return { messages, statuses, isConnected, error }
+}

--- a/src/lib/chat/youtube-relay-adapter.ts
+++ b/src/lib/chat/youtube-relay-adapter.ts
@@ -20,12 +20,15 @@ interface YouTubeRelayMessageHandler {
     (message: ChatMessage): void
 }
 
+const MAX_RECONNECT_ATTEMPTS = 5
+
 interface YouTubeRelayConnection {
     roomId: string
     ws: WebSocket | null
     state: "disconnected" | "connecting" | "connected"
     oauthToken: string
     cleanupFns: Array<() => void>
+    everConnected: boolean
 }
 
 export class YouTubeRelayChatAdapter implements ChatAdapter {
@@ -54,6 +57,7 @@ export class YouTubeRelayChatAdapter implements ChatAdapter {
             state: "connecting",
             oauthToken: token,
             cleanupFns: [],
+            everConnected: false,
         }
 
         this.connections.set(roomId, connection)
@@ -94,6 +98,7 @@ export class YouTubeRelayChatAdapter implements ChatAdapter {
 
                         if (data.type === "connected") {
                             connection.state = "connected"
+                            connection.everConnected = true
                             logger.info("YouTube relay connection established", {
                                 roomId: connection.roomId,
                             })
@@ -157,7 +162,6 @@ export class YouTubeRelayChatAdapter implements ChatAdapter {
                 ws.onclose = () => {
                     connection.state = "disconnected"
                     connection.ws = null
-                    this.connections.delete(connection.roomId)
                     logger.info("YouTube relay WebSocket closed", {
                         roomId: connection.roomId,
                     })
@@ -180,7 +184,26 @@ export class YouTubeRelayChatAdapter implements ChatAdapter {
     private reconnectAttempts = new Map<string, number>()
 
     private scheduleReconnect(connection: YouTubeRelayConnection): void {
+        if (!connection.everConnected) {
+            logger.info("YouTube relay reconnect skipped — never connected", {
+                roomId: connection.roomId,
+            })
+            this.connections.delete(connection.roomId)
+            this.reconnectAttempts.delete(connection.roomId)
+            return
+        }
+
         const attempts = this.reconnectAttempts.get(connection.roomId) || 0
+        if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+            logger.warn("YouTube relay max reconnect attempts reached", {
+                roomId: connection.roomId,
+                attempts,
+            })
+            this.connections.delete(connection.roomId)
+            this.reconnectAttempts.delete(connection.roomId)
+            return
+        }
+
         const delay = Math.min(
             RECONNECT_DELAY_MS * Math.pow(2, attempts),
             MAX_RECONNECT_DELAY_MS

--- a/src/lib/realtime/message-aggregator.ts
+++ b/src/lib/realtime/message-aggregator.ts
@@ -6,18 +6,13 @@
  */
 
 import { createLogger } from "@/lib/logger"
-import {
-    KickChatAdapter,
-    TwitchChatAdapter,
-    YouTubeLiveChatAdapter,
-    YouTubeRelayChatAdapter,
-} from "@/lib/chat"
+import { KickChatAdapter, TwitchChatAdapter } from "@/lib/chat"
 import type { ChatAdapter, ChatMessage } from "@/lib/chat/types"
 import { sendEvent } from "./sse-manager"
 
 const logger = createLogger("MessageAggregator")
 
-type ChatPlatform = "twitch" | "kick" | "youtube"
+type ChatPlatform = "twitch" | "kick"
 
 type PlatformConnectInfo = Partial<
     Record<ChatPlatform, { channelName: string; token?: string }>
@@ -28,15 +23,9 @@ interface PlatformAdapterEntry {
     cleanupFns: Array<() => void>
 }
 
-const USE_YOUTUBE_RELAY = !!process.env.YOUTUBE_RELAY_WS_URL
-
 const ADAPTER_REGISTRY: Record<ChatPlatform, () => ChatAdapter> = {
     twitch: () => new TwitchChatAdapter(),
     kick: () => new KickChatAdapter(),
-    youtube: () =>
-        USE_YOUTUBE_RELAY
-            ? new YouTubeRelayChatAdapter()
-            : new YouTubeLiveChatAdapter(),
 }
 
 export class MessageAggregator {
@@ -58,16 +47,12 @@ export class MessageAggregator {
         this.platformConnect = platformConnect
     }
 
-    /**
-     * Start listening on all configured platform adapters
-     */
     async start(): Promise<void> {
         if (this.started) {
             logger.debug("Aggregator already started", { userId: this.userId })
             return
         }
 
-        // Stop any existing aggregator for this user to prevent duplicates
         const existing = MessageAggregator.instances.get(this.userId)
         if (existing && existing !== this) {
             logger.info("Stopping previous aggregator for user", {
@@ -108,7 +93,6 @@ export class MessageAggregator {
                 const channelName = connectInfo.channelName
                 const token = connectInfo.token || ""
 
-                // Register message handler with channel name
                 const unsubMessage = adapter.onMessage(
                     channelName,
                     (message: ChatMessage) => {
@@ -117,7 +101,6 @@ export class MessageAggregator {
                 )
                 entry.cleanupFns.push(unsubMessage)
 
-                // Register error handler
                 const unsubError = adapter.onError((error: Error) => {
                     this.handleError(platform, error)
                 })
@@ -125,14 +108,12 @@ export class MessageAggregator {
 
                 this.adapters.set(platform, entry)
 
-                // Connect to the platform chat with actual channel name and token
                 await adapter.connect(channelName, token)
                 logger.info("Connected to platform chat", {
                     userId: this.userId,
                     platform,
                 })
 
-                // Send status update
                 sendEvent(this.userId, "status", {
                     platform,
                     connected: true,
@@ -163,9 +144,6 @@ export class MessageAggregator {
         }
     }
 
-    /**
-     * Stop all platform adapters and clean up
-     */
     async stop(): Promise<void> {
         if (!this.started) return
 
@@ -173,7 +151,6 @@ export class MessageAggregator {
         logger.info("Stopping message aggregator", { userId: this.userId })
 
         for (const [platform, entry] of this.adapters.entries()) {
-            // Run cleanup functions (unsubscribe handlers)
             for (const cleanup of entry.cleanupFns) {
                 try {
                     cleanup()
@@ -185,7 +162,6 @@ export class MessageAggregator {
                 }
             }
 
-            // Disconnect adapter
             try {
                 const connectInfo = this.platformConnect[platform]
                 if (!connectInfo) continue
@@ -205,7 +181,6 @@ export class MessageAggregator {
 
         this.adapters.clear()
 
-        // Remove from registry if this is the current instance
         if (MessageAggregator.instances.get(this.userId) === this) {
             MessageAggregator.instances.delete(this.userId)
         }
@@ -213,9 +188,6 @@ export class MessageAggregator {
         logger.info("Message aggregator stopped", { userId: this.userId })
     }
 
-    /**
-     * Handle an incoming chat message from any platform
-     */
     private handleMessage(message: ChatMessage): void {
         sendEvent(this.userId, "message", {
             id: message.id,
@@ -243,9 +215,6 @@ export class MessageAggregator {
         })
     }
 
-    /**
-     * Handle an error from a platform adapter
-     */
     private handleError(platform: ChatPlatform, error: Error): void {
         logger.error("Platform adapter error", {
             userId: this.userId,
@@ -259,10 +228,6 @@ export class MessageAggregator {
         })
     }
 
-    /**
-     * Send a message using an active platform adapter
-     * Falls back to a temporary connection if no active adapter exists
-     */
     static async sendMessage(
         userId: string,
         platform: ChatPlatform,
@@ -270,7 +235,6 @@ export class MessageAggregator {
         message: string,
         token: string
     ): Promise<boolean> {
-        // Prefer active adapter from running aggregator
         const aggregator = MessageAggregator.instances.get(userId)
         if (aggregator?.started) {
             const entry = aggregator.adapters.get(platform)
@@ -280,30 +244,28 @@ export class MessageAggregator {
             }
         }
 
-        // Fallback: temporary connection using the platform's adapter
-        const FactoryClass = ADAPTER_REGISTRY[platform]
-        if (FactoryClass) {
-            const adapter = FactoryClass()
-            try {
-                await adapter.connect(channelName, token)
-                await adapter.sendMessage(channelName, message)
-            } finally {
-                await adapter.disconnect(channelName)
+        const adapter =
+            platform === "twitch"
+                ? new TwitchChatAdapter()
+                : new KickChatAdapter()
+
+        try {
+            await adapter.connect(channelName, token)
+            if (platform === "twitch") {
+                const twitchAdapter = adapter as TwitchChatAdapter
+                await twitchAdapter.waitForJoin(channelName)
             }
+            await adapter.sendMessage(channelName, message)
+        } finally {
+            await adapter.disconnect(channelName)
         }
         return false
     }
 
-    /**
-     * Check if the aggregator is currently running
-     */
     isRunning(): boolean {
         return this.started
     }
 
-    /**
-     * Get the list of connected platforms
-     */
     getConnectedPlatforms(): ChatPlatform[] {
         return Array.from(this.adapters.keys())
     }


### PR DESCRIPTION
Closes #301

## Changes
- New relay server at \elay/\ with JWT-authenticated WebSocket connections
- Cloudflare Tunnel \gabrieltoth-ws\ routing \ws.gabrieltoth.com\ to relay
- Frontend WebSocket hooks (\use-relay-chat.ts\, \use-chat-ws.ts\)
- API routes for relay token generation and chat sending
- Message aggregator service for unified chat
- Updated unified chat component for multi-platform support
- \NEXT_PUBLIC_RELAY_WS_URL\ added to Vercel env
- \JWT_SECRET\ synced to relay .env on .203