### PR TITLE
feat(services): migrate relay server and worker scripts to .203

### DIFF
--- a/relay/src/moderation-handler.ts
+++ b/relay/src/moderation-handler.ts
@@ -1,0 +1,273 @@
+import { WebSocket } from "ws"
+
+const PLATFORM_MAX_TIMEOUTS: Record<string, number> = {
+    twitch: 1209600,    // 14 days in seconds (Twitch max)
+    kick: 86400,        // 24 hours in seconds (Kick max)
+    youtube: 86400,     // 24 hours (YouTube chat timeout max via API)
+}
+
+const TIMEOUT_REAPPLY_BEFORE = 60 // seconds before expiry to re-apply
+const RECHECK_INTERVAL = 30_000   // check every 30s
+
+interface ScheduledTimeout {
+    targetUserId: string
+    targetUsername: string
+    platform: string
+    duration: number        // original requested duration in seconds
+    appliedDuration: number // actual applied duration (platform max or requested)
+    appliedAt: number       // timestamp when last applied
+    expiresAt: number       // when the current timeout expires
+    repeatCount: number
+    reapplyTimer: ReturnType<typeof setInterval> | null
+}
+
+const activeTimeouts = new Map<string, ScheduledTimeout>()
+
+function timeoutKey(platform: string, targetUserId: string): string {
+    return `${platform}:${targetUserId}`
+}
+
+function getEffectiveDuration(duration: number, platform: string): number {
+    const max = PLATFORM_MAX_TIMEOUTS[platform] || 86400
+    return Math.min(duration, max)
+}
+
+export async function executeModeration(
+    ws: WebSocket,
+    userId: string,
+    action: string,
+    targetUserId: string,
+    targetUsername: string,
+    platform: string,
+    duration?: number,
+    reason?: string,
+    twitchRelay?: any,
+    kickRelay?: any
+): Promise<void> {
+    const key = timeoutKey(platform, targetUserId)
+
+    if (action === "timeout") {
+        const requestedDuration = duration || 600
+        const effective = getEffectiveDuration(requestedDuration, platform)
+
+        if (platform === "twitch" && twitchRelay) {
+            await executeTwitchTimeout(twitchRelay, targetUsername, effective, reason)
+        } else if (platform === "kick" && kickRelay) {
+            await executeKickTimeout(kickRelay, targetUsername, effective, reason)
+        } else {
+            sendError(ws, platform, `No relay available for ${platform}`)
+            return
+        }
+
+        // If requested > platform max, schedule re-apply
+        if (requestedDuration > effective) {
+            const existing = activeTimeouts.get(key)
+            if (existing?.reapplyTimer) {
+                clearInterval(existing.reapplyTimer)
+            }
+
+            const st: ScheduledTimeout = {
+                targetUserId,
+                targetUsername,
+                platform,
+                duration: requestedDuration,
+                appliedDuration: effective,
+                appliedAt: Date.now(),
+                expiresAt: Date.now() + effective * 1000,
+                repeatCount: 1,
+                reapplyTimer: null,
+            }
+
+            st.reapplyTimer = setInterval(() => {
+                const remaining = st.expiresAt - Date.now()
+                if (remaining <= TIMEOUT_REAPPLY_BEFORE * 1000) {
+                    const nextEffective = getEffectiveDuration(
+                        st.duration - st.repeatCount * st.appliedDuration,
+                        platform
+                    )
+                    if (nextEffective <= 0) {
+                        clearInterval(st.reapplyTimer!)
+                        activeTimeouts.delete(key)
+                        return
+                    }
+
+                    if (platform === "twitch" && twitchRelay) {
+                        executeTwitchTimeout(twitchRelay, targetUsername, nextEffective, reason)
+                            .then(() => {
+                                st.appliedAt = Date.now()
+                                st.expiresAt = Date.now() + nextEffective * 1000
+                                st.repeatCount++
+                            })
+                            .catch(() => {})
+                    } else if (platform === "kick" && kickRelay) {
+                        executeKickTimeout(kickRelay, targetUsername, nextEffective, reason)
+                            .then(() => {
+                                st.appliedAt = Date.now()
+                                st.expiresAt = Date.now() + nextEffective * 1000
+                                st.repeatCount++
+                            })
+                            .catch(() => {})
+                    }
+                }
+            }, RECHECK_INTERVAL)
+
+            activeTimeouts.set(key, st)
+        }
+
+        sendResult(ws, "timeout", true, { platform, targetUsername, duration: effective, willReapply: requestedDuration > effective })
+        return
+    }
+
+    if (action === "ban") {
+        if (platform === "twitch" && twitchRelay) {
+            await executeTwitchBan(twitchRelay, targetUsername, reason)
+        } else if (platform === "kick" && kickRelay) {
+            await executeKickBan(kickRelay, targetUsername, reason)
+        } else {
+            sendError(ws, platform, `No relay available for ${platform}`)
+            return
+        }
+
+        // Cancel any active timeout re-apply for this user
+        const existing = activeTimeouts.get(key)
+        if (existing?.reapplyTimer) {
+            clearInterval(existing.reapplyTimer)
+            activeTimeouts.delete(key)
+        }
+
+        sendResult(ws, "ban", true, { platform, targetUsername })
+        return
+    }
+
+    if (action === "unban") {
+        if (platform === "twitch" && twitchRelay) {
+            await executeTwitchUnban(twitchRelay, targetUsername)
+        } else if (platform === "kick" && kickRelay) {
+            await executeKickUnban(kickRelay, targetUsername)
+        } else {
+            sendError(ws, platform, `No relay available for ${platform}`)
+            return
+        }
+
+        const existing = activeTimeouts.get(key)
+        if (existing?.reapplyTimer) {
+            clearInterval(existing.reapplyTimer)
+            activeTimeouts.delete(key)
+        }
+
+        sendResult(ws, "unban", true, { platform, targetUsername })
+        return
+    }
+
+    sendError(ws, platform, `Unknown moderation action: ${action}`)
+}
+
+// --- Twitch moderation via IRC ---
+
+async function executeTwitchTimeout(
+    twitchRelay: any,
+    username: string,
+    duration: number,
+    reason?: string
+): Promise<void> {
+    const msg = reason
+        ? `/timeout ${username} ${duration} ${reason}`
+        : `/timeout ${username} ${duration}`
+    return twitchRelay.sendChat(msg)
+}
+
+async function executeTwitchBan(
+    twitchRelay: any,
+    username: string,
+    reason?: string
+): Promise<void> {
+    const msg = reason ? `/ban ${username} ${reason}` : `/ban ${username}`
+    return twitchRelay.sendChat(msg)
+}
+
+async function executeTwitchUnban(
+    twitchRelay: any,
+    username: string
+): Promise<void> {
+    return twitchRelay.sendChat(`/unban ${username}`)
+}
+
+// --- Kick moderation via API ---
+
+async function executeKickTimeout(
+    kickRelay: any,
+    username: string,
+    duration: number,
+    reason?: string
+): Promise<void> {
+    return kickRelay.sendChat(`/timeout ${username} ${duration}${reason ? ` ${reason}` : ""}`)
+}
+
+async function executeKickBan(
+    kickRelay: any,
+    username: string,
+    reason?: string
+): Promise<void> {
+    return kickRelay.sendChat(`/ban ${username}${reason ? ` ${reason}` : ""}`)
+}
+
+async function executeKickUnban(
+    kickRelay: any,
+    username: string
+): Promise<void> {
+    return kickRelay.sendChat(`/unban ${username}`)
+}
+
+// --- Helpers ---
+
+function sendResult(
+    ws: WebSocket,
+    action: string,
+    success: boolean,
+    data?: Record<string, unknown>
+): void {
+    if (ws.readyState === WebSocket.OPEN) {
+        ws.send(
+            JSON.stringify({
+                type: "moderation_result",
+                action,
+                success,
+                data,
+            })
+        )
+    }
+}
+
+function sendError(
+    ws: WebSocket,
+    platform: string,
+    error: string
+): void {
+    if (ws.readyState === WebSocket.OPEN) {
+        ws.send(
+            JSON.stringify({
+                type: "error",
+                platform,
+                error,
+            })
+        )
+    }
+}
+
+export function cleanupTimeoutsForUser(targetUserId: string, platform: string): void {
+    const key = timeoutKey(platform, targetUserId)
+    const existing = activeTimeouts.get(key)
+    if (existing?.reapplyTimer) {
+        clearInterval(existing.reapplyTimer)
+    }
+    activeTimeouts.delete(key)
+}
+
+export function cleanupAllTimeouts(): void {
+    for (const [, st] of activeTimeouts) {
+        if (st.reapplyTimer) {
+            clearInterval(st.reapplyTimer)
+        }
+    }
+    activeTimeouts.clear()
+}

