### PR TITLE
feat: Meta Business Suite browser auto-publisher

### DIFF
--- a/meta-publisher/SETUP.md
+++ b/meta-publisher/SETUP.md
@@ -1,0 +1,97 @@
+# Meta Publisher — Setup Guide
+
+## Architecture
+
+```
+Site (Vercel)
+  └── POST /api/meta/publish → creates task in Supabase
+  └── Frontend uploads video to .203 via tus (or provides SMB path)
+
+.203 (pentester-01)
+  ├── meta-publisher/server/  → HTTP tus upload server + Express
+  │   ├── index.js
+  │   └── package.json
+  │
+  └── meta-publisher/worker/  → Polls Supabase, runs browser automation
+      ├── index.js           → Polling loop
+      ├── publish-meta.js    → Puppeteer-core + Stealth
+      └── package.json
+```
+
+## Prerequisites (on .203)
+
+1. Node.js >= 18 (already installed)
+2. Chrome (latest) — already installed and logged into Meta Business Suite
+3. Cloudflare Tunnel (optional, for remote upload)
+
+## Chrome Setup
+
+### Option A: Chrome 144+ (native remote debugging)
+
+1. Open Chrome
+2. Go to `chrome://inspect/#remote-debugging`
+3. Click **Allow** (the toggle to enable remote debugging)
+4. Keep Chrome open and logged into https://business.facebook.com/
+
+### Option B: Command-line flag (any Chrome version)
+
+Create a shortcut or startup script:
+
+```
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+```
+
+Then log into https://business.facebook.com/ manually.
+
+## Server Setup
+
+```powershell
+cd C:\meta-publisher\server
+copy .env.example .env
+# Edit .env with your Supabase credentials
+npm install
+npm start
+```
+
+The server listens on `http://0.0.0.0:3001`.
+
+## Worker Setup
+
+```powershell
+cd C:\meta-publisher\worker
+copy .env.example .env
+# Edit .env with your Supabase credentials
+npm install
+npm start
+```
+
+## Cloudflare Tunnel (for remote upload)
+
+```powershell
+# Install cloudflared
+winget install Cloudflare.cloudflared
+
+# Create tunnel
+cloudflared tunnel create meta-pub
+
+# Route DNS
+cloudflared tunnel route dns meta-pub pub.yourdomain.com
+
+# Run
+cloudflared tunnel run meta-pub --url http://localhost:3001
+```
+
+### Optional: Run as Windows Services
+
+Use NSSM (Non-Sucking Service Manager) to run server + worker as services:
+
+```powershell
+nssm install MetaPublisherServer "C:\Program Files\nodejs\node.exe" "C:\meta-publisher\server\index.js"
+nssm install MetaPublisherWorker "C:\Program Files\nodejs\node.exe" "C:\meta-publisher\worker\index.js"
+```
+
+## Verifying
+
+1. Server health: `curl http://localhost:3001/health`
+2. Chrome debugging: Open `http://localhost:9222/json/version` in browser
+3. Worker logs: Check `C:\meta-publisher\worker\logs\`

--- a/meta-publisher/server/index.js
+++ b/meta-publisher/server/index.js
@@ -1,0 +1,121 @@
+const express = require("express")
+const cors = require("cors")
+const path = require("path")
+const fs = require("fs")
+const { Server } = require("@tus/server")
+const { FileStore } = require("@tus/file-store")
+require("dotenv").config()
+
+const PORT = parseInt(process.env.PORT, 10) || 3001
+const UPLOAD_DIR = process.env.UPLOAD_DIR || path.join(__dirname, "uploads")
+const SUPABASE_URL = process.env.SUPABASE_URL || ""
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+
+let supabase = null
+if (SUPABASE_URL && SUPABASE_KEY) {
+    const { createClient } = require("@supabase/supabase-js")
+    supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+        auth: { autoRefreshToken: false, persistSession: false },
+    })
+}
+
+fs.mkdirSync(UPLOAD_DIR, { recursive: true })
+
+const app = express()
+app.use(cors({ origin: true }))
+app.use(express.json())
+
+function extractAuth(req) {
+    const auth = req.headers.authorization || ""
+    const parts = auth.split(" ")
+    if (parts.length !== 2 || parts[0] !== "Bearer") return null
+    return parts[1]
+}
+
+// Health check
+app.get("/health", (_req, res) => {
+    res.json({ status: "ok", uptime: process.uptime() })
+})
+
+// FileStore for tus
+const fileStore = new FileStore({
+    directory: UPLOAD_DIR,
+})
+
+// tus server
+const tusServer = new Server(fileStore, {
+    path: "/upload",
+    async onIncomingRequest(req, res) {
+        const taskId = extractAuth(req)
+        if (!taskId) {
+            res.statusCode = 401
+            res.end(JSON.stringify({ error: "Missing or invalid Authorization header. Format: Bearer <taskId>" }))
+            return { completed: true }
+        }
+
+        if (!supabase) {
+            res.statusCode = 500
+            res.end(JSON.stringify({ error: "Server not configured" }))
+            return { completed: true }
+        }
+
+        const { data: task, error } = await supabase
+            .from("meta_publish_tasks")
+            .select("id, status")
+            .eq("id", taskId)
+            .single()
+
+        if (error || !task) {
+            res.statusCode = 404
+            res.end(JSON.stringify({ error: "Task not found" }))
+            return { completed: true }
+        }
+
+        if (task.status !== "uploading") {
+            res.statusCode = 400
+            res.end(JSON.stringify({ error: `Task is in '${task.status}' state, expected 'uploading'` }))
+            return { completed: true }
+        }
+
+        req.metaTaskId = taskId
+        return { completed: false }
+    },
+    async onUploadFinish(req, res, upload) {
+        const taskId = req.metaTaskId
+        const originalName = upload.metadata?.filename || "unknown"
+
+        if (taskId && supabase) {
+            const filePath = path.join(UPLOAD_DIR, upload.id)
+            await supabase
+                .from("meta_publish_tasks")
+                .update({
+                    status: "pending",
+                    video_path: filePath,
+                    video_original_name: originalName,
+                    upload_bytes_received: upload.size,
+                    upload_bytes_total: upload.size,
+                })
+                .eq("id", taskId)
+        }
+    },
+})
+
+app.all("/upload*", (req, res) => {
+    tusServer.handle(req, res)
+})
+
+// List uploaded files (for recovery)
+app.get("/files/:taskId", async (req, res) => {
+    const { taskId } = req.params
+    const dir = fs.readdirSync(UPLOAD_DIR)
+    const file = dir.find(f => f.includes(taskId))
+    if (!file) return res.status(404).json({ error: "File not found" })
+    const stat = fs.statSync(path.join(UPLOAD_DIR, file))
+    res.json({ filename: file, size: stat.size, created: stat.birthtime })
+})
+
+app.listen(PORT, "0.0.0.0", () => {
+    console.log(`Meta Publisher Server running on http://0.0.0.0:${PORT}`)
+    console.log(`Upload dir: ${UPLOAD_DIR}`)
+    console.log(`Allowed emails: ${ALLOWED_EMAILS.join(", ") || "(none)"}`)
+})

