### PR TITLE
fix: YouTube chat send/relay proto + OAuth callback redirect

### DIFF
--- a/relay/package.json
+++ b/relay/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc && node -e \"require('fs').cpSync('src/stream-list.proto','dist/stream-list.proto')\"",
         "start": "node dist/relay-server.js",
         "dev": "npx tsx watch src/relay-server.ts"
     },

--- a/src/app/[locale]/dashboard/channels/page.tsx
+++ b/src/app/[locale]/dashboard/channels/page.tsx
@@ -126,7 +126,7 @@ export default function ChannelsPage() {
             const response = await fetch(`/api/oauth/authorize/${platform}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ locale }),
+                body: JSON.stringify({ locale, redirectTo: window.location.pathname }),
             })
             if (!response.ok) {
                 const data = await response.json()

--- a/src/app/api/live/chat/send/route.ts
+++ b/src/app/api/live/chat/send/route.ts
@@ -328,6 +328,93 @@ async function sendTwitchMessage(
     return NextResponse.json({ success: true, sentViaActive })
 }
 
+async function sendYouTubeMessage(
+    userId: string,
+    message: string,
+    token: string
+): Promise<NextResponse> {
+    try {
+        const broadcastResponse = await fetch(
+            "https://www.googleapis.com/youtube/v3/liveBroadcasts?part=snippet,status&mine=true",
+            {
+                headers: { Authorization: `Bearer ${token}` },
+            }
+        )
+
+        if (!broadcastResponse.ok) {
+            const body = await broadcastResponse.text()
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "YOUTUBE_API_ERROR",
+                    message: `Failed to find live broadcast: ${broadcastResponse.status} ${body}`,
+                },
+                { status: 500 }
+            )
+        }
+
+        const broadcastData = await broadcastResponse.json()
+        const active = broadcastData.items?.find(
+            (item: { status?: { lifeCycleStatus?: string } }) =>
+                item.status?.lifeCycleStatus === "live"
+        )
+        const liveChatId = active?.snippet?.liveChatId
+
+        if (!liveChatId) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "NO_LIVE_BROADCAST",
+                    message: "No active YouTube live broadcast found",
+                },
+                { status: 400 }
+            )
+        }
+
+        const response = await fetch(
+            "https://www.googleapis.com/youtube/v3/liveChat/messages?part=snippet",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    snippet: {
+                        liveChatId,
+                        type: "textMessageEvent",
+                        textMessageDetails: {
+                            messageText: message,
+                        },
+                    },
+                }),
+            }
+        )
+
+        if (!response.ok) {
+            const body = await response.text()
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "YOUTUBE_SEND_FAILED",
+                    message: `YouTube API error: ${response.status} ${body}`,
+                },
+                { status: 500 }
+            )
+        }
+
+        logger.info("YouTube message sent", { userId, liveChatId })
+        return NextResponse.json({ success: true })
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        logger.error("YouTube send failed", err)
+        return NextResponse.json(
+            { success: false, error: "YOUTUBE_SEND_FAILED", message: err.message },
+            { status: 500 }
+        )
+    }
+}
+
 async function sendKickMessage(
     userId: string,
     channelName: string,
@@ -374,11 +461,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             )
         }
 
-        if (platform !== "twitch" && platform !== "kick") {
+        if (platform !== "twitch" && platform !== "kick" && platform !== "youtube") {
             return NextResponse.json(
                 { success: false, error: "UNSUPPORTED_PLATFORM" },
                 { status: 400 }
             )
+        }
+
+        if (platform === "youtube") {
+            const tokenStore = getTokenStore()
+            const stored = await tokenStore.getToken(userId, "youtube")
+            if (!stored?.accessToken) {
+                return NextResponse.json(
+                    { success: false, error: "NO_TOKEN" },
+                    { status: 400 }
+                )
+            }
+            return sendYouTubeMessage(userId, message, stored.accessToken)
         }
 
         const supabase = createClient(

--- a/src/app/api/live/chat/stream/route.ts
+++ b/src/app/api/live/chat/stream/route.ts
@@ -12,7 +12,6 @@ import { NextRequest } from "next/server"
 import { MessageAggregator } from "@/lib/realtime/message-aggregator"
 import { createSSEStream, closeConnections } from "@/lib/realtime/sse-manager"
 import { getTokenStore } from "@/lib/token-store"
-import { isTerminalTokenError, markAccountDisconnected } from "@/lib/auth/token-health"
 
 const logger = createLogger("ChatStreamEndpoint")
 
@@ -63,71 +62,38 @@ export async function GET(request: NextRequest): Promise<Response> {
             )
         }
 
-        // Determine which platforms the user has connected and their channel names
+        // Determine which platforms the user has connected and their channel names.
+        // YouTube is handled separately via the relay WebSocket, not the SSE MessageAggregator.
         const platformConnect: Partial<
-            Record<"twitch" | "kick" | "youtube", { channelName: string; token?: string }>
+            Record<"twitch" | "kick", { channelName: string; token?: string }>
         > = {}
-        let youtubeProcessed = false
         for (const network of networks || []) {
-            const plat = network.platform as "twitch" | "kick" | "youtube"
-            if (plat === "twitch" || plat === "kick" || plat === "youtube") {
-                // Only process YouTube once (user may have 2 channels, but liveBroadcasts?mine=true
-                // returns broadcasts for ALL channels — one connection is enough)
-                if (plat === "youtube") {
-                    if (youtubeProcessed) continue
-                    youtubeProcessed = true
-                }
-                const info: { channelName: string; token?: string } = {
-                    channelName: network.platform_username || plat,
-                }
+            const plat = network.platform as string
+            if (plat !== "twitch" && plat !== "kick") continue
 
-                try {
-                    const tokenStore = getTokenStore()
-                    let stored = await tokenStore.getToken(userId, plat)
+            const key = plat as "twitch" | "kick"
+            const info: { channelName: string; token?: string } = {
+                channelName: network.platform_username || plat,
+            }
 
-                    // Auto-refresh expired YouTube token
-                    if (plat === "youtube" && stored?.refreshToken && stored.expiresAt && stored.expiresAt < Date.now()) {
-                        try {
-                            const { getYouTubeOAuthService } = await import("@/lib/youtube/oauth-service")
-                            const { getYouTubeChannelLinkingConfig } = await import("@/lib/youtube/config")
-                            const { validateEnv } = await import("@/lib/config/env")
-                            const ytConfig = getYouTubeChannelLinkingConfig(validateEnv())
-                            const ytOAuth = getYouTubeOAuthService(ytConfig)
-                            await ytOAuth.initialize()
-                            const refreshed = await ytOAuth.refreshAccessToken(stored.refreshToken)
-                            const expiresAt = Date.now() + refreshed.expiresIn * 1000
-                            await tokenStore.refreshToken(userId, "youtube", {
-                                accessToken: refreshed.accessToken,
-                                refreshToken: refreshed.refreshToken,
-                                expiresAt,
-                                platform: "youtube",
-                                userId,
-                            })
-                            stored = await tokenStore.getToken(userId, "youtube")
-                        } catch (err) {
-                            const errMsg = err instanceof Error ? err.message : String(err)
-                            logger.error("YouTube token auto-refresh failed in stream", { userId, error: errMsg })
-                            if (isTerminalTokenError(errMsg)) {
-                                await markAccountDisconnected(userId, "youtube").catch(() => {})
-                            }
-                        }
-                    }
+            try {
+                const tokenStore = getTokenStore()
+                const stored = await tokenStore.getToken(userId, key)
 
-                    if (stored?.accessToken) {
-                        info.token = stored.accessToken
-                        logger.debug(`${plat} OAuth token retrieved for chat`, {
-                            userId,
-                        })
-                    }
-                } catch (tokenErr) {
-                    logger.warn(`Failed to retrieve ${plat} token for chat`, {
+                if (stored?.accessToken) {
+                    info.token = stored.accessToken
+                    logger.debug(`${key} OAuth token retrieved for chat`, {
                         userId,
-                        error: String(tokenErr),
                     })
                 }
-
-                platformConnect[plat] = info
+            } catch (tokenErr) {
+                logger.warn(`Failed to retrieve ${key} token for chat`, {
+                    userId,
+                    error: String(tokenErr),
+                })
             }
+
+            platformConnect[key] = info
         }
 
         const platforms = Object.keys(platformConnect)

--- a/src/app/api/oauth/authorize/[platform]/route.ts
+++ b/src/app/api/oauth/authorize/[platform]/route.ts
@@ -55,14 +55,17 @@ export async function POST(
         }
         const userId = session.user.id
 
-        // Extract locale from request body or query params
+        // Extract locale and redirectTo from request body or query params
         let locale: string | undefined
+        let redirectTo: string | undefined
         try {
             const body = await request.clone().json()
             locale = body.locale
+            redirectTo = body.redirectTo
         } catch {
             // Not JSON body, try query params
             locale = request.nextUrl.searchParams.get("locale") || undefined
+            redirectTo = request.nextUrl.searchParams.get("redirectTo") || undefined
         }
 
         // Validate platform
@@ -80,12 +83,13 @@ export async function POST(
             )
         }
 
-        // Generate authorization URL with locale for redirect back
+        // Generate authorization URL with locale and redirectTo for callback redirect
         const authResponse = await oauthManager.generateAuthorizationUrl(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             platform as any,
             userId,
-            locale
+            locale,
+            redirectTo
         )
 
         logger.info("OAuth authorization URL generated", {

--- a/src/app/api/oauth/callback/[platform]/route.ts
+++ b/src/app/api/oauth/callback/[platform]/route.ts
@@ -157,47 +157,23 @@ export async function GET(
                 process.env.SUPABASE_SERVICE_ROLE_KEY || ""
             )
 
-            if (normalizedPlatform === "youtube") {
-                // Update existing YouTube rows to connected (bypass YouTube API which may be blocked/quota-exceeded)
-                const { error: updateError } = await supabase
-                    .from("social_networks")
-                    .update({
-                        status: "connected",
-                        updated_at: new Date().toISOString(),
-                    })
-                    .eq("user_id", userId)
-                    .eq("platform", "youtube")
-
-                if (updateError) {
-                    logger.warn("Failed to update YouTube social_networks", {
-                        userId,
-                        error: updateError.message,
-                    })
-                } else {
-                    logger.info("YouTube social_networks set to connected", {
-                        userId,
-                    })
-                }
-            } else {
-                // Other platforms: save minimal record
-                await supabase.from("social_networks").upsert(
-                    {
-                        user_id: userId,
-                        platform: normalizedPlatform,
-                        platform_user_id: "",
-                        platform_username: normalizedPlatform,
-                        status: "connected",
-                        linked_at: new Date().toISOString(),
-                        metadata: {
-                            scopeVersion: getScopeVersion(normalizedPlatform),
-                        },
-                        updated_at: new Date().toISOString(),
+            await supabase.from("social_networks").upsert(
+                {
+                    user_id: userId,
+                    platform: normalizedPlatform,
+                    platform_user_id: "",
+                    platform_username: normalizedPlatform,
+                    status: "connected",
+                    linked_at: new Date().toISOString(),
+                    metadata: {
+                        scopeVersion: getScopeVersion(normalizedPlatform),
                     },
-                    {
-                        onConflict: "user_id, platform, platform_user_id",
-                    }
-                )
-            }
+                    updated_at: new Date().toISOString(),
+                },
+                {
+                    onConflict: "user_id, platform, platform_user_id",
+                }
+            )
         } catch (socialError) {
             logger.warn(
                 "Failed to save social_networks record, token already stored",
@@ -220,12 +196,11 @@ export async function GET(
             environment: getAuditEnvironment(),
         })
 
-        // Redirect back to channels page with correct locale
+        // Redirect back to original page (or fall back to channels page)
         const locale = stateResult.locale || "en"
-        const redirectUrl = new URL(
-            `/${locale}/dashboard/channels`,
-            request.nextUrl.origin
-        )
+        const redirectPath =
+            stateResult.redirectTo || `/${locale}/dashboard/channels`
+        const redirectUrl = new URL(redirectPath, request.nextUrl.origin)
         redirectUrl.searchParams.set("oauth_success", normalizedPlatform)
         return NextResponse.redirect(redirectUrl)
     } catch (error) {

--- a/src/components/settings/ChannelsSection.tsx
+++ b/src/components/settings/ChannelsSection.tsx
@@ -84,6 +84,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({
             const response = await fetch(`/api/oauth/authorize/${platform}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ redirectTo: window.location.pathname }),
             })
             if (!response.ok) {
                 const data = await response.json()

--- a/src/components/settings/SettingsContainer.tsx
+++ b/src/components/settings/SettingsContainer.tsx
@@ -332,6 +332,7 @@ export const SettingsContainer: React.FC<SettingsContainerProps> = ({
             const response = await fetch("/api/oauth/authorize/facebook", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ redirectTo: window.location.pathname }),
             })
             if (!response.ok) {
                 const data = await response.json()

--- a/src/lib/oauth/oauth-manager-core.ts
+++ b/src/lib/oauth/oauth-manager-core.ts
@@ -241,7 +241,8 @@ export class OAuthManager {
     async generateAuthorizationUrl(
         platform: OAuthPlatform,
         userId: string,
-        locale?: string
+        locale?: string,
+        redirectTo?: string
     ): Promise<AuthorizationUrlResponse> {
         const config = this.configs.get(platform)
         if (!config) {
@@ -250,8 +251,8 @@ export class OAuthManager {
 
         try {
             // Generate HMAC-signed state token (no Redis needed)
-            // The state contains userId, platform, locale, and timestamp — signed with HMAC-SHA256
-            const signedState = generateState(userId, platform, locale)
+            // The state contains userId, platform, locale, redirectTo, and timestamp — signed with HMAC-SHA256
+            const signedState = generateState(userId, platform, locale, redirectTo)
             const state = signedState.token
 
             // Build authorization URL
@@ -306,7 +307,7 @@ export class OAuthManager {
         platform: string,
         userId: string,
         state: string
-    ): Promise<{ valid: boolean; locale?: string }> {
+    ): Promise<{ valid: boolean; locale?: string; redirectTo?: string }> {
         try {
             const result = verifyState(state)
 
@@ -338,7 +339,7 @@ export class OAuthManager {
                 return { valid: false }
             }
 
-            return { valid: true, locale: result.payload?.locale }
+            return { valid: true, locale: result.payload?.locale, redirectTo: result.payload?.redirectTo }
         } catch (error) {
             logger.error("State validation failed", {
                 platform,


### PR DESCRIPTION
## Changes

### YouTube Chat
- **send/route.ts**: Added \sendYouTubeMessage\ function — now YouTube is accepted as a platform for sending chat messages via the Live Chat API
- **stream/route.ts**: Removed YouTube from MessageAggregator (YouTube messages come through the relay WebSocket, not SSE)
- **relay/package.json**: Build script now copies \stream-list.proto\ to \dist/\ so the gRPC YouTube stream can load it at runtime

### OAuth Bugs (from previous session)
- **callback/[platform]/route.ts**: YouTube branch no longer mass-updates ALL social_networks rows — uses upsert like other platforms
- **redirectTo**: Threaded through authorize → state → callback so OAuth returns to the original page instead of always going to \/dashboard/channels\
- **channels/page.tsx, SettingsContainer, ChannelsSection**: Pass \edirectTo: window.location.pathname\ in authorize request

## Deploy needed
1. Main app: auto-deploy by Vercel on merge
2. Relay on .203: \cd C:\\workspace\\gabrieltoth-ws && npm run build\ then restart