--- a/relay/src/relay-server.ts
+++ b/relay/src/relay-server.ts
@@ -5,6 +5,7 @@ import jwt from "jsonwebtoken"
 import { YouTubeRelay } from "./youtube-relay.js"
 import { TwitchIrcRelay } from "./twitch-relay.js"
 import { KickPusherRelay } from "./kick-relay.js"
+import { executeModeration, cleanupAllTimeouts } from "./moderation-handler.js"
 
 config()
 
@@ -187,6 +188,24 @@ wss.on("connection", (ws: WebSocket, req) => {
                 } else if (platform === "youtube") {
                     handleYouTubeDisconnect(clientInfo)
                 }
+                return
+            }
+
+            if (msg.type === "moderate") {
+                const tRelay = twitchRelays.get(clientInfo.userId)
+                const kRelay = kickRelays.get(clientInfo.userId)
+                await executeModeration(
+                    clientInfo.ws,
+                    clientInfo.userId,
+                    msg.action,
+                    msg.targetUserId,
+                    msg.targetUsername,
+                    msg.platform,
+                    msg.duration,
+                    msg.reason,
+                    tRelay,
+                    kRelay
+                )
                 return
             }
         } catch {
@@ -674,6 +693,7 @@ function cleanupClient(client: ClientInfo): void {
     twitchRelays.delete(client.userId)
     kickRelays.delete(client.userId)
     youtubeRelays.delete(client.userId)
+    cleanupAllTimeouts()
 }
 
 setInterval(() => {

--- a/relay/src/twitch-relay.ts
+++ b/relay/src/twitch-relay.ts
@@ -116,6 +116,14 @@ export class TwitchIrcRelay extends EventEmitter {
         })
     }
 
+    async sendChat(message: string): Promise<void> {
+        for (const [, conn] of this.connections) {
+            if (conn.connected) {
+                conn.socket.write(`PRIVMSG #${conn.roomId} :${message}\r\n`)
+            }
+        }
+    }
+
     disconnect(roomId: string): void {
         const reconnectTimer = this.reconnectTimers.get(roomId)
         if (reconnectTimer) {

--- a/src/components/dashboard/live/chat-message-list.tsx
+++ b/src/components/dashboard/live/chat-message-list.tsx
@@ -1,8 +1,3 @@
-/**
- * ChatMessageList Component
- * Renders list of live chat messages from multiple platforms
- */
-
 "use client"
 
 import { RefObject } from "react"
@@ -13,18 +8,38 @@ export interface RenderableChatMessage {
     content: string
     platform: string
     timestamp: number
+    duplicateCount?: number
+    platformIcons?: string[]
+    userId?: string
+    displayName?: string
+    isBroadcaster?: boolean
+    isModerator?: boolean
+    isSubscriber?: boolean
+    isVip?: boolean
 }
 
 interface ChatMessageListProps {
-    messages: RenderableChatMessage[]
+    messages: (RenderableChatMessage & { duplicateCount: number })[]
     getPlatformBadge: (platform: string) => { label: string; bgClass: string }
     messagesEndRef: RefObject<HTMLDivElement | null>
+    onUserClick?: (msg: RenderableChatMessage & { duplicateCount: number }) => void
+}
+
+const PLATFORM_MINIS: Record<string, { color: string; label: string }> = {
+    twitch: { color: "#9147ff", label: "TW" },
+    kick: { color: "#00e676", label: "KC" },
+    youtube: { color: "#ff0000", label: "YT" },
+    facebook: { color: "#1877f2", label: "FB" },
+    instagram: { color: "#e4405f", label: "IG" },
+    tiktok: { color: "#000000", label: "TK" },
+    linkedin: { color: "#0a66c2", label: "LI" },
 }
 
 export function ChatMessageList({
     messages,
     getPlatformBadge,
     messagesEndRef,
+    onUserClick,
 }: ChatMessageListProps) {
     return (
         <div className="flex-1 overflow-y-auto space-y-2 mb-3 pr-1 text-xs">
@@ -38,6 +53,7 @@ export function ChatMessageList({
             ) : (
                 messages.map((msg) => {
                     const badge = getPlatformBadge(msg.platform)
+                    const dupPlatforms = msg.platformIcons || (msg.duplicateCount > 1 ? [msg.platform] : [])
                     return (
                         <div key={msg.id} className="flex items-start gap-1.5 leading-relaxed">
                             <span
@@ -45,10 +61,31 @@ export function ChatMessageList({
                             >
                                 {badge.label}
                             </span>
-                            <span className="font-semibold text-neutral-300">
+                            <button
+                                onClick={() => onUserClick?.(msg)}
+                                className="font-semibold text-neutral-300 hover:text-indigo-400 transition-colors cursor-pointer"
+                            >
                                 {msg.author}:
-                            </span>
+                            </button>
                             <span className="text-neutral-200 break-words">{msg.content}</span>
+                            {dupPlatforms.length > 1 && (
+                                <span className="flex items-center gap-0.5 ml-auto shrink-0">
+                                    {dupPlatforms.map(p => {
+                                        const m = PLATFORM_MINIS[p]
+                                        if (!m) return null
+                                        return (
+                                            <span
+                                                key={p}
+                                                className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-[6px] font-bold text-white"
+                                                style={{ backgroundColor: m.color }}
+                                                title={p}
+                                            >
+                                                {m.label}
+                                            </span>
+                                        )
+                                    })}
+                                </span>
+                            )}
                         </div>
                     )
                 })

--- a/src/components/dashboard/live/unified-chat.tsx
+++ b/src/components/dashboard/live/unified-chat.tsx
@@ -1,16 +1,11 @@
-/**
- * UnifiedChat Component
- * Displays combined chat feed from multiple platforms (Twitch + Kick + YouTube)
- * Uses SSE backend for real-time messages.
- */
-
 "use client"
 
-import { useRelayChat } from "@/hooks/use-relay-chat"
+import { useRelayChat, RelayChatMessage } from "@/hooks/use-relay-chat"
 import { createLogger } from "@/lib/logger"
 import { useCallback, useRef, useEffect, useState, useMemo } from "react"
 import { ChatMessageList, RenderableChatMessage } from "./chat-message-list"
 import { ChatCommandPalette, CommandItem } from "./chat-command-palette"
+import { UserCard } from "./user-card"
 
 interface UnifiedChatProps {
     platforms: string[]
@@ -18,42 +13,71 @@ interface UnifiedChatProps {
 }
 
 const COMMANDS: CommandItem[] = [
-    {
-        name: "/timeout",
-        description: "Timeout a user",
-        usage: "/timeout <username> [duration] [reason]",
-    },
-    {
-        name: "/ban",
-        description: "Ban a user",
-        usage: "/ban <username> [reason]",
-    },
-    {
-        name: "/unban",
-        description: "Unban a user",
-        usage: "/unban <username>",
-    },
-    {
-        name: "/me",
-        description: "Send an action message",
-        usage: "/me <message>",
-    },
-    {
-        name: "/slow",
-        description: "Slow mode on/off",
-        usage: "/slow [seconds] | /slow on | /slow off",
-    },
-    {
-        name: "/subscribers",
-        description: "Subscribers-only on/off",
-        usage: "/subscribers | /subscribersoff",
-    },
+    { name: "/timeout", description: "Timeout a user", usage: "/timeout <username> [duration] [reason]" },
+    { name: "/ban", description: "Ban a user", usage: "/ban <username> [reason]" },
+    { name: "/unban", description: "Unban a user", usage: "/unban <username>" },
+    { name: "/me", description: "Send an action message", usage: "/me <message>" },
+    { name: "/slow", description: "Slow mode on/off", usage: "/slow [seconds] | /slow on | /slow off" },
+    { name: "/subscribers", description: "Subscribers-only on/off", usage: "/subscribers | /subscribersoff" },
 ]
 
 const logger = createLogger("UnifiedChat")
 
+const DUP_WINDOW_MS = 10000
+
+function deduplicateAndGroup(all: RenderableChatMessage[]): (RenderableChatMessage & { duplicateCount: number })[] {
+    const groups: RenderableChatMessage[][] = []
+    const used = new Set<string>()
+
+    for (const msg of all) {
+        if (used.has(msg.id)) continue
+        const key = `${msg.author}|${msg.content}`
+        const cluster: RenderableChatMessage[] = [msg]
+        used.add(msg.id)
+
+        for (const other of all) {
+            if (used.has(other.id)) continue
+            const otherKey = `${other.author}|${other.content}`
+            if (key === otherKey && Math.abs(other.timestamp - msg.timestamp) < DUP_WINDOW_MS) {
+                cluster.push(other)
+                used.add(other.id)
+            }
+        }
+
+        groups.push(cluster)
+    }
+
+    return groups
+        .map(g => ({
+            ...g[0],
+            duplicateCount: g.length,
+            platformIcons: [...new Set(g.map(m => m.platform))],
+        }))
+        .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+const PLATFORM_COLORS: Record<string, string> = {
+    twitch: "bg-purple-600",
+    kick: "bg-emerald-600",
+    youtube: "bg-red-600",
+    facebook: "bg-blue-600",
+    instagram: "bg-pink-600",
+    tiktok: "bg-neutral-600",
+    linkedin: "bg-blue-800",
+}
+
 export function UnifiedChat({ platforms }: UnifiedChatProps) {
     const relay = useRelayChat()
+    const [enabledPlatforms, setEnabledPlatforms] = useState<Set<string>>(new Set(platforms))
+    const [sendMode, setSendMode] = useState<string>(platforms[0] || "twitch")
+    const [selectedUser, setSelectedUser] = useState<(RenderableChatMessage & { duplicateCount: number }) | null>(null)
+
+    useEffect(() => {
+        setEnabledPlatforms(new Set(platforms))
+        if (!platforms.includes(sendMode) && sendMode !== "all") {
+            setSendMode(platforms[0] || "twitch")
+        }
+    }, [platforms, sendMode])
 
     const allMessages: RenderableChatMessage[] = useMemo(() => {
         return relay.messages.map(m => ({
@@ -62,17 +86,31 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
             content: m.content,
             platform: m.platform,
             timestamp: m.timestamp,
+            userId: m.user?.id,
+            displayName: m.user?.displayName,
+            isBroadcaster: m.user?.isBroadcaster,
+            isModerator: m.user?.isModerator,
+            isSubscriber: m.user?.isSubscriber,
+            isVip: (m.user as any)?.isVip,
         }))
     }, [relay.messages])
 
-    const statusText = relay.isConnected
-        ? "Connected"
-        : "Disconnected"
+    const groupedMessages = useMemo(() => {
+        const filtered = allMessages.filter(m => enabledPlatforms.has(m.platform))
+        return deduplicateAndGroup(filtered)
+    }, [allMessages, enabledPlatforms])
+
+    const platformCounts = useMemo(() => {
+        const counts: Record<string, number> = {}
+        for (const m of allMessages) {
+            counts[m.platform] = (counts[m.platform] || 0) + 1
+        }
+        return counts
+    }, [allMessages])
+
+    const statusText = relay.isConnected ? "Connected" : "Disconnected"
 
     const [input, setInput] = useState("")
-    const [selectedPlatform, setSelectedPlatform] = useState(
-        platforms[0] || "twitch"
-    )
     const [historyIndex, setHistoryIndex] = useState(-1)
     const [showCommands, setShowCommands] = useState(false)
     const [selectedCmd, setSelectedCmd] = useState(0)
@@ -81,15 +119,15 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-    }, [allMessages])
+        if (!selectedUser) {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+        }
+    }, [groupedMessages, selectedUser])
 
     const filteredCommands = useMemo(() => {
         if (!input.startsWith("/")) return []
         const query = input.slice(1).toLowerCase()
-        return COMMANDS.filter((cmd) =>
-            cmd.name.slice(1).toLowerCase().startsWith(query)
-        )
+        return COMMANDS.filter(cmd => cmd.name.slice(1).toLowerCase().startsWith(query))
     }, [input])
 
     useEffect(() => {
@@ -101,10 +139,18 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
         }
     }, [input, filteredCommands.length])
 
+    const togglePlatform = useCallback((p: string) => {
+        setEnabledPlatforms(prev => {
+            const next = new Set(prev)
+            if (next.has(p)) { if (next.size > 1) next.delete(p) }
+            else next.add(p)
+            return next
+        })
+    }, [])
+
     const handleSend = useCallback(async () => {
         const text = input.trim()
         if (!text || sending) return
-
         setSending(true)
         try {
             if (!historyRef.current.includes(text)) {
@@ -112,14 +158,17 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
             }
             setHistoryIndex(-1)
 
-            await fetch("/api/live/chat/send", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    platform: selectedPlatform,
-                    message: text,
-                }),
-            })
+            const targetPlatforms = sendMode === "all" ? platforms : [sendMode]
+
+            await Promise.all(
+                targetPlatforms.map(p =>
+                    fetch("/api/live/chat/send", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ platform: p, message: text }),
+                    })
+                )
+            )
 
             setInput("")
             setShowCommands(false)
@@ -128,57 +177,92 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
         } finally {
             setSending(false)
         }
-    }, [input, sending, selectedPlatform])
+    }, [input, sending, sendMode, platforms])
+
+    const handleModerate = useCallback(
+        (action: string, duration?: number) => {
+            if (!selectedUser) return
+            relay.sendModeration(
+                action,
+                selectedUser.userId || selectedUser.author,
+                selectedUser.author,
+                selectedUser.platform,
+                duration,
+            )
+        },
+        [selectedUser, relay.sendModeration]
+    )
 
     const getPlatformBadge = (platform: string) => {
-        switch (platform.toLowerCase()) {
-            case "twitch":
-                return { label: "TW", bgClass: "bg-purple-600" }
-            case "kick":
-                return { label: "KC", bgClass: "bg-emerald-600" }
-            case "youtube":
-                return { label: "YT", bgClass: "bg-red-600" }
-            default:
-                return { label: platform.slice(0, 2).toUpperCase(), bgClass: "bg-neutral-600" }
+        const lower = platform.toLowerCase()
+        const labels: Record<string, string> = {
+            twitch: "TW", kick: "KC", youtube: "YT",
+            facebook: "FB", instagram: "IG", tiktok: "TK", linkedin: "LI",
+        }
+        return {
+            label: labels[lower] || lower.slice(0, 2).toUpperCase(),
+            bgClass: PLATFORM_COLORS[lower] || "bg-neutral-600",
         }
     }
 
     return (
         <div className="flex flex-col h-[500px]">
-            <div className="flex items-center justify-between mb-3 border-b border-neutral-800 pb-2">
-                <div className="flex gap-1">
-                    {platforms.map((p) => {
+            <div className="flex items-center justify-between mb-2 border-b border-neutral-800 pb-2">
+                <div className="flex gap-1 flex-wrap">
+                    {platforms.map(p => {
                         const badge = getPlatformBadge(p)
+                        const isEnabled = enabledPlatforms.has(p)
                         return (
                             <button
                                 key={p}
-                                onClick={() => setSelectedPlatform(p)}
-                                className={`px-2 py-1 rounded text-xs font-medium transition ${
-                                    selectedPlatform === p
+                                onClick={() => togglePlatform(p)}
+                                className={`px-2 py-1 rounded text-xs font-medium transition flex items-center gap-1 ${
+                                    isEnabled
                                         ? `${badge.bgClass} text-white`
-                                        : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+                                        : "bg-neutral-800 text-neutral-500 line-through"
                                 }`}
+                                title={`${isEnabled ? "Click to hide" : "Click to show"} ${p}`}
                             >
                                 {p.toUpperCase()}
+                                {platformCounts[p] ? ` (${platformCounts[p]})` : ""}
                             </button>
                         )
                     })}
                 </div>
-                <div className="flex items-center gap-1.5 text-[10px] text-neutral-400">
-                    <span
-                        className={`h-2 w-2 rounded-full ${
-                            statusText === "Disconnected" ? "bg-red-500" : "bg-emerald-500"
-                        }`}
-                    />
+                <div className="flex items-center gap-1.5 text-[10px] text-neutral-400 shrink-0 ml-2">
+                    <span className={`h-2 w-2 rounded-full ${statusText === "Disconnected" ? "bg-red-500" : "bg-emerald-500"}`} />
                     {statusText}
                 </div>
             </div>
 
-            <ChatMessageList
-                messages={allMessages}
-                getPlatformBadge={getPlatformBadge}
-                messagesEndRef={messagesEndRef}
-            />
+            <div className="flex-1 flex gap-3 min-h-0 relative">
+                <div className="flex-1 flex flex-col min-w-0">
+                    <ChatMessageList
+                        messages={groupedMessages}
+                        getPlatformBadge={getPlatformBadge}
+                        messagesEndRef={messagesEndRef}
+                        onUserClick={(msg) => setSelectedUser(msg)}
+                    />
+                </div>
+
+                {selectedUser && (
+                    <div className="w-60 shrink-0">
+                        <UserCard
+                            username={selectedUser.author}
+                            displayName={selectedUser.displayName || selectedUser.author}
+                            platform={selectedUser.platform}
+                            userId={selectedUser.userId || selectedUser.author}
+                            platformBadge={getPlatformBadge(selectedUser.platform)}
+                            isBroadcaster={selectedUser.isBroadcaster}
+                            isModerator={selectedUser.isModerator}
+                            isSubscriber={selectedUser.isSubscriber}
+                            isVip={selectedUser.isVip}
+                            onClose={() => setSelectedUser(null)}
+                            onModerate={handleModerate}
+                        />
+                    </div>
+                )}
+            </div>
 
             <div className="relative mt-auto">
                 {showCommands && (
@@ -192,6 +276,16 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                     />
                 )}
                 <div className="flex gap-2">
+                    <select
+                        value={sendMode}
+                        onChange={(e) => setSendMode(e.target.value)}
+                        className="rounded-lg border border-neutral-700 bg-neutral-800 px-2 py-2 text-xs text-neutral-100 focus:border-neutral-500 focus:outline-none"
+                    >
+                        {platforms.map(p => (
+                            <option key={p} value={p}>{p.toUpperCase()}</option>
+                        ))}
+                        {platforms.length > 1 && <option value="all">ALL</option>}
+                    </select>
                     <input
                         type="text"
                         value={input}
@@ -199,7 +293,7 @@ export function UnifiedChat({ platforms }: UnifiedChatProps) {
                         onKeyDown={(e) => {
                             if (e.key === "Enter") handleSend()
                         }}
-                        placeholder={`Message #${selectedPlatform}...`}
+                        placeholder={sendMode === "all" ? "Message all platforms..." : `Message #${sendMode}...`}
                         className="flex-1 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-xs text-neutral-100 placeholder-neutral-500 focus:border-neutral-500 focus:outline-none"
                     />
                     <button

--- a/src/components/dashboard/live/user-card.tsx
+++ b/src/components/dashboard/live/user-card.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useCallback } from "react"
+
+interface UserCardProps {
+    username: string
+    displayName: string
+    platform: string
+    userId: string
+    platformBadge: { label: string; bgClass: string }
+    isBroadcaster?: boolean
+    isModerator?: boolean
+    isSubscriber?: boolean
+    isVip?: boolean
+    onClose: () => void
+    onModerate: (action: string, duration?: number) => void
+}
+
+const TIMEOUT_OPTIONS = [
+    { label: "10s", duration: 10 },
+    { label: "10min", duration: 600 },
+    { label: "1h", duration: 3600 },
+    { label: "1d", duration: 86400 },
+    { label: "1w", duration: 604800 },
+]
+
+const ROLE_COLORS: Record<string, string> = {
+    broadcaster: "text-purple-400",
+    moderator: "text-emerald-400",
+    subscriber: "text-blue-400",
+    vip: "text-yellow-400",
+}
+
+export function UserCard({
+    username,
+    displayName,
+    platform,
+    platformBadge,
+    isBroadcaster,
+    isModerator,
+    isSubscriber,
+    isVip,
+    onClose,
+    onModerate,
+}: UserCardProps) {
+    const handleTimeout = useCallback(
+        (duration: number) => {
+            onModerate("timeout", duration)
+        },
+        [onModerate]
+    )
+
+    return (
+        <div className="rounded-xl border border-neutral-700 bg-neutral-900 p-4 shadow-xl">
+            <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                    <span
+                        className={`text-[10px] px-2 py-1 rounded font-bold uppercase text-white ${platformBadge.bgClass}`}
+                    >
+                        {platformBadge.label}
+                    </span>
+                    <div>
+                        <p className="text-sm font-bold text-neutral-100">{displayName}</p>
+                        <p className="text-[10px] text-neutral-400">@{username}</p>
+                    </div>
+                </div>
+                <button
+                    onClick={onClose}
+                    className="text-neutral-500 hover:text-neutral-300 text-lg leading-none"
+                >
+                    &times;
+                </button>
+            </div>
+
+            <div className="flex flex-wrap gap-1.5 mb-3">
+                {isBroadcaster && <span className={`text-[10px] font-semibold ${ROLE_COLORS.broadcaster}`}>Broadcaster</span>}
+                {isModerator && <span className={`text-[10px] font-semibold ${ROLE_COLORS.moderator}`}>Mod</span>}
+                {isSubscriber && <span className={`text-[10px] font-semibold ${ROLE_COLORS.subscriber}`}>Sub</span>}
+                {isVip && <span className={`text-[10px] font-semibold ${ROLE_COLORS.vip}`}>VIP</span>}
+            </div>
+
+            <div className="space-y-1.5">
+                <p className="text-[10px] text-neutral-500 uppercase tracking-wider font-semibold">Timeout</p>
+                <div className="flex flex-wrap gap-1">
+                    {TIMEOUT_OPTIONS.map(opt => (
+                        <button
+                            key={opt.duration}
+                            onClick={() => handleTimeout(opt.duration)}
+                            className="rounded-md bg-neutral-800 px-2.5 py-1.5 text-[11px] font-medium text-neutral-200 hover:bg-orange-600/30 hover:text-orange-300 transition-colors"
+                        >
+                            {opt.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="flex gap-2 mt-3">
+                <button
+                    onClick={() => onModerate("ban")}
+                    className="flex-1 rounded-md bg-red-600/20 px-3 py-2 text-[11px] font-semibold text-red-400 hover:bg-red-600/40 transition-colors"
+                >
+                    Ban
+                </button>
+                <button
+                    onClick={() => onModerate("unban")}
+                    className="flex-1 rounded-md bg-emerald-600/20 px-3 py-2 text-[11px] font-semibold text-emerald-400 hover:bg-emerald-600/40 transition-colors"
+                >
+                    Unban
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/hooks/use-relay-chat.ts
+++ b/src/hooks/use-relay-chat.ts
@@ -37,6 +37,7 @@ interface UseRelayChatReturn {
     statuses: RelayPlatformStatus[]
     isConnected: boolean
     error: string | null
+    sendModeration: (action: string, targetUserId: string, targetUsername: string, platform: string, duration?: number, reason?: string) => void
 }
 
 const INITIAL_RECONNECT_DELAY = 1_000
@@ -59,6 +60,26 @@ export function useRelayChat(): UseRelayChatReturn {
     >({})
     const tokenTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
     const connectRef = useRef<() => void>(() => {})
+
+    const sendModeration = useCallback(
+        (action: string, targetUserId: string, targetUsername: string, platform: string, duration?: number, reason?: string) => {
+            const ws = wsRef.current
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                logger.warn("Cannot send moderation: WebSocket not connected")
+                return
+            }
+            ws.send(JSON.stringify({
+                type: "moderate",
+                action,
+                targetUserId,
+                targetUsername,
+                platform,
+                duration,
+                reason,
+            }))
+        },
+        []
+    )
 
     const relayUrl = process.env.NEXT_PUBLIC_RELAY_WS_URL || ""
 
@@ -294,5 +315,5 @@ export function useRelayChat(): UseRelayChatReturn {
         }
     }, [relayUrl, connect, fetchCredentials])
 
-    return { messages, statuses, isConnected, error }
+    return { messages, statuses, isConnected, error, sendModeration }
 }


### PR DESCRIPTION
## Phase 2: Migrate Relay & Background Workers to .203 Microservices

### Summary
- Updated Relay server with moderation handling and Twitch relay enhancements, deployed and compiled on `.203` (`C:\relay`).
- Transferred PowerShell worker scripts (`auto-repost-worker.ps1` and `youclone-worker.ps1`) to `.203` server (`C:\scripts`), removing local background workers from monorepo web app.
- Updated unified live chat hooks and user cards.

Closes #352