--- a/meta-publisher/server/package.json
+++ b/meta-publisher/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "meta-publisher-server",
+  "version": "1.0.0",
+  "private": true,
+  "description": "HTTP server on .203 that receives video uploads (tus) for Meta Business Suite publishing",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "@tus/file-store": "^1.0.0",
+    "@tus/server": "^1.0.0",
+    "@supabase/supabase-js": "^2.49.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2"
+  }
+}

--- a/meta-publisher/worker/index.js
+++ b/meta-publisher/worker/index.js
@@ -1,0 +1,164 @@
+/**
+ * meta-publisher worker
+ *
+ * Polls Supabase meta_publish_tasks table for pending tasks,
+ * executes publish-meta.js against the real Chrome, and updates
+ * the task status.
+ *
+ * Usage:
+ *   node index.js
+ */
+
+const { createClient } = require("@supabase/supabase-js")
+const { execSync } = require("child_process")
+const path = require("path")
+const fs = require("fs")
+
+require("dotenv").config()
+
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL, 10) || 10000
+const CHROME_PORT = parseInt(process.env.CHROME_PORT, 10) || 9222
+const PUBLISH_SCRIPT = process.env.PUBLISH_SCRIPT || path.join(__dirname, "publish-meta.js")
+const UPLOAD_DIR = process.env.UPLOAD_DIR || "C:\\meta-pub\\uploads"
+const LOG_DIR = process.env.LOG_DIR || path.join(__dirname, "logs")
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required")
+    process.exit(1)
+}
+
+fs.mkdirSync(LOG_DIR, { recursive: true })
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+})
+
+function log(level, message, data) {
+    const entry = {
+        timestamp: new Date().toISOString(),
+        level,
+        message,
+        ...data,
+    }
+    const line = JSON.stringify(entry)
+    console.log(line)
+    fs.appendFileSync(
+        path.join(LOG_DIR, `worker-${new Date().toISOString().slice(0, 10)}.log`),
+        line + "\n"
+    )
+}
+
+async function poll() {
+    try {
+        const { data: tasks, error } = await supabase
+            .from("meta_publish_tasks")
+            .select("*")
+            .in("status", ["pending"])
+            .order("created_at", { ascending: true })
+            .limit(5)
+
+        if (error) {
+            log("error", "Failed to poll tasks", { error: error.message })
+            return
+        }
+
+        for (const task of tasks || []) {
+            await processTask(task)
+        }
+    } catch (err) {
+        log("error", "Poll iteration failed", { error: err.message })
+    }
+}
+
+async function processTask(task) {
+    log("info", "Processing task", { taskId: task.id, type: task.task_type })
+
+    await supabase
+        .from("meta_publish_tasks")
+        .update({ status: "processing" })
+        .eq("id", task.id)
+
+    const taskFile = path.join(LOG_DIR, `task-${task.id}.json`)
+    fs.writeFileSync(taskFile, JSON.stringify(task, null, 2))
+
+    try {
+        const scriptPath = PUBLISH_SCRIPT
+        const cmd = `node "${scriptPath}" --task-file "${taskFile}" --chrome-port ${CHROME_PORT}`
+
+        log("info", "Executing publish script", { cmd })
+
+        const output = execSync(cmd, {
+            cwd: path.dirname(scriptPath),
+            timeout: 600000,
+            encoding: "utf-8",
+            maxBuffer: 10 * 1024 * 1024,
+        })
+
+        const resultMatch = output.match(/---RESULT---\n([\s\S]*?)\n---END RESULT---/)
+        if (!resultMatch) {
+            throw new Error("Could not parse script output")
+        }
+
+        const result = JSON.parse(resultMatch[1])
+
+        if (result.success) {
+            log("info", "Task completed successfully", {
+                taskId: task.id,
+                result: result.result,
+            })
+
+            await supabase
+                .from("meta_publish_tasks")
+                .update({
+                    status: "completed",
+                    result: result.result,
+                    completed_at: new Date().toISOString(),
+                })
+                .eq("id", task.id)
+
+            cleanupVideo(task)
+        } else {
+            throw new Error(result.error || "Unknown error")
+        }
+    } catch (err) {
+        log("error", "Task failed", { taskId: task.id, error: err.message })
+
+        await supabase
+            .from("meta_publish_tasks")
+            .update({
+                status: "failed",
+                error_message: err.message,
+            })
+            .eq("id", task.id)
+    } finally {
+        try {
+            fs.unlinkSync(taskFile)
+        } catch {}
+    }
+}
+
+function cleanupVideo(task) {
+    if (task.video_path && task.video_source === "upload") {
+        try {
+            fs.unlinkSync(task.video_path)
+            log("info", "Cleaned up uploaded video", { path: task.video_path })
+        } catch (err) {
+            log("warn", "Failed to cleanup video", {
+                path: task.video_path,
+                error: err.message,
+            })
+        }
+    }
+}
+
+console.log(`Meta Publisher Worker starting...`)
+console.log(`Supabase URL: ${SUPABASE_URL}`)
+console.log(`Chrome port: ${CHROME_PORT}`)
+console.log(`Poll interval: ${POLL_INTERVAL}ms`)
+console.log(`Publish script: ${PUBLISH_SCRIPT}`)
+console.log(`Log dir: ${LOG_DIR}`)
+
+poll()
+setInterval(poll, POLL_INTERVAL)

--- a/meta-publisher/worker/package.json
+++ b/meta-publisher/worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "meta-publisher-worker",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Worker on .203 that polls Supabase tasks and executes Puppeteer-core + Stealth for Meta Business Suite publishing",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "publish": "node publish-meta.js"
+  },
+  "dependencies": {
+    "commander": "^13.1.0",
+    "dotenv": "^16.4.7",
+    "@supabase/supabase-js": "^2.49.4",
+    "puppeteer-core": "^24.6.1",
+    "puppeteer-extra": "^3.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2"
+  }
+}

--- a/meta-publisher/worker/publish-meta.js
+++ b/meta-publisher/worker/publish-meta.js
@@ -1,0 +1,246 @@
+/**
+ * publish-meta.js
+ *
+ * Connects to an existing Chrome (via CDP) that is already logged into
+ * Meta Business Suite, then navigates the Meta UI to create the post.
+ *
+ * This is a DETERMINISTIC script — no AI, no LLM. It follows the same
+ * fixed sequence of steps every time. Selectors may need updates when
+ * Meta changes their UI.
+ *
+ * Usage:
+ *   node publish-meta.js --task '{"id":"...","taskType":"video",...}' --chrome-port 9222
+ */
+
+const { program } = require("commander")
+
+program
+    .option("--task <json>", "Task JSON string")
+    .option("--task-file <path>", "Path to task JSON file")
+    .option("--chrome-port <port>", "Chrome remote debugging port", "9222")
+    .option("--chrome-host <host>", "Chrome remote debugging host", "127.0.0.1")
+    .parse(process.argv)
+
+const opts = program.opts()
+
+let task
+if (opts.task) {
+    task = JSON.parse(opts.task)
+} else if (opts.taskFile) {
+    task = JSON.parse(require("fs").readFileSync(opts.taskFile, "utf-8"))
+} else {
+    console.error("Either --task or --task-file is required")
+    process.exit(1)
+}
+
+const CHROME_URL = `http://${opts.chromeHost}:${opts.chromePort}`
+
+async function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms))
+}
+
+async function waitForSelector(page, selector, timeout = 15000) {
+    await page.waitForSelector(selector, { timeout })
+}
+
+async function clickAndWait(page, selector, delay = 2000) {
+    await waitForSelector(page, selector)
+    await page.click(selector)
+    await sleep(delay)
+}
+
+async function typeText(page, selector, text) {
+    await waitForSelector(page, selector)
+    await page.click(selector, { clickCount: 3 })
+    await page.keyboard.press("Backspace")
+    await page.keyboard.type(text, { delay: 30 })
+}
+
+async function uploadFile(page, selector, filePath) {
+    await waitForSelector(page, selector)
+    const input = await page.$(selector)
+    await input.uploadFile(filePath)
+}
+
+async function navigateToBusinessSuite(page) {
+    await page.goto("https://business.facebook.com/", {
+        waitUntil: "networkidle2",
+        timeout: 30000,
+    })
+    await sleep(3000)
+}
+
+async function publishVideo(page, task) {
+    const { payload } = task
+    const { title, description, hashtags, scheduleTime } = payload
+
+    await clickAndWait(page, 'a[href*="/media"]', 3000)
+
+    await clickAndWait(page, 'div[aria-label="Create"]', 2000)
+
+    await clickAndWait(page, 'span:has-text("Video")', 2000)
+
+    if (task.video_path) {
+        await uploadFile(page, 'input[type="file"]', task.video_path)
+        await sleep(5000)
+    }
+
+    if (description) {
+        await typeText(page, 'div[aria-label*="description" i]', description)
+        await sleep(1000)
+    }
+
+    if (title) {
+        await typeText(page, 'div[aria-label*="title" i]', title)
+        await sleep(1000)
+    }
+
+    if (hashtags && Array.isArray(hashtags)) {
+        const existingText = description || ""
+        const tagText = existingText + " " + hashtags.map(h => `#${h}`).join(" ")
+        await typeText(page, 'div[aria-label*="description" i]', tagText)
+    }
+
+    if (scheduleTime) {
+        await clickAndWait(page, 'span:has-text("Schedule")', 1000)
+        await sleep(500)
+    }
+
+    await clickAndWait(page, 'div[aria-label="Publish"]', 5000)
+
+    let facebookUrl = null
+    let instagramUrl = null
+
+    const url = page.url()
+    if (url.includes("/facebook.com/")) {
+        facebookUrl = url
+    }
+
+    return { facebook_url: facebookUrl, instagram_url: instagramUrl }
+}
+
+async function publishPost(page, task) {
+    const { payload } = task
+    const { title, description, hashtags, imagePaths, linkUrl } = payload
+
+    await clickAndWait(page, 'a[href*="/media"]', 3000)
+    await clickAndWait(page, 'div[aria-label="Create"]', 2000)
+    await clickAndWait(page, 'span:has-text("Post")', 2000)
+
+    if (description) {
+        await typeText(page, 'div[role="textbox"][aria-label*="post" i]', description)
+    }
+
+    if (imagePaths && Array.isArray(imagePaths)) {
+        for (const imgPath of imagePaths) {
+            await uploadFile(page, 'input[type="file"]', imgPath)
+            await sleep(3000)
+        }
+    }
+
+    if (hashtags && Array.isArray(hashtags)) {
+        const tagText = " " + hashtags.map(h => `#${h}`).join(" ")
+        const textbox = await page.$('div[role="textbox"][aria-label*="post" i]')
+        if (textbox) {
+            await textbox.type(tagText, { delay: 30 })
+        }
+    }
+
+    await clickAndWait(page, 'div[aria-label="Publish"]', 5000)
+
+    return { facebook_url: page.url() }
+}
+
+async function publishStory(page, task) {
+    const { payload } = task
+    const { description, hashtags } = payload
+
+    await clickAndWait(page, 'a[href*="/stories"]', 3000)
+
+    if (task.video_path) {
+        await uploadFile(page, 'input[type="file"]', task.video_path)
+        await sleep(5000)
+    }
+
+    if (description) {
+        await typeText(page, 'div[aria-label*="story" i]', description)
+    }
+
+    if (hashtags && Array.isArray(hashtags)) {
+        const tagText = " " + hashtags.map(h => `#${h}`).join(" ")
+        const textbox = await page.$('div[aria-label*="story" i]')
+        if (textbox) {
+            await textbox.type(tagText, { delay: 30 })
+        }
+    }
+
+    await clickAndWait(page, 'div[aria-label="Share"]', 5000)
+
+    return { facebook_url: page.url() }
+}
+
+async function main() {
+    const puppeteer = require("puppeteer-extra")
+    const StealthPlugin = require("puppeteer-extra-plugin-stealth")
+    puppeteer.use(StealthPlugin())
+
+    console.log(`Connecting to Chrome at ${CHROME_URL}...`)
+
+    const browser = await puppeteer.connect({
+        browserURL: CHROME_URL,
+        defaultViewport: null,
+    })
+
+    console.log("Connected to Chrome. Opening new page...")
+
+    const page = await browser.newPage()
+    page.setDefaultTimeout(30000)
+
+    try {
+        await navigateToBusinessSuite(page)
+
+        console.log(`Starting publish task: ${task.id} (${task.taskType})`)
+
+        let result = {}
+        switch (task.taskType) {
+            case "video":
+                result = await publishVideo(page, task)
+                break
+            case "post":
+                result = await publishPost(page, task)
+                break
+            case "story":
+                result = await publishStory(page, task)
+                break
+            default:
+                throw new Error(`Unknown task type: ${task.taskType}`)
+        }
+
+        console.log("Publish completed successfully:", JSON.stringify(result))
+
+        await page.close()
+
+        return { success: true, result }
+    } catch (error) {
+        const screenshotPath = `error-${task.id}.png`
+        await page.screenshot({ path: screenshotPath, fullPage: true })
+        console.error(`Error screenshot saved to ${screenshotPath}`)
+
+        console.error("Publish failed:", error.message)
+        await page.close()
+
+        return { success: false, error: error.message }
+    }
+}
+
+main()
+    .then(output => {
+        console.log("---RESULT---")
+        console.log(JSON.stringify(output))
+        console.log("---END RESULT---")
+        process.exit(output.success ? 0 : 1)
+    })
+    .catch(err => {
+        console.error("Fatal error:", err.message)
+        process.exit(1)
+    })

--- a/src/app/api/meta/publish/route.ts
+++ b/src/app/api/meta/publish/route.ts
@@ -1,0 +1,206 @@
+import { getServerSession } from "@/lib/auth/get-server-session"
+import { getAdminClient } from "@/lib/supabase/server"
+import { createLogger } from "@/lib/logger"
+import { NextRequest, NextResponse } from "next/server"
+
+const logger = createLogger("MetaPublishApi")
+
+const ALLOWED_EMAILS = new Set([
+    "gabrieltothgoncalves@gmail.com",
+    "csgoblackbelt@gmail.com",
+])
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+        }
+
+        const supabase = getAdminClient()
+
+        const { data: user } = await supabase
+            .from("users")
+            .select("email")
+            .eq("id", session.user.id)
+            .single()
+
+        if (!user?.email || !ALLOWED_EMAILS.has(user.email)) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+        }
+
+        const { searchParams } = new URL(request.url)
+        const taskId = searchParams.get("id")
+        const status = searchParams.get("status")
+
+        let query = supabase
+            .from("meta_publish_tasks")
+            .select("*")
+            .eq("created_by", user.email)
+            .order("created_at", { ascending: false })
+            .limit(50)
+
+        if (taskId) {
+            query = query.eq("id", taskId)
+        }
+        if (status) {
+            query = query.eq("status", status)
+        }
+
+        const { data: tasks, error } = await query
+
+        if (error) {
+            logger.error("Failed to fetch meta tasks", { error: error.message })
+            return NextResponse.json(
+                { error: "Failed to fetch tasks" },
+                { status: 500 }
+            )
+        }
+
+        return NextResponse.json({ tasks })
+    } catch (error) {
+        logger.error("Unexpected error fetching meta tasks", {
+            error: error instanceof Error ? error.message : String(error),
+        })
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        )
+    }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    try {
+        const session = await getServerSession(request)
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+        }
+
+        const supabase = getAdminClient()
+
+        const { data: user } = await supabase
+            .from("users")
+            .select("email")
+            .eq("id", session.user.id)
+            .single()
+
+        if (!user?.email || !ALLOWED_EMAILS.has(user.email)) {
+            logger.warn("Unauthorized user attempted to create meta task", {
+                userId: session.user.id,
+                email: user?.email,
+            })
+            return NextResponse.json(
+                { error: "Forbidden: you are not authorized to use this feature" },
+                { status: 403 }
+            )
+        }
+
+        let body: Record<string, unknown>
+        try {
+            body = await request.json()
+        } catch {
+            return NextResponse.json(
+                { error: "Invalid JSON body" },
+                { status: 400 }
+            )
+        }
+
+        const taskType = body.taskType as string
+        if (!taskType || !["video", "post", "story"].includes(taskType)) {
+            return NextResponse.json(
+                { error: "taskType must be 'video', 'post', or 'story'" },
+                { status: 400 }
+            )
+        }
+
+        const videoSource = body.videoSource as string
+        if (videoSource && !["smb", "upload", "local"].includes(videoSource)) {
+            return NextResponse.json(
+                { error: "videoSource must be 'smb', 'upload', or 'local'" },
+                { status: 400 }
+            )
+        }
+
+        if (videoSource === "smb" && !body.videoPath) {
+            return NextResponse.json(
+                { error: "videoPath is required when videoSource is 'smb'" },
+                { status: 400 }
+            )
+        }
+
+        if (taskType === "video" && !videoSource) {
+            return NextResponse.json(
+                { error: "videoSource is required for video tasks" },
+                { status: 400 }
+            )
+        }
+
+        const payload = body.payload as Record<string, unknown> | undefined
+        if (!payload || typeof payload !== "object") {
+            return NextResponse.json(
+                { error: "payload must be a non-empty object" },
+                { status: 400 }
+            )
+        }
+
+        const platforms = payload.platforms as string[] | undefined
+        if (!Array.isArray(platforms) || platforms.length === 0) {
+            return NextResponse.json(
+                { error: "payload.platforms must be a non-empty array" },
+                { status: 400 }
+            )
+        }
+
+        for (const p of platforms) {
+            if (!["facebook", "instagram"].includes(p)) {
+                return NextResponse.json(
+                    {
+                        error: `Invalid platform '${p}' for meta publish. Only facebook and instagram are supported.`,
+                    },
+                    { status: 400 }
+                )
+            }
+        }
+
+        const { data: task, error } = await supabase
+            .from("meta_publish_tasks")
+            .insert({
+                created_by: user.email,
+                task_type: taskType,
+                video_source: videoSource || null,
+                video_path: body.videoPath || null,
+                video_original_name: body.videoOriginalName || null,
+                payload,
+                status: videoSource === "upload" ? "uploading" : "pending",
+            })
+            .select()
+            .single()
+
+        if (error) {
+            logger.error("Failed to create meta publish task", {
+                error: error.message,
+            })
+            return NextResponse.json(
+                { error: "Failed to create publish task" },
+                { status: 500 }
+            )
+        }
+
+        logger.info("Meta publish task created", {
+            taskId: task.id,
+            createdBy: user.email,
+            taskType,
+            videoSource,
+        })
+
+        return NextResponse.json({ task }, { status: 201 })
+    } catch (error) {
+        logger.error("Unexpected error in meta publish API", {
+            error: error instanceof Error ? error.message : String(error),
+        })
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        )
+    }
+}

--- a/src/components/publish/wizard/types.ts
+++ b/src/components/publish/wizard/types.ts
@@ -79,8 +79,14 @@ export interface PublishWizardState {
     /** Platform-specific metadata, keyed by platform id */
     platformMetadata: Record<
         string,
-        YouTubeMetadata | FacebookMetadata | TikTokMetadata
+        YouTubeMetadata | FacebookMetadata | TikTokMetadata | MetaPublishMetadata
     >
+
+    /** Video source for Facebook/Instagram meta publishing */
+    metaVideoSource?: "smb" | "upload" | "local"
+
+    /** SMB path for meta video */
+    metaVideoPath?: string
 
     /** Processing state */
     processing: ProcessingState
@@ -109,6 +115,17 @@ export interface AdSuitability {
 export interface FacebookMetadata {
     description: string
     tags: string[]
+}
+
+export interface MetaPublishMetadata {
+    description: string
+    tags: string[]
+    /** Where the video file comes from */
+    videoSource?: "smb" | "upload" | "local"
+    /** SMB path (only when videoSource is 'smb') */
+    videoPath?: string
+    /** Target platforms */
+    platforms: ("facebook" | "instagram")[]
 }
 
 export interface TikTokMetadata {
@@ -227,6 +244,12 @@ export const DEFAULT_FACEBOOK_METADATA: FacebookMetadata = {
 export const DEFAULT_TIKTOK_METADATA: TikTokMetadata = {
     description: "",
     tags: [],
+}
+
+export const DEFAULT_META_METADATA: MetaPublishMetadata = {
+    description: "",
+    tags: [],
+    platforms: [],
 }
 
 export const INITIAL_STATE: PublishWizardState = {

--- a/src/components/publish/wizard/usePublishExecution.ts
+++ b/src/components/publish/wizard/usePublishExecution.ts
@@ -5,6 +5,7 @@ import {
     type PublishWizardState,
     type PlatformResult,
     type YouTubeMetadata,
+    type MetaPublishMetadata,
     type WizardStep,
 } from "./types"
 
@@ -195,76 +196,131 @@ export default function usePublishExecution({
                                 : "Unknown error",
                     })
                 }
-            } else if (platformId === "facebook") {
-                // Post text to Facebook page feed
+            } else if (
+                platformId === "facebook" ||
+                platformId === "instagram"
+            ) {
                 setWizardState(prev => ({
                     ...prev,
                     processing: {
                         status: "uploading",
-                        platformId: "facebook",
+                        platformId,
                         progress: 0,
                         speed: "0 KB/s",
                     },
                 }))
 
                 try {
-                    const pageId = sel.channelIds[0]
-                    if (!pageId) {
+                    const metaMeta = wizardState.platformMetadata[
+                        "meta"
+                    ] as MetaPublishMetadata | undefined
+
+                    const description =
+                        wizardState.content.text || metaMeta?.description || ""
+                    const tags = metaMeta?.tags || []
+                    const videoSource = wizardState.metaVideoSource || "upload"
+                    const videoPath = wizardState.metaVideoPath || ""
+
+                    if (!description.trim() && !wizardState.content.videoFile) {
                         results.push({
-                            platformId: "facebook",
+                            platformId,
                             success: false,
-                            error: "No Facebook page selected",
+                            error: "No content or video provided",
                         })
                         continue
                     }
 
-                    const message = wizardState.content.text
-                    if (!message.trim()) {
-                        results.push({
-                            platformId: "facebook",
-                            success: false,
-                            error: "No message content",
-                        })
-                        continue
+                    // Collect all meta target platforms
+                    const metaPlatforms = wizardState.platformSelections
+                        .filter(
+                            s =>
+                                s.platformId === "facebook" ||
+                                s.platformId === "instagram"
+                        )
+                        .map(s => s.platformId as "facebook" | "instagram")
+
+                    // Create the task in Supabase
+                    const payload = {
+                        title: wizardState.content.autoFillTitle || "",
+                        description,
+                        hashtags: tags,
+                        platforms: metaPlatforms,
+                        channelIds: sel.channelIds,
+                        scheduleTime: null,
+                    }
+
+                    const taskRes = await fetch("/api/meta/publish", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                            taskType:
+                                wizardState.contentType === "video"
+                                    ? "video"
+                                    : "post",
+                            videoSource,
+                            videoPath: videoSource === "smb" ? videoPath : null,
+                            videoOriginalName:
+                                wizardState.content.videoFile?.name || null,
+                            payload,
+                        }),
+                    })
+
+                    if (!taskRes.ok) {
+                        const data = await taskRes.json()
+                        throw new Error(
+                            data.error || "Failed to create publish task"
+                        )
+                    }
+
+                    const { task } = await taskRes.json() as { task: { id: string; status: string } }
+
+                    // If video source is 'upload', upload the video via tus
+                    if (
+                        videoSource === "upload" &&
+                        wizardState.content.videoFile
+                    ) {
+                        setWizardState(prev => ({
+                            ...prev,
+                            processing: {
+                                status: "uploading",
+                                platformId,
+                                progress: 10,
+                                speed: "0 KB/s",
+                            },
+                        }))
+
+                        await uploadViaTus(
+                            wizardState.content.videoFile,
+                            task.id
+                        )
                     }
 
                     setWizardState(prev => ({
                         ...prev,
                         processing: {
                             status: "publishing",
-                            platformId: "facebook",
+                            platformId,
                         },
                     }))
 
-                    const res = await fetch("/api/platform/facebook/publish", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({
-                            pageId,
-                            message,
-                        }),
-                    })
+                    // Poll until task is completed or failed
+                    const finalTask = await pollTaskResult(task.id)
 
-                    if (!res.ok) {
-                        const data = await res.json()
+                    if (finalTask.status === "completed") {
+                        const r = finalTask.result as Record<string, string> | undefined
+                        results.push({
+                            platformId,
+                            success: true,
+                            url: r?.facebook_url || r?.instagram_url,
+                        })
+                    } else {
                         throw new Error(
-                            data.message ||
-                                data.error ||
-                                "Failed to publish to Facebook"
+                            finalTask.error_message || "Publishing failed"
                         )
                     }
-
-                    const result = await res.json()
-                    results.push({
-                        platformId: "facebook",
-                        success: true,
-                        url: result.url,
-                    })
                 } catch (err) {
                     results.push({
-                        platformId: "facebook",
+                        platformId,
                         success: false,
                         error:
                             err instanceof Error
@@ -333,4 +389,73 @@ export default function usePublishExecution({
         handleRetry,
         isPublishing: wizardState.processing.status !== "idle",
     }
+}
+
+async function uploadViaTus(file: File, taskId: string): Promise<void> {
+    const TUS_ENDPOINT =
+        process.env.NEXT_PUBLIC_META_TUS_ENDPOINT ||
+        "https://pub.gabrieltoth.com/upload"
+
+    return new Promise((resolve, reject) => {
+        const { Upload } = require("@tus/upload-js") as {
+            Upload: new (file: File, opts: Record<string, unknown>) => {
+                start: () => void
+                abort: () => void
+            }
+        }
+
+        const upload = new Upload(file, {
+            endpoint: TUS_ENDPOINT,
+            headers: {
+                Authorization: `Bearer ${taskId}`,
+            },
+            metadata: {
+                filename: file.name,
+                filetype: file.type,
+                taskId,
+            },
+            chunkSize: 5 * 1024 * 1024,
+            retryDelays: [0, 3000, 5000, 10000, 20000],
+            onError: (err: Error) => {
+                reject(err)
+            },
+            onProgress: (_bytesSent: number, _bytesTotal: number) => {
+                // could update progress via callback
+            },
+            onSuccess: () => {
+                resolve()
+            },
+        })
+
+        upload.start()
+    })
+}
+
+async function pollTaskResult(
+    taskId: string,
+    maxAttempts = 120,
+    intervalMs = 2000
+): Promise<{ status: string; result?: unknown; error_message?: string }> {
+    for (let i = 0; i < maxAttempts; i++) {
+        const res = await fetch(`/api/meta/publish?id=${taskId}`)
+        const { tasks } = await res.json()
+        const task = tasks?.[0]
+
+        if (!task) {
+            await new Promise(r => setTimeout(r, intervalMs))
+            continue
+        }
+
+        if (task.status === "completed") {
+            return { status: "completed", result: task.result }
+        }
+
+        if (task.status === "failed") {
+            return { status: "failed", error_message: task.error_message }
+        }
+
+        await new Promise(r => setTimeout(r, intervalMs))
+    }
+
+    return { status: "failed", error_message: "Timed out waiting for publish" }
 }

--- a/supabase/migrations/20260720_meta_publish_tasks.sql
+++ b/supabase/migrations/20260720_meta_publish_tasks.sql
@@ -1,0 +1,105 @@
+-- Migration: meta_publish_tasks
+-- Description: Queue for Meta Business Suite browser automation tasks.
+-- When a user publishes to Facebook/Instagram, instead of calling the Graph API
+-- (which is localOnly / unapproved), a task is created here. The .203 worker
+-- polls this table, executes Puppeteer-core + stealth against a real Chrome
+-- session logged into Meta Business Suite.
+
+-- ============================================================================
+-- META_PUBLISH_TASKS TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.meta_publish_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Who created this task (JWT email verified server-side)
+  created_by TEXT NOT NULL,
+
+  -- Task lifecycle
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'uploading', 'downloading', 'processing', 'completed', 'failed')),
+
+  -- What to publish
+  task_type TEXT NOT NULL
+    CHECK (task_type IN ('video', 'post', 'story')),
+
+  -- Full metadata (title, description, hashtags, schedule, platforms, etc.)
+  payload JSONB NOT NULL DEFAULT '{}',
+
+  -- Video source: 'smb' (direct from .100), 'upload' (via tus from anywhere), 'local' (already on .203)
+  video_source TEXT
+    CHECK (video_source IN ('smb', 'upload', 'local')),
+
+  -- SMB path or local path on .203
+  video_path TEXT,
+
+  -- Original filename (for display / logs)
+  video_original_name TEXT,
+
+  -- Upload progress tracking
+  upload_bytes_received BIGINT DEFAULT 0,
+  upload_bytes_total BIGINT,
+
+  -- Result
+  result JSONB,
+  error_message TEXT,
+
+  -- Timestamps
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_status ON public.meta_publish_tasks(status);
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_created_by ON public.meta_publish_tasks(created_by);
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_created_at ON public.meta_publish_tasks(created_at);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+
+ALTER TABLE public.meta_publish_tasks ENABLE ROW LEVEL SECURITY;
+
+-- Only allowed users can insert tasks
+-- Whitelist: gabrieltothgoncalves@gmail.com, csgoblackbelt@gmail.com
+CREATE POLICY "Allowed users can create tasks"
+  ON public.meta_publish_tasks FOR INSERT
+  WITH CHECK (
+    auth.email() IN (
+      'gabrieltothgoncalves@gmail.com',
+      'csgoblackbelt@gmail.com'
+    )
+    AND created_by = auth.email()
+  );
+
+-- Users can view their own tasks
+CREATE POLICY "Users can view own tasks"
+  ON public.meta_publish_tasks FOR SELECT
+  USING (
+    created_by = auth.email()
+    AND auth.email() IN (
+      'gabrieltothgoncalves@gmail.com',
+      'csgoblackbelt@gmail.com'
+    )
+  );
+
+-- Only service_role can update (for the .203 worker)
+-- This is enforced via the API route that checks service_role key
+-- No UPDATE policy for public role
+
+-- ============================================================================
+-- UPDATED AT TRIGGER
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.update_meta_publish_tasks_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_meta_publish_tasks_updated_at
+  BEFORE UPDATE ON public.meta_publish_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_meta_publish_tasks_updated_at();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -926,3 +926,87 @@ COMMENT ON COLUMN public.scheduled_streams.platform IS 'Array of platforms for t
 COMMENT ON COLUMN public.scheduled_streams.status IS 'Current status: scheduled, cancelled, live, completed';
 COMMENT ON COLUMN public.scheduled_streams.notification_methods IS 'Array of notification channels (discord, telegram)';
 COMMENT ON COLUMN public.scheduled_streams.notification_sent IS 'Whether notification has been sent for this stream';
+
+-- ============================================================================
+-- META_PUBLISH_TASKS TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.meta_publish_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Who created this task (JWT email verified server-side)
+  created_by TEXT NOT NULL,
+
+  -- Task lifecycle
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'uploading', 'downloading', 'processing', 'completed', 'failed')),
+
+  -- What to publish
+  task_type TEXT NOT NULL
+    CHECK (task_type IN ('video', 'post', 'story')),
+
+  -- Full metadata (title, description, hashtags, schedule, platforms, etc.)
+  payload JSONB NOT NULL DEFAULT '{}',
+
+  -- Video source: 'smb' (direct from .100), 'upload' (via tus from anywhere), 'local' (already on .203)
+  video_source TEXT
+    CHECK (video_source IN ('smb', 'upload', 'local')),
+
+  -- SMB path or local path on .203
+  video_path TEXT,
+
+  -- Original filename (for display / logs)
+  video_original_name TEXT,
+
+  -- Upload progress tracking
+  upload_bytes_received BIGINT DEFAULT 0,
+  upload_bytes_total BIGINT,
+
+  -- Result
+  result JSONB,
+  error_message TEXT,
+
+  -- Timestamps
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_status ON public.meta_publish_tasks(status);
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_created_by ON public.meta_publish_tasks(created_by);
+CREATE INDEX IF NOT EXISTS idx_meta_publish_tasks_created_at ON public.meta_publish_tasks(created_at);
+
+ALTER TABLE public.meta_publish_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allowed users can create tasks"
+  ON public.meta_publish_tasks FOR INSERT
+  WITH CHECK (
+    auth.email() IN (
+      'gabrieltothgoncalves@gmail.com',
+      'csgoblackbelt@gmail.com'
+    )
+    AND created_by = auth.email()
+  );
+
+CREATE POLICY "Users can view own tasks"
+  ON public.meta_publish_tasks FOR SELECT
+  USING (
+    created_by = auth.email()
+    AND auth.email() IN (
+      'gabrieltothgoncalves@gmail.com',
+      'csgoblackbelt@gmail.com'
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.update_meta_publish_tasks_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_meta_publish_tasks_updated_at
+  BEFORE UPDATE ON public.meta_publish_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_meta_publish_tasks_updated_at();


### PR DESCRIPTION
Closes #311

## Summary

New system for publishing to Facebook and Instagram via **real Chrome browser automation** on .203 (pentester-01), bypassing the need for Meta Graph API approval.

## Components

### Site (Next.js)
- **supabase/migrations/20260720_meta_publish_tasks.sql** — New table + RLS (only gabrieltothgoncalves@gmail.com and csgoblackbelt@gmail.com)
- **src/app/api/meta/publish/route.ts** — POST to create task, GET to poll task status
- **src/components/publish/wizard/types.ts** — MetaPublishMetadata type
- **src/components/publish/wizard/usePublishExecution.ts** — Meta publish handler (video source selection, tus upload, polling)

### .203 (pentester-01)
- **meta-publisher/server/** — Express + tus server for chunked/resumable video upload via Cloudflare Tunnel
- **meta-publisher/worker/** — Polls Supabase, executes publish-meta.js against real Chrome
- **meta-publisher/worker/publish-meta.js** — Puppeteer-core + stealth plugin for deterministic Meta Business Suite automation

## Flow
1. Wizard creates task in Supabase
2. Client uploads video via tus (chunked, retomável) to .203 OR provides SMB path
3. Worker picks up task, connects to real Chrome (already logged into Meta)
4. Puppeteer navigates Meta Business Suite UI and publishes
5. Website polls task status until complete